### PR TITLE
Add Health Status stored procedure

### DIFF
--- a/chroma-manager/chroma_core/migrations/0032_health_status_procedure.py
+++ b/chroma-manager/chroma_core/migrations/0032_health_status_procedure.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from south.db import db
+from south.v2 import SchemaMigration
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        db.execute("""
+CREATE OR REPLACE FUNCTION health_status(
+    OUT health text
+    ,OUT num_alerts int
+) AS
+$func$
+DECLARE
+    sev integer;
+BEGIN
+    SELECT severity
+    INTO sev
+    FROM chroma_core_alertstate a
+    WHERE COALESCE(a.dismissed, FALSE) = FALSE
+    AND a.active = TRUE
+    AND a.severity IN (30, 40)
+    ORDER BY a.severity DESC LIMIT 1;
+
+    IF sev = 30 THEN
+        health := 'WARNING';
+    ELSIF sev = 40 THEN
+        health := 'ERROR';
+    ELSE
+        health := 'GOOD';
+    END IF;
+
+    SELECT COUNT(*)
+    INTO num_alerts
+    FROM chroma_core_alertstate a
+    WHERE COALESCE(a.dismissed, FALSE) = FALSE
+    AND a.severity IN (30, 40)
+    AND a.active = TRUE;
+END
+$func$ LANGUAGE plpgsql;
+        """)
+
+    def backwards(self, orm):
+        db.execute("DROP FUNCTION IF EXISTS health_status();")


### PR DESCRIPTION
We ask for status and count of alerts to represent
system health.

This call currently involves

  1. Selecting every active row with a certain severity.
  2. Reducing the rows into a count + maximum severity.

Instead of this, we can use a stored procedure. This will
centralize the information for any consumer, and allows us
to get the status with a simple call: `select * from health_status()`.

Then, we can couple this call with postgres listen + notify.

This will end up providing a reactive event flow, all in the postgres
level.

That means that a consumer can subscribe to changes from the
DB. This approach will scale as well.

Signed-off-by: Joe Grund <jgrund@whamcloud.com>