### PR TITLE
Add flag if running in docker

### DIFF
--- a/iml-settings-populator.service
+++ b/iml-settings-populator.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=IML Settings Populator
-Requires=postgresql.service
+Wants=postgresql.service
 After=postgresql.service
 
 [Service]


### PR DESCRIPTION
Add a flag `service_config.py` that checks if
we are running in docker. We can use this flag
to skip setup of services that have been extracted into their
own container.

In addition, changes the requires to a wants for `iml-settings-populator`
so we don't die if postgres isn't present.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>
