### PR TITLE
Tidy use of initialise blockdevices

### DIFF
--- a/chroma-manager/chroma_core/models/host.py
+++ b/chroma-manager/chroma_core/models/host.py
@@ -806,15 +806,6 @@ class BaseSetupHostJob(NullStateChangeJob):
         return DependAll(deps)
 
 
-class InitialiseBlockDeviceDriversStep(Step):
-    """ Perform driver initialisation routine for each block device type on a given host """
-
-    def run(self, kwargs):
-        host = kwargs['host']
-
-        self.invoke_agent_expect_result(host, 'initialise_block_device_drivers', {})
-
-
 class SetupHostJob(BaseSetupHostJob):
     """For historical reasons this is called the original name of SetupHostJob rather than the more
     obvious SetupManagedHostJob.
@@ -832,9 +823,6 @@ class SetupHostJob(BaseSetupHostJob):
 
     def get_deps(self):
         return self._common_deps('lnet_up', None, None)
-
-    def get_steps(self):
-        return [(InitialiseBlockDeviceDriversStep, {'host': self.target_object})]
 
     @classmethod
     def can_run(cls, host):


### PR DESCRIPTION
initialise block device driver method should not be necessary within the manager code as it should be run when the agent daemon starts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/328)
<!-- Reviewable:end -->
