### PR TITLE
Add required HA package to managed profile

### DIFF
--- a/base_managed_RH7.profile
+++ b/base_managed_RH7.profile
@@ -16,6 +16,10 @@
     "external": [
       "python2-iml-agent-management",
       "kernel-devel-lustre",
+      "pcs",
+      "fence-agents",
+      "fence-agents-virsh",
+      "lustre-resource-agents",
       "lustre-ldiskfs-zfs"
     ]
   },


### PR DESCRIPTION
Removing HA rpm dependencies from python2-iml-agent-management,
necessitates adding them them here.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>