### PR TITLE
Add ordering on rabbitmq-server

### DIFF
--- a/iml-corosync.service
+++ b/iml-corosync.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Corosync Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/iml-http-agent.service
+++ b/iml-http-agent.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Http Agent Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/iml-job-scheduler.service
+++ b/iml-job-scheduler.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Job Scheduler Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/iml-lustre-audit.service
+++ b/iml-lustre-audit.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Lustre Audit Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/iml-manager.target
+++ b/iml-manager.target
@@ -13,6 +13,7 @@ Requires=iml-syslog.service
 Requires=iml-view-server.service
 Requires=iml-settings-populator.service
 Requires=nginx.service
+Requires=rabbitmq-server.service
 Requires=device-aggregator.socket
 After=postgresql.service
 After=rabbitmq-server.service

--- a/iml-plugin-runner.service
+++ b/iml-plugin-runner.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Plugin Runner Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/iml-stats.service
+++ b/iml-stats.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Stats Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/iml-syslog.service
+++ b/iml-syslog.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Syslog Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
We have a number of services that need to come up after
rabbitmq-server.

Add the `After` directive to ensure they are started after
rabbitmq-server.