### PR TITLE
See if we can revert to python2-iml-common

### DIFF
--- a/chroma-agent/chroma-agent.spec
+++ b/chroma-agent/chroma-agent.spec
@@ -28,7 +28,7 @@ Requires: python2-tablib
 Requires: yum-utils
 Requires: initscripts
 Requires: iml_sos_plugin
-Requires: python2-iml-common1.3
+Requires: python2-iml-common >= 1, python2-iml-common < 2
 Requires: systemd-python
 Requires: python-tzlocal
 Requires: python2-toolz

--- a/chroma-bundles/chroma_support.repo
+++ b/chroma-bundles/chroma_support.repo
@@ -25,3 +25,9 @@ enabled=1
 gpgcheck=1
 #gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
 gpgkey=https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
+[iml-common-test]
+name=iml-common from: http://jenkins.lotus.hpdd.lab.intel.com/job/iml-common/arch=x86_64,distro=el7/47/
+baseurl=http://jenkins.lotus.hpdd.lab.intel.com/job/iml-common/arch=x86_64%2Cdistro=el7/47/artifact/artifacts/RPMS/
+enabled=1
+gpgcheck=0

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -119,7 +119,7 @@ This is the Intel Manager for Lustre Monitoring and Administration Interface
 %package libs
 Summary: Common libraries for Chroma Server
 Group: System/Libraries
-Requires: python2-iml-common1.3
+Requires: python2-iml-common >= 1, python2-iml-common < 2
 %description libs
 This package contains libraries for Chroma CLI and Chroma Server.
 
@@ -134,7 +134,8 @@ or on a separate node.
 %package integration-tests
 Summary: Intel Manager for Lustre Integration Tests
 Group: Development/Tools
-Requires: python-requests >= 2.6.0 python-nose python-nose-testconfig python-paramiko python-ordereddict python2-iml-common1.3
+Requires: python-requests >= 2.6.0 python-nose python-nose-testconfig python-paramiko python-ordereddict
+Requires: python2-iml-common >= 1, python2-iml-common < 2
 Requires: Django >= 1.4, Django < 1.5
 %description integration-tests
 This package contains the Intel Manager for Lustre integration tests and scripts and is intended


### PR DESCRIPTION
DO NOT LAND

Environment: STORAGE_SERVER_REPOS=http://jenkins.lotus.hpdd.lab.intel.com/job/iml-common/47/arch=x86_64,distro=el7/artifact/artifacts/iml-common-test.repo

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/509)
<!-- Reviewable:end -->
