### PR TITLE
Join rx_svc_thread

### DIFF
--- a/chroma_core/services/http_agent/__init__.py
+++ b/chroma_core/services/http_agent/__init__.py
@@ -128,7 +128,7 @@ class Service(ChromaService):
         host_checker_thread.stop()
         session_rpc_thread.join()
         tx_svc_thread.join()
-        tx_svc_thread.join()
+        rx_svc_thread.join()
         host_checker_thread.join()
 
     def stop(self):


### PR DESCRIPTION
There is a typo when stopping the `http_agent`.

We call `tx_svc_thread.join()` twice but we really want to call
`rx_svc_thread.join()` the second time.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>