### PR TITLE
Bump rabbitmq

### DIFF
--- a/chroma_support.repo
+++ b/chroma_support.repo
@@ -25,3 +25,10 @@ enabled=1
 gpgcheck=1
 #gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
 gpgkey=https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
+[bintray-rabbitmq-server]
+name=bintray-rabbitmq-rpm
+baseurl=https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.6.x/el/7/
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1


### PR DESCRIPTION
The rabbitmq supplied in EPEL is ancient and no longer officially
supported.

Bump to a newer rabbitmq so we can utilize features like direct
reply-to.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>