### PR TITLE
await_server_boot should wait for resources

### DIFF
--- a/tests/integration/core/chroma_integration_testcase.py
+++ b/tests/integration/core/chroma_integration_testcase.py
@@ -248,7 +248,7 @@ class ChromaIntegrationTestCase(ApiTestCaseWithTestReset):
 
         # Setup pacemaker debugging
         self.execute_simultaneous_commands(
-            ['grep -q ^PCMK_debug || echo PCMK_debug=crmd,pengine,stonith-ng >> /etc/sysconfig/pacemaker',
+            ['grep -q ^PCMK_debug /etc/sysconfig/pacemaker || echo PCMK_debug=crmd,pengine,stonith-ng >> /etc/sysconfig/pacemaker',
              'systemctl try-restart pacemaker'],
             [x['fqdn'] for x in new_hosts],
             'Set pacemaker debug for test',

--- a/tests/integration/core/chroma_integration_testcase.py
+++ b/tests/integration/core/chroma_integration_testcase.py
@@ -248,7 +248,7 @@ class ChromaIntegrationTestCase(ApiTestCaseWithTestReset):
 
         # Setup pacemaker debugging
         self.execute_simultaneous_commands(
-            ['echo PCMK_debug=pengine,cib,stonith-ng >> /etc/sysconfig/pacemaker',
+            ['grep -q ^PCMK_debug || echo PCMK_debug=crmd,pengine,stonith-ng >> /etc/sysconfig/pacemaker',
              'systemctl try-restart pacemaker'],
             [x['fqdn'] for x in new_hosts],
             'Set pacemaker debug for test',

--- a/tests/integration/core/failover_testcase_mixin.py
+++ b/tests/integration/core/failover_testcase_mixin.py
@@ -47,6 +47,7 @@ class FailoverTestCaseMixin(ChromaIntegrationTestCase):
         self.remote_operations.await_server_boot(primary_host['fqdn'], secondary_host['fqdn'])
 
         # Verify did not auto-failback
+        self.wait_until_true(lambda: self.targets_for_volumes_started_on_expected_hosts(filesystem_id, volumes_expected_hosts_in_failover_state))
         self.verify_targets_for_volumes_started_on_expected_hosts(filesystem_id, volumes_expected_hosts_in_failover_state)
 
     def chroma_controlled_failover(self, primary_host, secondary_host, filesystem_id, volumes_expected_hosts_in_normal_state, volumes_expected_hosts_in_failover_state):

--- a/tests/integration/core/remote_operations.py
+++ b/tests/integration/core/remote_operations.py
@@ -747,7 +747,7 @@ class RealRemoteOperations(RemoteOperations):
                 self._test_case.assertIsNotNone(node, "Host %s not defined in crm_mon" % hostname)
 
                 # Wait for host to be online
-                if node.get('online') == 'true':
+                if node.get('online') == 'true' and node.get('pending') == 'false':
                     resources = tree.findall('.//resource[@status]')
                     # Done if all resources are started or no resources
                     if not resources or not next((res for res in resources


### PR DESCRIPTION
RealRemoteOperations.await_server_boot() should wait for pacemaker to be
quiescent before returning.

This now not only waits for node to be online in pacemaker, but also
waits for all resources to be started.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>