### PR TITLE
SSI: test_server_authentication using wrong path

### DIFF
--- a/tests/integration/shared_storage_configuration/test_storage_server_authentication.py
+++ b/tests/integration/shared_storage_configuration/test_storage_server_authentication.py
@@ -1,24 +1,22 @@
 from testconfig import config
-from django.utils.unittest import skipIf
-
 from tests.integration.core.chroma_integration_testcase import ChromaIntegrationTestCase
 
 
 class TestStorageServerAuthentication(ChromaIntegrationTestCase):
 
     SERVER = config["lustre_servers"][0]
-    SECURITY_FILE_DIR = "/var/lib/chroma"
+    SECURITY_FILE_DIR = "/etc/iml"
 
     def test_server_authentication(self):
 
         self.host = self.add_hosts([self.SERVER["address"]])
         self.remote_operations.copy_file(
             self.SERVER["address"],
-            "%s/private.pem" % self.SECURITY_FILE_DIR,
-            "%s/private.pem.save" % self.SECURITY_FILE_DIR,
+            "{}/private.pem".format(self.SECURITY_FILE_DIR),
+            "{}/private.pem.save".format(self.SECURITY_FILE_DIR),
         )
         self.remote_operations._ssh_address(
-            self.SERVER["address"], 'sed -i "2s/$/XCXXXXCVDS/" %s/private.pem' % self.SECURITY_FILE_DIR
+            self.SERVER["address"], 'sed -i "2s/$/XCXXXXCVDS/" {}/private.pem'.format(self.SECURITY_FILE_DIR)
         )
 
         active_lost_contact_filter = {"active": True, "alert_type": "HostContactAlert"}
@@ -26,7 +24,7 @@ class TestStorageServerAuthentication(ChromaIntegrationTestCase):
 
         self.remote_operations.rename_file(
             self.SERVER["address"],
-            "%s/private.pem.save" % self.SECURITY_FILE_DIR,
-            "%s/private.pem" % self.SECURITY_FILE_DIR,
+            "{}/private.pem.save".format(self.SECURITY_FILE_DIR),
+            "{}/private.pem".format(self.SECURITY_FILE_DIR),
         )
         self.wait_until_true(lambda: len(self.get_list("/api/alert/", active_lost_contact_filter)) == 0)


### PR DESCRIPTION
Fixes #778

https://github.com/whamcloud/integrated-manager-for-lustre/blob/5f8dcc3615388527c833df348617119352f51d07/tests/integration/shared_storage_configuration/test_storage_server_authentication.py#L10

Is using the wrong path. It should be `"/etc/iml/"`.

```
Traceback (most recent call last):
  File "/usr/share/chroma-manager/tests/integration/shared_storage_configuration/test_storage_server_authentication.py", line 18, in test_server_authentication
    "%s/private.pem.save" % self.SECURITY_FILE_DIR,
  File "/usr/share/chroma-manager/tests/integration/core/remote_operations.py", line 325, in copy_file
    self._ssh_address(address, "cp %s %s" % (current_file_path, new_file_path))
  File "/usr/share/chroma-manager/tests/integration/core/remote_operations.py", line 236, in _ssh_address
    % (rc, expected_return_code, stdout, stderr),
AssertionError: rc (1) != expected_return_code (0), stdout: '', stderr: 'cp: cannot stat ‘/var/lib/chroma/private.pem’: No such file or directory
```

Signed-off-by: Joe Grund <jgrund@whamcloud.io>