### PR TITLE
Jobstats: Do not return empty list when only one point fall in range

### DIFF
--- a/chroma_core/lib/metrics.py
+++ b/chroma_core/lib/metrics.py
@@ -72,7 +72,8 @@ class MetricStore(object):
         "Return datetimes with dicts of field names and values."
         result = collections.defaultdict(dict)
         types = set()
-        end = Stats[0].floor(end)  # exclude points from a partial sample
+        begin = Stats[0].round(begin)  # exclude points from a partial sample
+        end = Stats[0].round(end)  # exclude points from a partial sample
         for series in Series.filter(self.measured_object, name__in=fetch_metrics):
             types.add(series.type)
             minimum = 0.0 if series.type == "Counter" else float("-inf")
@@ -98,7 +99,8 @@ class MetricStore(object):
         "Return datetimes with dicts of field names and values."
         result = collections.defaultdict(dict)
         types = set()
-        end = Stats[0].floor(end)  # exclude points from a partial sample
+        begin = Stats[0].round(begin)  # exclude points from a partial sample
+        end = Stats[0].round(end)  # exclude points from a partial sample
         series_ids = Series.filter(self.measured_object, name__startswith="job_" + metric).values("id")
         series_ids = Stats[0].objects.filter(id__in=series_ids, dt__gte=begin).values("id").distinct("id")
         for series in Series.filter(self.measured_object, id__in=series_ids):

--- a/chroma_core/models/stats.py
+++ b/chroma_core/models/stats.py
@@ -161,9 +161,17 @@ class Sample(models.Model):
         return dt - timedelta(seconds=timestamp(dt) % cls.step, microseconds=dt.microsecond)
 
     @classmethod
+    def round(cls, dt):
+        "Return datetime rounded to nearest sample size."
+        floor = timestamp(dt) % cls.step
+        ceil = cls.step - floor
+        diff = -ceil if ceil < floor else floor
+        return dt - timedelta(seconds=diff, microseconds=dt.microsecond)
+
+    @classmethod
     def reduce(cls, points_to_reduce):
         "Generate points grouped and summed by sample size."
-        for dt, points in itertools.groupby(points_to_reduce, key=lambda point: cls.floor(point.dt)):
+        for dt, points in itertools.groupby(points_to_reduce, key=lambda point: cls.round(point.dt)):
             yield Point(dt, *sum(points, Point.zero)[1:])
 
     @classmethod


### PR DESCRIPTION
Hello again

The problem in this case that if only one value is returned from the model,
and `rate` operator specified(which is default for `fetch_jobs`), then related "Jobstats" page
says that no data is available.

However, that's not true.

In any way, you seem to have strange representation of timestamps since on the server side they tend to change up to 10 seconds and highly depend on client-side time, which is strange since you do display charts correctly BUT the user may not find associated `Jobstats` by clicking on the heat-map chart, since the values falls out of transformed `begin` and `end` range.
Also, hell knows why you do not show target names on the chart but the `PK` instead.