### PR TITLE
Fix Makefile from subrepo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,3 +147,5 @@ chroma_test_env/bin/activate: chroma-manager/requirements.txt
 
 unit_tests: chroma_test_env
 	sh -c '. chroma_test_env/bin/activate; make -C chroma-manager unit_tests'
+
+include include/githooks.mk

--- a/include/Makefile
+++ b/include/Makefile
@@ -1,1 +1,0 @@
-include githooks.mk


### PR DESCRIPTION
This fixes general build targets in root: all rpms docs download subdirs substs clean_substs

Since the merged include/Makefile didn't support them, but was included in SUBDIRS.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>