### PR TITLE
Give the AgentShell the shell= named parameter

### DIFF
--- a/chroma-agent/chroma_agent/lib/shell.py
+++ b/chroma-agent/chroma_agent/lib/shell.py
@@ -74,7 +74,7 @@ class AgentShell(BaseShell):
             raise AgentShell.SubprocessAborted()
 
     @classmethod
-    def run(cls, arg_list):
+    def run(cls, arg_list, shell=False):
         """
         Run a subprocess, and return a named tuple of rc, stdout, stderr.
         Record subprocesses run and their results in log.
@@ -83,7 +83,7 @@ class AgentShell(BaseShell):
         using this function.
         """
 
-        result = super(AgentShell, cls).run(arg_list, console_log, cls.monitor_func)
+        result = super(AgentShell, cls).run(arg_list, console_log, cls.monitor_func, shell=shell)
 
         cls.thread_state.save_result(arg_list, result)
 
@@ -97,10 +97,10 @@ class AgentShell(BaseShell):
         return result.rc, result.stdout, result.stderr
 
     @classmethod
-    def try_run(cls, arg_list):
+    def try_run(cls, arg_list,shell=False):
         """ Run a subprocess, and raise an exception if it returns nonzero.  Return stdout string. """
 
-        result = AgentShell.run(arg_list)
+        result = AgentShell.run(arg_list, shell=shell)
 
         if result.rc != 0:
             raise AgentShell.CommandExecutionError(result, arg_list)
@@ -108,13 +108,13 @@ class AgentShell(BaseShell):
         return result.stdout
 
     @classmethod
-    def run_canned_error_message(cls, arg_list):
+    def run_canned_error_message(cls, arg_list, shell=False):
         """
         Run a shell command return None is successful, or User Error message if not
 
         :return: None if successful or canned user error message
         """
-        result = AgentShell.run(arg_list)
+        result = AgentShell.run(arg_list, shell=shell)
 
         if result.rc != 0:
             return "Error (%s) running '%s': '%s' '%s'" % (result.rc, " ".join(arg_list), result.stdout, result.stderr)

--- a/chroma-agent/tests/actions_plugins/test_agent_updates.py
+++ b/chroma-agent/tests/actions_plugins/test_agent_updates.py
@@ -68,7 +68,7 @@ sslclientcert = {2}
         self.assertEqual(agent_updates.unconfigure_repo(self.tmpRepo.name), agent_result_ok)
 
     def test_kernel_status(self):
-        def run(arg_list):
+        def run(arg_list, shell=False):
             values = {("rpm", "-q", "--whatprovides", "kmod-lustre"):
                       "kmod-lustre-1.2.3-1.el6.x86_64\n",
                       ("uname", "-r"):


### PR DESCRIPTION
Pull up the shell= named parameter functionality from
the BaseShell to the AgentShell.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/451)
<!-- Reviewable:end -->
