### PR TITLE
Create /action endpoint

### DIFF
--- a/chroma_api/action.py
+++ b/chroma_api/action.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2018 DDN. All rights reserved.
+# Use of this source code is governed by a MIT-style
+# license that can be found in the LICENSE file.
+
+
+from django.contrib.contenttypes.models import ContentType
+from tastypie.authorization import DjangoAuthorization
+from tastypie.validation import Validation
+from tastypie.resources import Resource
+from tastypie import fields
+
+from chroma_api.authentication import AnonymousAuthentication
+from chroma_api.validation_utils import validate
+from chroma_core.services.job_scheduler.job_scheduler_client import JobSchedulerClient
+
+ID_TYPE = "composite_id"
+ID_TYPES = "{}s".format(ID_TYPE)
+
+
+class ActionValidation(Validation):
+    def is_valid(self, bundle, request=None):
+
+        if ID_TYPES not in request.GET:
+            return {ID_TYPES: "param is missing"}
+
+        ids = request.GET.getlist(ID_TYPES)
+
+        if not isinstance(ids, list):
+            return {ID_TYPES: "param is not an array"}
+
+        for x in ids:
+            xs = x.split(":")
+
+            if len(xs) != 2:
+                return {ID_TYPES: "Recieved a {} that is not made of two parts".format(ID_TYPE)}
+
+            (content_type, _) = xs
+
+            try:
+                ContentType.objects.get_for_id(content_type)
+            except ContentType.DoesNotExist:
+                return {ID_TYPES: "Got a {} that does not exist".format(ID_TYPE)}
+
+        return {}
+
+
+class Action(object):
+    def __init__(
+        self,
+        composite_id=None,
+        args=None,
+        class_name=None,
+        confirmation=None,
+        display_group=None,
+        display_order=None,
+        long_description=None,
+        state=None,
+        verb=None,
+    ):
+        self.composite_id = composite_id
+        self.args = args
+        self.class_name = class_name
+        self.confirmation = confirmation
+        self.display_group = display_group
+        self.display_order = display_order
+        self.long_description = long_description
+        self.state = state
+        self.verb = verb
+
+
+class ActionResource(Resource):
+    """
+    Returns Available actions (transitions + jobs).
+    Meant to be polled by the GUI once per 10s on any
+    open action dropdowns.
+    """
+
+    args = fields.DictField(attribute="args", readonly=True, null=True)
+    composite_id = fields.CharField(attribute="composite_id", readonly=True)
+    class_name = fields.CharField(attribute="class_name", readonly=True, null=True)
+    confirmation = fields.CharField(attribute="confirmation", readonly=True, null=True)
+    display_group = fields.IntegerField(attribute="display_group", readonly=True)
+    display_order = fields.IntegerField(attribute="display_order", readonly=True)
+    long_description = fields.CharField(attribute="long_description", readonly=True)
+    state = fields.CharField(attribute="state", readonly=True, null=True)
+    verb = fields.CharField(attribute="verb", readonly=True, null=True)
+
+    class Meta:
+        allowed_methods = None
+        authentication = AnonymousAuthentication()
+        authorization = DjangoAuthorization()
+        validation = ActionValidation()
+        object_class = Action
+        resource_name = "action"
+        list_allowed_methods = ["get"]
+
+    # Create our array of custom data
+    def get_object_list(self, request):
+        raw_ids = request.GET.getlist(ID_TYPES)
+        ids = map(lambda x: x.split(":"), raw_ids)
+        ids = map(lambda x: (int(x[0]), int(x[1])), ids)
+
+        computed_transitions = JobSchedulerClient.available_transitions(ids)
+        computed_jobs = JobSchedulerClient.available_jobs(ids)
+
+        actions = []
+
+        #  decorate the transition lists with verbs
+        #  and install in the bundle for return
+        for y in raw_ids:
+            obj_transitions_states_and_verbs = computed_transitions[y]
+            obj_jobs = computed_jobs[y]
+
+            available_actions = sorted(
+                obj_transitions_states_and_verbs + obj_jobs, key=lambda action: action["display_order"]
+            )
+            actions += map(lambda x: Action(y, **x), available_actions)
+
+        return actions
+
+    @validate
+    def obj_get_list(self, bundle, **kwargs):
+        return self.get_object_list(bundle.request)

--- a/chroma_api/urls.py
+++ b/chroma_api/urls.py
@@ -61,6 +61,7 @@ import chroma_api.copytool
 import chroma_api.nid
 import chroma_api.lnet_configuration
 import chroma_api.pacemaker
+import chroma_api.action
 
 api.register(chroma_api.host.HostResource())
 api.register(chroma_api.host.ServerProfileResource())
@@ -98,5 +99,6 @@ api.register(chroma_api.nid.NidResource())
 api.register(chroma_api.lnet_configuration.LNetConfigurationResource())
 api.register(chroma_api.corosync.CorosyncConfigurationResource())
 api.register(chroma_api.pacemaker.PacemakerConfigurationResource())
+api.register(chroma_api.action.ActionResource())
 
 urlpatterns = patterns("", (r"^", include(api.urls)))

--- a/chroma_api/utils.py
+++ b/chroma_api/utils.py
@@ -168,22 +168,10 @@ class CustomModelResource(ChromaModelResource):
 
 class StatefulModelResource(CustomModelResource):
     content_type_id = fields.IntegerField()
-    available_transitions = fields.ListField()
-    available_jobs = fields.ListField()
     label = fields.CharField()
 
     class Meta:
-        readonly = [
-            "id",
-            "immutable_state",
-            "state",
-            "content_type_id",
-            "available_transitions",
-            "available_jobs",
-            "label",
-            "state_modified_at",
-            "locks",
-        ]
+        readonly = ["id", "immutable_state", "state", "content_type_id", "label", "state_modified_at"]
 
     def dehydrate_content_type_id(self, bundle):
         if hasattr(bundle.obj, "content_type"):
@@ -193,84 +181,6 @@ class StatefulModelResource(CustomModelResource):
 
     def dehydrate_label(self, bundle):
         return bundle.obj.get_label()
-
-    def alter_detail_data_to_serialize(self, request, bundle):
-        """Add post dehydrate data to a single bundle
-
-        Call in methods that call obj_create() and have a flag to create
-        a fresh copy of the bundle.
-
-        Recommended to be used in places that call full_dehydrate directly
-        around this app to get available_* data added to the bundle.
-
-        Normally as GET call to TastyPie will call the
-        alter_list_data_to_serialize hook method which populates the
-        available_* data.  In the short circuit case of calling full_dehydrate
-        you can use this method to get the available_* post added.
-
-        Example:
-          self.alter_detail_data_to_serialize(
-            self.full_dehydrate(
-                self.build_bundle(obj=the_obj)
-                )
-            ).data
-
-        or, perhaps more readable
-
-          bundle = self.full_dehydrate(self.build_bundle(obj=the_obj))
-          bundle = self.alter_detail_data_to_serialize(bundle)
-          data = bundle.data
-
-        """
-
-        to_be_serialized = dict()
-        to_be_serialized["objects"] = [bundle]
-        to_be_serialized = self.alter_list_data_to_serialize(None, to_be_serialized)
-
-        #  Return the bundle
-        return to_be_serialized["objects"][0]
-
-    def alter_list_data_to_serialize(self, request, to_be_serialized):
-        """Post process available jobs and state transitions
-
-        This method is a TastyPie hook that is called after all fields
-        have been dehydrated.  The available_* methods are no longer
-        dehydrated one at a time.  Instead, they are all done in two batched
-        calls, and set in the return datastructure here.
-
-        to_be_serialized is a list of TastyPie Bundles composing some
-        subclass of StatefulObjects under the key 'objects.
-
-        Returns an updated copy of the input dict.
-        """
-
-        batch = []
-        for bundle in to_be_serialized["objects"]:
-            so_ct_key = ContentType.objects.get_for_model(bundle.obj.downcast()).natural_key()
-            batch.append((so_ct_key, bundle.obj.id))
-
-        computed_transitions = JobSchedulerClient.available_transitions(batch)
-        computed_jobs = JobSchedulerClient.available_jobs(batch)
-
-        #  decorate the transition lists with verbs
-        #  and install in the bundle for return
-        for idx, bundle in enumerate(to_be_serialized["objects"]):
-            obj_transitions_states_and_verbs = computed_transitions[str(bundle.obj.id)]
-
-            obj_jobs = computed_jobs[str(bundle.obj.id)]
-
-            # TODO: available_transitions is deprecated, use available_actions
-            bundle.data["available_transitions"] = obj_transitions_states_and_verbs
-
-            # TODO: available_jobs is deprecated, use available_actions
-            bundle.data["available_jobs"] = obj_jobs
-
-            available_actions = sorted(
-                obj_transitions_states_and_verbs + obj_jobs, key=lambda action: action["display_order"]
-            )
-            bundle.data["available_actions"] = available_actions
-
-        return to_be_serialized
 
     # PUT handler for accepting {'state': 'foo', 'dry_run': <true|false>}
     def obj_update(self, bundle, **kwargs):
@@ -351,7 +261,7 @@ class ConfParamResource(StatefulModelResource):
         # FIXME HYD-1032: PUTing modified conf_params and modified state in the same request will
         # cause one of those two things to be ignored.
 
-        if not "conf_params" in bundle.data or isinstance(obj, ManagedMgs):
+        if "conf_params" not in bundle.data or isinstance(obj, ManagedMgs):
             super(ConfParamResource, self).obj_update(bundle, **kwargs)
 
         try:

--- a/tests/integration/core/api_testcase_with_test_reset.py
+++ b/tests/integration/core/api_testcase_with_test_reset.py
@@ -13,8 +13,7 @@ from tests.integration.core.constants import TEST_TIMEOUT
 from tests.integration.core.remote_operations import RealRemoteOperations
 from tests.integration.core.utility_testcase import UtilityTestCase
 from tests.integration.utils.test_blockdevices.test_blockdevice import TestBlockDevice
-from tests.utils.http_requests import AuthorizedHttpRequests
-from tests.utils.http_requests import HttpRequests
+from tests.utils.http_requests import AuthorizedHttpRequests, HttpRequests, get_actions
 
 logger = logging.getLogger("test")
 logger.setLevel(logging.DEBUG)
@@ -319,7 +318,13 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         or the timeout is reached, filtering on action keys: class_name, state.
         """
         for _ in util.wait(timeout):
-            actions = self.get_json_by_uri(victim["resource_uri"])["available_actions"]
+            obj = self.get_json_by_uri(victim["resource_uri"])
+
+            actions = obj.get("available_actions", None)
+
+            if actions is None:
+                actions = get_actions(self.chroma_manager, [obj]).json["objects"]
+
             for action in actions:
                 if all(action.get(key) == filters[key] for key in filters):
                     return action

--- a/tests/integration/shared_storage_configuration/test_anonymous_access_control.py
+++ b/tests/integration/shared_storage_configuration/test_anonymous_access_control.py
@@ -17,6 +17,7 @@ class TestAnonymousAccessControl(ChromaIntegrationTestCase):
             "/api/system_status/",
             "/api/updates_available/",
             "/api/session/",
+            "/api/action/",
         ]
 
         end_points = self.get_json_by_uri("/api/", args={"limit": 0})

--- a/tests/integration/shared_storage_configuration/test_client_mount_management.py
+++ b/tests/integration/shared_storage_configuration/test_client_mount_management.py
@@ -1,11 +1,14 @@
 from tests.integration.core.chroma_integration_testcase import ChromaIntegrationTestCase
+from tests.utils.http_requests import get_actions
 
 
 class TestClientMountManagement(ChromaIntegrationTestCase):
     def _get_mount_job(self, job_class):
         self.worker = self.get_json_by_uri(self.worker["resource_uri"])
 
-        for action in self.worker["available_actions"]:
+        actions = get_actions(self.chroma_manager, [self.worker]).json["objects"]
+
+        for action in actions:
             if action.get("class_name", None) == job_class:
                 return action
 

--- a/tests/unit/chroma_api/test_sorting_actions.py
+++ b/tests/unit/chroma_api/test_sorting_actions.py
@@ -4,7 +4,8 @@ from chroma_core.models import ConfigureLNetJob
 from chroma_core.services.job_scheduler.job_scheduler import JobScheduler
 from tests.unit.chroma_api.chroma_api_test_case import ChromaApiTestCase
 from tests.unit.chroma_core.helpers import synthetic_host
-
+from tests.utils.http_requests import get_actions
+import json
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class TestSortingActions(ChromaApiTestCase):
         def _mock_job_dict(verb, order, group):
             return {
                 "verb": verb,
-                "long_description": None,
+                "long_description": "foo",
                 "display_group": group,
                 "display_order": order,
                 "confirmation": None,
@@ -50,7 +51,7 @@ class TestSortingActions(ChromaApiTestCase):
         @classmethod
         def _get_jobs(cls, obj_list):
             #  Return these jobs for this host only.
-            return {str(host.id): wrapped_jobs}
+            return {"{}:{}".format(host.content_type_id, host.id): wrapped_jobs}
 
         # ChromaApiTestCase.setup() will save off the orginal and monkey patch
         # Here we redefining the monkey patch for use in this test
@@ -65,7 +66,7 @@ class TestSortingActions(ChromaApiTestCase):
         def _mock_trans_to_job_dict(verb, order, group):
             return {
                 "verb": verb,
-                "long_description": None,
+                "long_description": "foo",
                 "display_group": group,
                 "display_order": order,
                 "state": None,
@@ -76,7 +77,7 @@ class TestSortingActions(ChromaApiTestCase):
         @classmethod
         def _get_transitions(cls, obj_list):
             #  Return these jobs for this host only.
-            return {str(host.id): wrapped_jobs}
+            return {"{}:{}".format(host.content_type_id, host.id): wrapped_jobs}
 
         # ChromaApiTestCase.setup() will save off the orginal and monkey patch
         # Here we redefining the monkey patch for use in this test
@@ -95,17 +96,15 @@ class TestSortingActions(ChromaApiTestCase):
         self._mock_available_transitions(host, [("Job 3", 3, 2), ("Job 1", 1, 1), ("Job 6", 6, 3)])
         self._mock_available_jobs(host, [("Job 5", 5, 3), ("Job 2", 2, 1), ("Job 4", 4, 2)])
 
-        response = self.api_client.get("/api/host/%s/" % host.id)
+        resp = get_actions(self.api_client, [host])
+        actions = json.loads(resp.content)["objects"]
 
-        self.assertHttpOK(response)
-        host = self.deserialize(response)
-
-        received_verbs_order = [t["verb"] for t in host["available_actions"]]
+        received_verbs_order = [t["verb"] for t in actions]
         expected_verbs_order = ["Job 1", "Job 2", "Job 3", "Job 4", "Job 5", "Job 6"]
 
         self.assertEqual(received_verbs_order, expected_verbs_order)
 
-        received_verbs_group = [t["display_group"] for t in host["available_actions"]]
+        received_verbs_group = [t["display_group"] for t in actions]
         expected_verbs_group = [1, 1, 2, 2, 3, 3]
 
         self.assertEqual(received_verbs_group, expected_verbs_group)

--- a/tests/unit/chroma_core/services/job_scheduler/test_available_jobs.py
+++ b/tests/unit/chroma_core/services/job_scheduler/test_available_jobs.py
@@ -62,13 +62,13 @@ class TestAvailableJobs(IMLUnitTestCase):
     def _get_jobs(self, object):
         """Check that expected states are returned for given object"""
 
-        so_ct_key = ContentType.objects.get_for_model(object).natural_key()
+        ct_id = ContentType.objects.get_for_model(object).id
         so_id = object.id
 
         #  In-process JSC call that works over RPC in production
-        receive_jobs = self.js.available_jobs([(so_ct_key, so_id)])
+        receive_jobs = self.js.available_jobs([(ct_id, so_id)])
 
-        return receive_jobs[object.id]
+        return receive_jobs["{}:{}".format(ct_id, so_id)]
 
     def test_managed_mgs(self):
         """Test the MGS available jobs."""

--- a/tests/unit/chroma_core/services/job_scheduler/test_available_transitions.py
+++ b/tests/unit/chroma_core/services/job_scheduler/test_available_transitions.py
@@ -49,13 +49,13 @@ class TestAvailableTransitions(IMLUnitTestCase):
     def _get_transition_states(self, object):
         """Check that expected states are returned for given object"""
 
-        so_ct_key = ContentType.objects.get_for_model(object).natural_key()
+        ct_id = ContentType.objects.get_for_model(object).id
         so_id = object.id
 
         #  In-process JSC call that works over RPC in production
-        receive_states = self.js.available_transitions([(so_ct_key, so_id)])
+        receive_states = self.js.available_transitions([(ct_id, so_id)])
 
-        return receive_states[object.id]
+        return receive_states["{}:{}".format(ct_id, so_id)]
 
     def test_managed_mgs(self):
         """Test the MGS some possible states."""
@@ -210,15 +210,17 @@ class TestAvailableTransitions(IMLUnitTestCase):
         )
 
     def test_managed_target_dne(self):
-        host_ct_key = ContentType.objects.get_for_model(self.host.downcast()).natural_key()
+        ct_id = ContentType.objects.get_for_model(self.host.downcast()).id
         host_id = self.host.id
 
         self.host.mark_deleted()
 
         job_scheduler = JobScheduler()
 
-        avail_trans = job_scheduler.available_transitions([(host_ct_key, host_id)])[host_id]
+        composite_id = "{}:{}".format(ct_id, host_id)
+
+        avail_trans = job_scheduler.available_transitions([(ct_id, host_id)])[composite_id]
         self.assertTrue(len(avail_trans) == 0, avail_trans)
-        avail_jobs = job_scheduler.available_jobs([(host_ct_key, host_id)])[host_id]
+        avail_jobs = job_scheduler.available_jobs([(ct_id, host_id)])[composite_id]
         self.assertTrue(self.host.state, "managed")
         self.assertTrue(len(avail_jobs) == 3)  # Three states from configured -> Force Remove. Reboot, Shutdown

--- a/tests/utils/http_requests.py
+++ b/tests/utils/http_requests.py
@@ -146,3 +146,19 @@ class AuthorizedHttpRequests(HttpRequests):
         response = self.post("/api/session/", data=json.dumps({"username": username, "password": password}))
         if not response.successful:
             raise RuntimeError("Failed to authenticate with username: %s and password: %s" % (username, password))
+
+
+def _get_value(obj, key):
+    attr = getattr(obj, key, None)
+
+    if attr is None:
+        attr = obj[key]
+
+    return attr
+
+
+def get_actions(requests, stateful_objects):
+
+    xs = ["{}:{}".format(_get_value(x, "content_type_id"), _get_value(x, "id")) for x in stateful_objects]
+
+    return requests.get("/api/action/", data={"composite_ids": xs, "limit": 0})


### PR DESCRIPTION
Currently for each stateful object requested via the API,
we tack on extra information regarding it's available jobs +
transitions, and locks.

This is done in:

https://github.com/whamcloud/integrated-manager-for-lustre/blob/5f8dcc3615388527c833df348617119352f51d07/chroma_api/utils.py#L198-L280

This is primarily done for convenience, but adds a bunch of overhead
both in RPC calls and database access.

Add a /action endpoint that can be called on demand, and remove the actions being appended to utils.

This will make any API polling calls for stateful objects cheaper, as additional queue / db traffic is mitigated.

To call the endpoint, do something like the following:

```
https://localhost:8443/api/action/?composite_ids=62:1&composite_ids=62:2
```

Where 62 is the content_type_id, and 1,2 are the resource ids.

The endpoint can be called to resolve 1-N records at once.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>