### PR TITLE
Create iml-settings file using atomic operation

### DIFF
--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -13,6 +13,7 @@ import time
 import os
 import json
 import glob
+import shutil
 
 # without GNU readline, raw_input prompt goes to stderr
 import readline
@@ -623,8 +624,9 @@ class ServiceConfig(CommandLine):
         # Many iml docker containers depend on the iml-settings file and its contents. However, redirecting the settings output
         # into /var/lib/chroma/iml-settings.conf is not sufficient as the > operator is not atomic (the file will be created without content). 
         # The mv command is atomic, thus the contents will be created in a temp file and then moved into /var/lib/chroma/iml-settings.conf.
-        self.try_shell(['python ./manage.py print-settings > /tmp/temp-settings.conf'], shell=True)
-        self.try_shell(['mv /tmp/temp-settings.conf /var/lib/chroma/iml-settings.conf'], shell=True)
+        f = open("/tmp/temp-settings.conf", "w")
+        self.try_shell(['python', './manage.py', 'print-settings'], mystdout=f)
+        shutil.move("/tmp/temp-settings.conf", "/var/lib/chroma/iml-settings.conf")
 
     def setup(self, username, password, ntp_server, check_db_space):
         if not self._check_name_resolution():

--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -620,7 +620,11 @@ class ServiceConfig(CommandLine):
 
         self._setup_crypto()
 
-        self.try_shell(['python ./manage.py print-settings > /var/lib/chroma/iml-settings.conf'], shell=True)
+        # Many iml docker containers depend on the iml-settings file and its contents. However, redirecting the settings output
+        # into /var/lib/chroma/iml-settings.conf is not sufficient as the > operator is not atomic (the file will be created without content). 
+        # The mv command is atomic, thus the contents will be created in a temp file and then moved into /var/lib/chroma/iml-settings.conf.
+        self.try_shell(['python ./manage.py print-settings > /tmp/temp-settings.conf'], shell=True)
+        self.try_shell(['mv /tmp/temp-settings.conf /var/lib/chroma/iml-settings.conf'], shell=True)
 
     def setup(self, username, password, ntp_server, check_db_space):
         if not self._check_name_resolution():


### PR DESCRIPTION
The iml-settings.conf file was being created using redirection, which is not
an atomic operation. The result of doing this is that the file will be
created without contents. This ultimately leads to multiple docker
containers thinking environment variables are available when they
actually aren't and causes the process running in the container to
crash.

This patch changes how the iml-settings.conf file is created by first
redirecting into a temp file and then using the `mv` command to move it
to /var/lib/chroma/iml-settings.conf. The mv command is atomic and
guarantees that the contents will be available when the file exists.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>