### PR TITLE
Remove fetch-help from server install

### DIFF
--- a/tests/integration/core/chroma_integration_testcase.py
+++ b/tests/integration/core/chroma_integration_testcase.py
@@ -237,12 +237,7 @@ class ChromaIntegrationTestCase(ApiTestCaseWithTestReset):
 
             return False
 
-        self._fetch_help(
-            lambda: self.wait_for_commands(self.chroma_manager, command_ids, timeout=INSTALL_TIMEOUT),
-            ["iml@whamcloud.com"],
-            "Waiting for developer inspection.  DO NOT ABORT THIS TEST.",
-            timeout=60 * 60 * 24 * 3,
-        )
+        self.wait_for_commands(self.chroma_manager, command_ids, timeout=INSTALL_TIMEOUT)
 
     def _add_hosts(self, addresses, auth_type):
         """Add a list of lustre server addresses to chroma and ensure lnet ends in the correct state."""

--- a/tests/integration/core/utility_testcase.py
+++ b/tests/integration/core/utility_testcase.py
@@ -212,12 +212,12 @@ class UtilityTestCase(TestCase):
 
         Typical usage.
         self._fetch_help(lambda: self.assertEqual(commandResult, True),
-                         ['joe.grund@intel.com', 'tom.nabarro@intel.com', 'william.c.johnson@intel.com'],
+                         ['iml@whamcloud.com'],
                          'Send the cavalry',
                          callback=lambda: check_if_significant(data))
 
         self._fetch_help(lambda: self.assertEqual(commandResult, True),
-                         ['joe.grund@intel.com', 'tom.nabarro@intel.com', 'william.c.johnson@intel.com'],
+                         ['iml@whamcloud.com'],
                          lambda: 'Send the cavalry',
                          callback=lambda: check_if_significant(data))
 


### PR DESCRIPTION
We have a fetch-help call that's currently a noop as emails
aren't going out.

Remove it.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>