### PR TITLE
Fixed NID without network ID for all types of networks

### DIFF
--- a/chroma_core/lib/util.py
+++ b/chroma_core/lib/util.py
@@ -8,6 +8,7 @@ import sys
 import logging
 import time
 import settings
+import re
 
 # We use an integer for time and record microseconds.
 SECONDSTOMICROSECONDS = 1000000
@@ -197,7 +198,7 @@ def normalize_nids(nid_list):
 def normalize_nid(string):
     """Cope with the Lustre and users sometimes calling tcp0 'tcp' to allow
        direct comparisons between NIDs"""
-    if string[-4:] == "@tcp":
+    if not re.search(r"\d+$", string):
         string += "0"
 
     # remove _ from nids (i.e. @tcp_0 -> @tcp0


### PR DESCRIPTION
Comparison [here](https://github.com/AlexTalker/integrated-manager-for-lustre/blob/master/chroma_core/lib/detection.py#L237) fails if I have an `InfiniBand` interface utilized by `LNet`.
This happens because `normalize_nid` doesn't act the same as the [agent](https://github.com/whamcloud/iml-agent/blob/master/chroma_agent/device_plugins/linux_network.py#L248).
Example of such metadata for `MGS`:
```
# tunefs.lustre --dryrun /dev/l_mgs 
checking for existing Lustre data: found
Reading CONFIGS/mountdata

   Read previous values:
Target:     MGS
Index:      unassigned
Lustre FS:  
Mount type: ldiskfs
Flags:      0x1004
              (MGS no_primnode )
Persistent mount opts: user_xattr,errors=remount-ro
Parameters:    failover.node=:10.239.239.1@o2ib:10.239.239.2@o2ib


   Permanent disk data:
Target:     MGS
Index:      unassigned
Lustre FS:  
Mount type: ldiskfs
Flags:      0x1004
              (MGS no_primnode )
Persistent mount opts: user_xattr,errors=remount-ro
Parameters:    failover.node=:10.239.239.1@o2ib:10.239.239.2@o2ib

exiting before disk write.
```

@jgrund @utopiabound Would you kindly review this one?