### PR TITLE
Ensure we raise on update error.

### DIFF
--- a/chroma_api/alert.py
+++ b/chroma_api/alert.py
@@ -290,7 +290,7 @@ class UpdatesAvailableAlertResource(Resource):
         try:
             mh = ManagedHost.objects.get(fqdn=host_address)
         except ManagedHost.DoesNotExist:
-            ImmediateHttpResponse(
+            raise ImmediateHttpResponse(
                 response=self.error_response(
                     bundle.request, {
                         'host_not_found':


### PR DESCRIPTION
We need to raise when we don't have a
matching managedHost to update.