### PR TITLE
Add ordering on rabbitmq-server (#665)

### DIFF
--- a/chroma-manager/iml-corosync.service
+++ b/chroma-manager/iml-corosync.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Corosync Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/chroma-manager/iml-http-agent.service
+++ b/chroma-manager/iml-http-agent.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Http Agent Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/chroma-manager/iml-job-scheduler.service
+++ b/chroma-manager/iml-job-scheduler.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Job Scheduler Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/chroma-manager/iml-lustre-audit.service
+++ b/chroma-manager/iml-lustre-audit.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Lustre Audit Service
 PartOf=iml-manager.target
+After=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/chroma-manager/iml-manager.target
+++ b/chroma-manager/iml-manager.target
@@ -13,6 +13,7 @@ Requires=iml-syslog.service
 Requires=iml-view-server.service
 Requires=iml-settings-populator.service
 Requires=nginx.service
+Requires=rabbitmq-server.service
 After=postgresql.service
 After=rabbitmq-server.service
 After=iml-settings-populator.service

--- a/chroma-manager/iml-plugin-runner.service
+++ b/chroma-manager/iml-plugin-runner.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Plugin Runner Service
 PartOf=iml-manager.target
+Requires=rabbitmq-server.service
 
 [Service]
 Type=simple

--- a/chroma-manager/iml-stats.service
+++ b/chroma-manager/iml-stats.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=IML Stats Service
 PartOf=iml-manager.target
+Requires=rabbitmq-server.service
+
 
 [Service]
 Type=simple

--- a/chroma-manager/iml-syslog.service
+++ b/chroma-manager/iml-syslog.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=IML Syslog Service
 PartOf=iml-manager.target
+Requires=rabbitmq-server.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
We have a number of services that need to come up after
rabbitmq-server.

Add the `After` directive to ensure they are started after
rabbitmq-server.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>