### PR TITLE
Fix jobscheduler bug.

### DIFF
--- a/chroma_cli/parser.py
+++ b/chroma_cli/parser.py
@@ -98,7 +98,7 @@ class ResettableArgumentParser(ArgumentParser):
         super(ResettableArgumentParser, self)._remove_action(action)
         action.container._group_actions.remove(action)
         for option_string in action.option_strings:
-            del (self._option_string_actions[option_string])
+            del self._option_string_actions[option_string]
 
     def clear_resets(self):
         """
@@ -106,7 +106,7 @@ class ResettableArgumentParser(ArgumentParser):
         will be "frozen" into the parser (e.g. global arguments).  Any
         arguments added after this will be removed by a reset().
         """
-        del (self._resettable_actions[0:])
+        del self._resettable_actions[0:]
 
     def reset(self):
         """

--- a/chroma_core/models/command.py
+++ b/chroma_core/models/command.py
@@ -104,7 +104,7 @@ class Command(models.Model):
     )
     created_at = models.DateTimeField(auto_now_add=True)
 
-    def save(self, force_insert=False, force_update=False, using=None):
+    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         """
         Saves the current instance. Override this in a subclass if you want to
         control the saving process.
@@ -119,7 +119,7 @@ class Command(models.Model):
         :param force_update: bool
         :param using: str
         """
-        super(Command, self).save(force_insert, force_update, using)
+        super(Command, self).save(force_insert, force_update, using, update_fields)
 
         # This is a little bit messy and maybe shouldn't go here. We want to get the existing alert, if it exists
         # which could be of a number of types. CommandRunningAlert, CommandSuccessfulAlert, CommandCancelledAlert

--- a/chroma_core/models/corosync.py
+++ b/chroma_core/models/corosync.py
@@ -120,7 +120,7 @@ class CorosyncConfiguration(DeletableStatefulObject):
                 pass
 
         for interface in host_interfaces:
-            interface.save()
+            interface.save(update_fields=["corosync_configuration"])
 
     @property
     def configure_job_name(self):

--- a/chroma_core/models/corosync2.py
+++ b/chroma_core/models/corosync2.py
@@ -40,9 +40,9 @@ class Corosync2Configuration(CorosyncConfiguration):
 
     # This is temporary, although will work perfectly functionally. Once landed we will move to
     #  use the sparse table functionality.
-    def save(self, force_insert=False, force_update=False, using=None):
+    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         self.record_type = "Corosync2Configuration"
-        return super(Corosync2Configuration, self).save(force_insert, force_update, using)
+        return super(Corosync2Configuration, self).save(force_insert, force_update, using, update_fields)
 
     @property
     def configure_job_name(self):

--- a/chroma_core/models/corosync_common.py
+++ b/chroma_core/models/corosync_common.py
@@ -254,7 +254,7 @@ class GetCorosyncStateStep(Step):
         try:
             lnet_data = self.invoke_agent(host, "device_plugin", {"plugin": "linux_network"})["linux_network"]["lnet"]
             host.set_state(lnet_data["state"])
-            host.save()
+            host.save(update_fields=["state", "state_modified_at"])
         except TypeError:
             self.log("Data received from old client. Host %s state cannot be updated until agent is updated" % host)
         except AgentException as e:

--- a/chroma_core/models/host.py
+++ b/chroma_core/models/host.py
@@ -294,7 +294,7 @@ class ManagedHost(DeletableStatefulObject, MeasuredEntity):
         # configured, once until that occurs just remember what it wants.
         if self.state in ["unconfigured", "undeployed"]:
             self.server_profile = server_profile
-            self.save()
+            self.save(update_fields=["server_profile"])
 
             return []
         else:

--- a/chroma_core/models/pacemaker.py
+++ b/chroma_core/models/pacemaker.py
@@ -337,7 +337,7 @@ class GetPacemakerStateStep(Step):
         try:
             lnet_data = self.invoke_agent(host, "device_plugin", {"plugin": "linux_network"})["linux_network"]["lnet"]
             host.set_state(lnet_data["state"])
-            host.save()
+            host.save(update_fields=["state", "state_modified_at"])
         except TypeError:
             self.log("Data received from old client. Host %s state cannot be updated until agent is updated" % host)
         except AgentException as e:

--- a/chroma_core/models/target.py
+++ b/chroma_core/models/target.py
@@ -1748,7 +1748,7 @@ class ManagedTargetMount(models.Model):
     primary = models.BooleanField(default=False)
     target = models.ForeignKey("ManagedTarget")
 
-    def save(self, force_insert=False, force_update=False, using=None):
+    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         # If primary is true, then target must be unique
         if self.primary:
             from django.db.models import Q
@@ -1772,7 +1772,7 @@ class ManagedTargetMount(models.Model):
 
                 raise ValidationError("Cannot have multiple MGS mounts on host %s" % self.host.address)
 
-        return super(ManagedTargetMount, self).save(force_insert, force_update, using)
+        return super(ManagedTargetMount, self).save(force_insert, force_update, using, update_fields)
 
     def device(self):
         return self.volume_node.path

--- a/chroma_core/services/job_scheduler/job_scheduler.py
+++ b/chroma_core/services/job_scheduler/job_scheduler.py
@@ -815,7 +815,7 @@ class JobScheduler(object):
                 else:
                     # If setting a normal attribute just write it straight away
                     setattr(instance, attr, value)
-                    instance.save()
+                    instance.save(update_fields=[attr])
                     log.info(
                         "_notify: Set %s=%s on %s (%s-%s) and saved"
                         % (attr, value, instance, model_klass.__name__, instance.id)

--- a/tests/unit/services/job_scheduler/test_job_scheduler.py
+++ b/tests/unit/services/job_scheduler/test_job_scheduler.py
@@ -179,7 +179,7 @@ class TestStateManager(JobTestCaseWithHost):
 
         # Now, remove the lock and make sure that the second notification
         # didn't get through during the lock.
-        del (self.job_scheduler._lock_cache.all_by_item[self.host])
+        del self.job_scheduler._lock_cache.all_by_item[self.host]
         self.assertEqual(freshen(self.host).boot_time, now)
 
         # Run any job, doesn't matter -- we just want to ensure that the

--- a/tests/utils/http_requests.py
+++ b/tests/utils/http_requests.py
@@ -104,10 +104,10 @@ class AuthorizedHttpRequests(HttpRequests):
             ignore_set = set(os.environ["IGNORE_PROXY_LIST"].split())
             if len(ignore_set & set(["all", "ALL"])):
                 for key in [key for key in os.environ.keys() if key in [key for p in ["_proxy", "_PROXY"] if p in key]]:
-                    del (os.environ[key])
+                    del os.environ[key]
             else:
                 for key in set(os.environ.keys()) & ignore_set:
-                    del (os.environ[key])
+                    del os.environ[key]
 
         # Usually on our Intel laptops https_proxy is set, and needs to be unset for tests,
         # but let's not completely rule out the possibility that someone might want to run


### PR DESCRIPTION
We're intermittently seeing the following errors in the
job_scheduler.log:

```
[2019-01-08 17:43:03,166: CRITICAL/job_scheduler] Unhandled exception in RunJobThread: Traceback (most recent call last):
  File "/usr/share/chroma-manager/chroma_core/services/job_scheduler/job_scheduler.py", line 270, in run
    self._run()
  File "/usr/share/chroma-manager/chroma_core/services/job_scheduler/job_scheduler.py", line 294, in _run
    self.job.id, step_klass=klass, args=clean_args, step_index=step_index, step_count=len(self.steps)
  File "/usr/share/chroma-manager/chroma_core/services/job_scheduler/job_scheduler.py", line 197, in getter
    self.put(deepcopy((name, args, kwargs)))
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 237, in _deepcopy_tuple
    y.append(deepcopy(a, memo))
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 257, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 257, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python2.7/copy.py", line 190, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python2.7/copy.py", line 334, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 257, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python2.7/copy.py", line 190, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python2.7/copy.py", line 334, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 257, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python2.7/copy.py", line 190, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python2.7/copy.py", line 334, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 256, in _deepcopy_dict
    for key, value in x.iteritems():
RuntimeError: dictionary changed size during iteration
```

Add some remote_pdb debugging to get to the bottom of it.

COPR Module: managerforlustre/iml-agent-HA

Signed-off-by: Joe Grund <jgrund@whamcloud.io>