### PR TITLE
IML container tuning

### DIFF
--- a/chroma-manager.py
+++ b/chroma-manager.py
@@ -13,8 +13,16 @@ SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 sys.path.insert(0, SITE_ROOT)
 
+# From Gunicorn Docs:
+# DO NOT scale the number of workers to the number of clients you expect to have.
+# Gunicorn should only need 4-12 worker processes to handle hundreds or thousands of requests per second.
+#
+# Obviously, your particular hardware and application are going to affect the optimal number of workers.
+# Our recommendation is to start with the above guess and tune using TTIN and TTOU signals while the application is under load.
+# Always remember, there is such a thing as too many workers.
+# After a point your worker processes will start thrashing system resources decreasing the throughput of the entire system.
 import multiprocessing
-workers = multiprocessing.cpu_count() * 2 + 1
+workers = max(multiprocessing.cpu_count() * 2 + 1, 8)
 
 worker_class = 'gevent'
 
@@ -24,7 +32,8 @@ bind = "{}:{}".format(settings.PROXY_HOST, settings.HTTP_API_PORT)
 
 pidfile = settings.GUNICORN_PID_PATH
 
-errorlog = '-' if USE_CONSOLE else os.path.join(settings.LOG_PATH, 'gunicorn-error.log')
+errorlog = '-' if USE_CONSOLE else os.path.join(
+    settings.LOG_PATH, 'gunicorn-error.log')
 accesslog = None
 
 timeout = settings.LONG_POLL_TIMEOUT_SECONDS + 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
       start_period: 10s
   rabbit:
-    image: "rabbitmq:3.6"
+    image: "rabbitmq:3.6-management"
     hostname: "rabbit"
     deploy:
       restart_policy:
@@ -37,9 +37,8 @@ services:
       interval: 5s
       retries: 5
       start_period: 10s
-    volumes:
-      - /etc/rabbitmq/
-      - /var/lib/rabbitmq/
+    ports:
+      - "15672:15672"
   nginx:
     image: "imlteam/manager-nginx"
     restart: "on-failure"
@@ -82,7 +81,7 @@ services:
       - "IML_CA_PATH=/var/lib/chroma/authority.crt"
   realtime:
     image: "imlteam/realtime"
-    restart: "on-failure"
+    restart: always
     hostname: "realtime"
     deploy:
       restart_policy:


### PR DESCRIPTION
Upon trying IML in docker on a larger system, I noticed a few areas of
improvement.

   1. We should scale down our gunicorn workers a bit (max out at 8).
This improves memory usage considerably while still maintaining the same
level of responsiveness.
  2. Add a retry to intermittent queue connection issues. While
debugging https://success.docker.com/article/ipvs-connection-timeout-issue I
noticed that kombu (rabbitMQ client lib) has a retry option. I've added
this to at least notify that we have an issue and might retry.
  3. The RabbitMQ container can be ephemeral; there is nothing durable
that needs to be stored. In addition we can use the management version
which will allow us to view connections / queues / exchanges etc... over
port 15672.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>