### PR TITLE
Accept linux plugin device data

### DIFF
--- a/chroma_agent_comms/views.py
+++ b/chroma_agent_comms/views.py
@@ -385,12 +385,12 @@ proxy=_none_
     crypto = Crypto()
     cert_str = open(crypto.AUTHORITY_CERT_FILE).read()
 
-    repo_packages = 'chroma-agent'
+    repo_packages = 'python2-iml-agent'
     server_profile = ServerProfile.objects.get(name = request.REQUEST['profile_name'])
 
     try:
         if server_profile.managed:
-            repo_packages += ' chroma-agent-management'
+            repo_packages += ' python2-iml-agent-management'
     except (ServerProfile.DoesNotExist, KeyError) as e:
         if type(e) is KeyError:
             err = "Profile name not specified"

--- a/chroma_core/plugins/linux.py
+++ b/chroma_core/plugins/linux.py
@@ -200,17 +200,20 @@ class Linux(Plugin):
     def teardown(self):
         log.debug("Linux.teardown")
 
-    def agent_session_continue(self, host_id, _):
+    def agent_session_continue(self, host_id, data):
         # The agent plugin sends us another full report when it thinks something has changed
-        self.agent_session_start(host_id, None, initial_scan=False)
+        self.agent_session_start(host_id, data, initial_scan=False)
 
-    def agent_session_start(self, host_id, _, initial_scan=True):
-        # devices = data
+    def agent_session_start(self, host_id, data, initial_scan=True):
         initiate_device_poll = False
         reported_device_node_paths = []
 
         fqdn = ManagedHost.objects.get(id=host_id).fqdn
         devices = get_devices(fqdn)
+
+        # use info from IML 4.0
+        if not devices and data:
+            devices = data
 
         for expected_item in [
                 'vgs', 'lvs', 'zfspools', 'zfsdatasets', 'devs', 'local_fs',

--- a/python-iml-manager.spec.in
+++ b/python-iml-manager.spec.in
@@ -273,6 +273,8 @@ if [ -d %{_localstatedir}/lib/rpm-state/%{name}/ ]; then
     mkdir -p /var/lib/chroma/
     cp -rf %{_localstatedir}/lib/rpm-state/%{name}/* /var/lib/chroma/
     rm -rf %{_localstatedir}/lib/rpm-state/%{name}/
+    rm -rf /var/lib/chroma/repo/iml-agent
+    chroma-config bundle delete /var/lib/chroma/repo/iml-agent/7
 fi
 
 %triggerun -n python2-%{pypi_name} -- chroma-manager

--- a/python-iml-manager.spec.in
+++ b/python-iml-manager.spec.in
@@ -78,7 +78,7 @@ Requires:       policycoreutils-python
 Requires:       python2-gevent >= 1.0.1
 Requires:       system-config-firewall-base
 Requires:       nodejs >= 1:6.9.4-2
-Requires:       iml-gui
+Requires:       iml-gui >= 6.4.0
 Requires:       iml-old-gui
 Requires:       iml-srcmap-reverse
 Requires:       iml-online-help


### PR DESCRIPTION
Always try to use device-aggregator data first, but allow IML 4.0
to pass device data via linux plugin (/agent/message).

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>