### PR TITLE
modify check_block_device agent action to be more generic

### DIFF
--- a/chroma-agent/chroma-agent.spec
+++ b/chroma-agent/chroma-agent.spec
@@ -29,9 +29,9 @@ Requires: yum-utils
 Requires: initscripts
 Requires: chroma-diagnostics >= %{version}
 Requires: python2-iml-common1.2
-Obsolete: python2-iml-common
-Obsolete: python2-iml-common1.0
-Obsolete: python2-iml-common1.1
+Obsoletes: python2-iml-common
+Obsoletes: python2-iml-common1.0
+Obsoletes: python2-iml-common1.1
 Requires: systemd-python
 Requires: python-tzlocal
 Requires: python2-toolz

--- a/chroma-agent/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma-agent/chroma_agent/action_plugins/manage_targets.py
@@ -177,7 +177,7 @@ def check_block_device(path, device_type):
     :param device_type: The type of device the path references
     :return The filesystem type of the filesystem on the device, or None if unoccupied.
     """
-    return agent_ok_or_error(BlockDevice(device_type, path).filesystem_info)
+    return agent_result(BlockDevice(device_type, path).filesystem_type)
 
 
 def format_target(device_type, target_name, device, backfstype,

--- a/chroma-agent/tests/actions_plugins/test_manage_target.py
+++ b/chroma-agent/tests/actions_plugins/test_manage_target.py
@@ -375,37 +375,51 @@ class TestCheckBlockDevice(CommandCaptureTestCase, AgentUnitTestCase):
     def test_occupied_device_ldiskfs(self):
         self.add_commands(CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), stdout="ext4\n"))
 
-        self.assertAgentError(manage_targets.check_block_device("/dev/sdb", "linux"), "Filesystem found: type 'ext4'")
+        result = manage_targets.check_block_device('/dev/sdb', 'linux')
+        self.assertEqual(result['result'], 'ext4')
         self.assertRanAllCommands()
 
     def test_mbr_device_ldiskfs(self):
         self.add_commands(CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), stdout="\n"))
 
-        self.assertAgentOK(manage_targets.check_block_device("/dev/sdb", "linux"))
+        result = manage_targets.check_block_device('/dev/sdb', 'linux')
+        self.assertEqual(result['result'], None)
         self.assertRanAllCommands()
 
     def test_empty_device_ldiskfs(self):
         self.add_commands(CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), rc=2))
 
-        self.assertAgentOK(manage_targets.check_block_device("/dev/sdb", "linux"))
+        result = manage_targets.check_block_device('/dev/sdb', 'linux')
+        self.assertEqual(result['result'], None)
         self.assertRanAllCommands()
 
     def test_occupied_device_zfs(self):
         self.add_command(("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\npool1/dataset_1\n")
 
-        self.assertAgentError(manage_targets.check_block_device("pool1", "zfs"),
-                              "Dataset 'dataset_1' found on zpool 'pool1'")
+        result = manage_targets.check_block_device("pool1", "zfs")
+        self.assertEqual(result['result'], 'zfs')
         self.assertRanAllCommands()
 
     def test_empty_device_zfs(self):
         self.add_command(("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\n")
 
-        self.assertAgentOK(manage_targets.check_block_device("pool1", "zfs"))
+        result = manage_targets.check_block_device("pool1", "zfs")
+        self.assertEqual(result['result'], None)
         self.assertRanAllCommands()
 
-    @unittest.skip('Unimplemented, need to test running check_block_device on a zfs dataset')
     def test_dataset_device_zfs(self):
-        pass
+        self.add_command(("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\npool1/dataset_1\n")
+
+        result = manage_targets.check_block_device("pool1/dataset_1", "zfs")
+        self.assertEqual(result['result'], 'zfs')
+        self.assertRanAllCommands()
+
+    def test_nonexistent_dataset_device_zfs(self):
+        self.add_command(("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\n")
+
+        result = manage_targets.check_block_device("pool1/dataset_1", "zfs")
+        self.assertEqual(result['result'], None)
+        self.assertRanAllCommands()
 
 
 class TestCheckImportExport(CommandCaptureTestCase, AgentUnitTestCase):

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -117,9 +117,9 @@ This is the Intel Manager for Lustre Monitoring and Administration Interface
 Summary: Common libraries for Chroma Server
 Group: System/Libraries
 Requires: python2-iml-common1.2
-Obsolete: python2-iml-common
-Obsolete: python2-iml-common1.0
-Obsolete: python2-iml-common1.1
+Obsoletes: python2-iml-common
+Obsoletes: python2-iml-common1.0
+Obsoletes: python2-iml-common1.1
 %description libs
 This package contains libraries for Chroma CLI and Chroma Server.
 
@@ -136,9 +136,9 @@ Summary: Intel Manager for Lustre Integration Tests
 Group: Development/Tools
 Requires: python-requests >= 2.6.0 python-nose python-nose-testconfig python-paramiko python-django python-ordereddict
 Requires: python2-iml-common1.2
-Obsolete: python2-iml-common
-Obsolete: python2-iml-common1.0
-Obsolete: python2-iml-common1.1
+Obsoletes: python2-iml-common
+Obsoletes: python2-iml-common1.0
+Obsoletes: python2-iml-common1.1
 %description integration-tests
 This package contains the Intel Manager for Lustre integration tests and scripts and is intended
 to be used by the Chroma test framework.

--- a/chroma-manager/chroma_core/models/target.py
+++ b/chroma-manager/chroma_core/models/target.py
@@ -1138,8 +1138,14 @@ class PreFormatCheck(Step):
         return "Prepare for format %s:%s" % (kwargs['host'], kwargs['path'])
 
     def run(self, kwargs):
-        self.invoke_agent_expect_result(kwargs['host'], "check_block_device", {'path': kwargs['path'],
-                                                                               'device_type': kwargs['device_type']})
+        result = self.invoke_agent_expect_result(kwargs['host'],
+                                                 'check_block_device',
+                                                 {'path': kwargs['path'], 'device_type': kwargs['device_type']})
+        if result is not None:
+            error = "Query of block device at %s returned '%s' when expecting to find no filesystem" % (kwargs['path'],
+                                                                                                        result)
+            job_log.error(error)
+            raise RuntimeError(error)
 
 
 class PreFormatComplete(Step):


### PR DESCRIPTION
check_block_device currently checks if filesystem exists and if it does , it reports that the agent call failed. it is using the wrong mechanism to represent information returned. Instead a result should be returned indicating whether or not a filesystem exists on the block device. Also fix BlockDeviceZfs.filesystem_info to accept dataset as self so that we can run the method on datasets as well Pools.

fix agent unit tests relevant to change in usage of check_block_device

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/310)
<!-- Reviewable:end -->
