### PR TITLE
Enable locally created repos

### DIFF
--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -638,7 +638,7 @@ class ServiceConfig(CommandLine):
         repo = """[%s]
 name=Created Repo - %s
 baseurl=%s/%s/
-enabled=0
+enabled=1
 gpgcheck=0
 repo_gpgcheck=0
 sslverify = 1


### PR DESCRIPTION
If repos aren't created as enabled, they won't be used by default.  This fixes that issue.

Follow up to #812

Fixes #820

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>