### PR TITLE
"No data available" when target is active on failover node

### DIFF
--- a/chroma_core/services/lustre_audit/update_scan.py
+++ b/chroma_core/services/lustre_audit/update_scan.py
@@ -290,7 +290,7 @@ class UpdateScan(object):
         try:
             target = ManagedTarget.objects.get(name=target_name).downcast()
 
-            if target.immutable_state:
+            if target.immutable_state and (target.active_host == target.primary_host):
                 # in monitored mode we want to make sure the target volume is accessible on current host
                 target.volume.volumenode_set.get(host=self.host, not_deleted=True)
             else:


### PR DESCRIPTION
Unfortunately, I came across something broken again.
If I do fail-over a target from primary node, after short amount of time(about 7 minutes usually),
charts on dashboard, related to the target, shows "No data available" sign for everything.
I noticed that action happens just after the fail-over and the log shows this:
```
http-agent_1         | ::ffff:172.27.0.17 - - [2019-02-12 10:18:26] "POST /agent/message/ HTTP/1.0" 200 115 0.002040
device-aggregator_1  | Aggregator received update with devices from host lustre2.rd.com
lustre-audit_1       | [2019-02-12 10:18:26,405: WARNING/chroma_core.services.lustre_audit.update_scan] Discarding metrics for unknown target: fs1-OST0
000 (VolumeNode matching query does not exist.)                                        
lustre-audit_1       | [2019-02-12 10:18:26,405: WARNING/chroma_core.services.lustre_audit.update_scan] Discarding metrics for unknown target: fs1-OST0
000 (VolumeNode matching query does not exist.)                                        
lustre-audit_1       | [2019-02-12 10:18:26,416: WARNING/chroma_core.services.lustre_audit.update_scan] Discarding metrics for unknown target: fs1-MDT0
000 (VolumeNode matching query does not exist.)                                                                                                        
lustre-audit_1       | [2019-02-12 10:18:26,416: WARNING/chroma_core.services.lustre_audit.update_scan] Discarding metrics for unknown target: fs1-MDT0000 (VolumeNode matching query does not exist.)
```

I made short investigation and found out that you do match with a wrong host.
Moreover, a `primary` or `fail-over` host is selected from `ManagedTargetMount` model, so I see no point why you do the look-up for a volume.
But it was there for some reason, so I just improved the condition so that it's clearly seen what is expected.

Also, I somehow managed to broke the relationship between `ManagedTarget` and `VolumeNode` models, `PostgreSQL` tables were correct but `Django` query showed empty list. I'm not very familiar with the `ORM`, so you better investigate it yourself.