### PR TITLE
dnf malformed lock file

### DIFF
--- a/chroma-manager/tests/integration/shared_storage_configuration/test_power_control.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_power_control.py
@@ -9,7 +9,7 @@ class ChromaPowerControlTestCase(ChromaIntegrationTestCase):
 
     def setUp(self):
         super(ChromaPowerControlTestCase, self).setUp()
-        
+
         # Even though the tests only need 1 server, we need to add a server
         # and its HA peer in order to ensure that the peer doesn't send
         # outdated CIB data over. There is an assumption here that the
@@ -178,3 +178,9 @@ class TestPduOperations(ChromaPowerControlTestCase):
             return post_boot_time > pre_boot_time
 
         self.wait_until_true(boot_time_is_newer)
+
+        # remove any corrupted dnf lock files https://github.com/intel-hpdd/intel-manager-for-lustre/issues/618
+        self.remote_command(
+            self.server['address'],
+            'systemd-tmpfiles --remove dnf.conf',
+            expected_return_code=None)

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_power_control.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_power_control.py
@@ -182,5 +182,5 @@ class TestPduOperations(ChromaPowerControlTestCase):
         # remove any corrupted dnf lock files https://github.com/intel-hpdd/intel-manager-for-lustre/issues/618
         self.remote_command(
             self.server['address'],
-            'systemd-tmpfiles --remove dnf.conf',
+            '[[ -f {0} && ! -s {0} ]] && rm -f {0}'.format('/var/cache/dnf/metadata_lock.pid'),
             expected_return_code=None)


### PR DESCRIPTION
Seen during multiple lotus SSI runs:

```
Malformed lock file found: /var/cache/dnf/metadata_lock.pid.
Ensure no other dnf process is running and remove the lock file manually or run systemd-tmpfiles --remove dnf.conf.

dnf clean metadata: 0
Cleaning repos: ngompa-dnf-el7 epel updates-centos7.3-x86_64 lustre e2fsprogs
              : core-0 chef-stable-el7-x86_64 lustre-client
              : managerforlustremanager-for-lustre-devel
              : updates-centos7.4-x86_64
0 metadata files removed
0 dbcache files removed
```

Investigating the file shows it is present and empty:

```
 ls -l /var/cache/dnf/metadata_lock.pid 
-rw-r--r-- 1 root root 0 May 20 01:42 /var/cache/dnf/metadata_lock.pid
```

No full disks either.