### PR TITLE
Build docker images in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 jobs:
   include:
   - stage: test
-    env: Type='unit tests'
+    name: "Unit Tests"
     install:
       - pip install -r requirements.txt
       - pip install -r requirements.test
@@ -30,12 +30,24 @@ jobs:
   - stage: cd
     git:
       depth: 999999
-    env: Type='Continuous Deployment'
+    name: "Continuous Deployment (Copr)"
     script:
       - include/travis/copr-deploy.sh prepare
       - ./travis_wait "./include/travis/run_in_centos7_docker.sh include/travis/copr-deploy.sh build_srpm"
+  - stage: cd
+    git:
+      depth: 999999
+    name: "Continuous Deployment (Docker)"
+    script:
+      - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      - docker build --rm -t imlteam/manager-service-base -f base.dockerfile .
+      - docker push imlteam/manager-service-base
+      - docker build --rm -t imlteam/manager-nginx -f nginx.dockerfile .
+      - docker push imlteam/manager-nginx
+      - docker-compose build
+      - docker-compose push
   - stage: test
-    env: Type='behave tests'
+    name: "Behave tests"
     install:
       - pip install -r requirements.txt
       - pip install -r requirements.test
@@ -47,7 +59,7 @@ jobs:
       - export IML_DISABLE_THREADS=1
       - behave --format plain tests/feature/cli/features
   - stage: test
-    env: Type='service tests'
+    name: "Service tests"
     script:
       - docker run -dit --privileged --name systemd --mount type=bind,source="$(pwd)",target=/integrated-manager-for-lustre  -v /sys/fs/cgroup:/sys/fs/cgroup:ro centos/systemd
       - docker exec -i systemd bash -c "./integrated-manager-for-lustre/tests/framework/services/runner.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,9 @@ services:
     image: "imlteam/manager-corosync"
     restart: on-failure
     hostname: "corosync"
+    build:
+      context: .
+      dockerfile: ./corosync.dockerfile
     deploy:
       restart_policy:
         condition: on-failure
@@ -155,6 +158,9 @@ services:
     image: "imlteam/manager-gunicorn"
     restart: on-failure
     hostname: "gunicorn"
+    build:
+      context: .
+      dockerfile: ./gunicorn.dockerfile
     deploy:
       restart_policy:
         condition: on-failure
@@ -174,6 +180,9 @@ services:
     volumes:
       - "manager-config:/var/lib/chroma"
     hostname: "http-agent"
+    build:
+      context: .
+      dockerfile: ./http-agent.dockerfile
     deploy:
       restart_policy:
         condition: on-failure
@@ -189,6 +198,9 @@ services:
     image: "imlteam/manager-job-scheduler"
     restart: on-failure
     hostname: "job-scheduler"
+    build:
+      context: .
+      dockerfile: ./job-scheduler.dockerfile
     deploy:
       restart_policy:
         condition: on-failure
@@ -206,6 +218,9 @@ services:
     image: "imlteam/manager-lustre-audit"
     restart: on-failure
     hostname: "lustre-audit"
+    build:
+      context: .
+      dockerfile: ./lustre-audit.dockerfile
     deploy:
       restart_policy:
         condition: on-failure
@@ -223,6 +238,9 @@ services:
     image: "imlteam/manager-plugin-runner"
     restart: on-failure
     hostname: "plugin-runner"
+    build:
+      context: .
+      dockerfile: ./plugin-runner.dockerfile
     deploy:
       restart_policy:
         condition: on-failure
@@ -242,6 +260,9 @@ services:
     image: "imlteam/manager-power-control"
     restart: on-failure
     hostname: "power-control"
+    build:
+      context: .
+      dockerfile: ./power-control.dockerfile
     deploy:
       restart_policy:
         condition: on-failure
@@ -259,6 +280,9 @@ services:
     image: "imlteam/manager-stats"
     restart: on-failure
     hostname: "stats"
+    build:
+      context: .
+      dockerfile: ./stats.dockerfile
     deploy:
       restart_policy:
         condition: on-failure
@@ -276,6 +300,9 @@ services:
     image: "imlteam/manager-syslog"
     restart: on-failure
     hostname: "syslog"
+    build:
+      context: .
+      dockerfile: ./syslog.dockerfile
     deploy:
       restart_policy:
         condition: on-failure
@@ -293,6 +320,9 @@ services:
   setup:
     image: "imlteam/manager-setup"
     command: ["tail", "-f", "/dev/null"]
+    build:
+      context: .
+      dockerfile: ./setup.dockerfile
     volumes:
       - "manager-config:/var/lib/chroma"
     deploy:


### PR DESCRIPTION
We are currently using docker cloud
to build images upon landing something in the IML repo.

This currently has two downsides:

1. manager-service-base needs to be built / pushed before everything
else builds, but there is not a way to sequence that.
2. There are very long queueing times in docker cloud, leading to large
lags between landing some changes and it moving to production.

By moving the continuous integration step to travis we alieviate both of
these issues.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>