### PR TITLE
Restart nginx after upgrade

### DIFF
--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -308,7 +308,13 @@ class ServiceConfig(CommandLine):
         for service in self.CONTROLLED_SERVICES:
             controller = ServiceControl.create(service)
 
-            error = controller.start()
+            if controller.running:
+                if service.endswith('.target'):
+                    error = False
+                else:
+                    error = controller.reload()
+            else:
+                error = controller.start()
             if error:
                 log.error(error)
                 raise RuntimeError(error)


### PR DESCRIPTION
When processes are asked to start, either them or if they are running, reload their configs.
    

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>