### PR TITLE
Fix bug with updates_available available field.

### DIFF
--- a/chroma_api/alert.py
+++ b/chroma_api/alert.py
@@ -267,7 +267,7 @@ class UpdatesAvailableAlertValidation(Validation):
         if not bundle.data.get('host_address'):
             errors['host_address'] = 'host_address required'
 
-        if not bundle.data.get('available'):
+        if bundle.data.get('available') is None:
             errors['available'] = 'available required'
 
         return errors


### PR DESCRIPTION
There is a bug with updates_available in that we don't
check for boolean `True` / `False`, but instead for truthiness,

This means a valid value of `False` will cause validation to fail.

Fix this.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>