### PR TITLE
Add packages to profile on client

### DIFF
--- a/chroma_core/models/host.py
+++ b/chroma_core/models/host.py
@@ -1431,6 +1431,9 @@ class UpdatePackagesStep(RebootIfNeededStep):
             self.invoke_agent(kwargs['host'], 'start_pacemaker')
 
 class UpdateProfileStep(RebootIfNeededStep):
+    '''
+    Update profile definition on node.
+    '''
     def run(self, kwargs):
         self.invoke_agent(kwargs['host'], 'set_profile',
                           {'profile_json', json.dumps(kwargs['profile'].as_dict)})

--- a/chroma_core/models/host.py
+++ b/chroma_core/models/host.py
@@ -1430,6 +1430,10 @@ class UpdatePackagesStep(RebootIfNeededStep):
             # and not running,
             self.invoke_agent(kwargs['host'], 'start_pacemaker')
 
+class UpdateProfileStep(RebootIfNeededStep):
+    def run(self, kwargs):
+        self.invoke_agent(kwargs['host'], 'set_profile',
+                          {'profile_json', json.dumps(kwargs['profile'].as_dict)})
 
 class UpdateYumFileStep(RebootIfNeededStep):
     def run(self, kwargs):
@@ -1483,6 +1487,8 @@ proxy=_none_
                 (UpdatePackagesStep, {'host': self.host,
                                       'bundles': [b['bundle_name'] for b in self.host.server_profile.bundles.all().values('bundle_name') if b['bundle_name'] != "external"],
                                       'packages': list(self.host.server_profile.packages)}),
+                (UpdateProfileStep, {'host': self.host,
+                                     'profile': self.host.server_profile }),
                 (RebootIfNeededStep, {'host': self.host,
                                       'timeout': settings.INSTALLATION_REBOOT_TIMEOUT})]
 

--- a/chroma_core/models/server_profile.py
+++ b/chroma_core/models/server_profile.py
@@ -72,6 +72,7 @@ class ServerProfile(models.Model):
 
         for field in self._meta.fields:
             result[field.name] = getattr(self, field.name)
+        result['packages'] = list(self.packages)
 
         return result
 


### PR DESCRIPTION
List required packages so it will get saved on client so update checker can look at it.
Also add step to refresh profile on server upgrade.

Related to Issue #744 

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>