### PR TITLE
Update start_services

### DIFF
--- a/agent-bootstrap-script.template
+++ b/agent-bootstrap-script.template
@@ -155,8 +155,7 @@ def configure_server():
 
 
 def start_services():
-    launch_command("systemctl enable chroma-agent.service")
-    launch_command("systemctl start iml-storage-server.target")
+    launch_command("systemctl enable --now iml-storage-server.target")
 
 
 def kill_zombies():


### PR DESCRIPTION
Now that the iml-storage-server.target drives everything,
we only need to enable / start it during bootstrap.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>