### PR TITLE
Use a single "mode" for rpcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ localenv
 storage_server.repo
 base.repo
 copr-local.mk
+target/
+.cargo/

--- a/chroma_core/management/commands/chroma_service.py
+++ b/chroma_core/management/commands/chroma_service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 DDN. All rights reserved.
+# Copyright (c) 2019 DDN. All rights reserved.
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
@@ -22,7 +22,6 @@ except ImportError:
 from daemon import DaemonContext
 from django.core.management.base import BaseCommand
 from chroma_core.services.log import log_set_filename, log_register, log_enable_stdout
-from chroma_core.services.rpc import RpcClientFactory
 from iml_common.lib.date_time import IMLDateTime
 import chroma_core.services.log
 
@@ -35,7 +34,6 @@ class Command(BaseCommand):
     help = """Run a single ChromaService in a new plugin."""
     option_list = BaseCommand.option_list + (
         make_option("--gevent", action="store_true", dest="gevent", default=False),
-        make_option("--lightweight-rpc", action="store_true", dest="lightweight_rpc", default=False),
         make_option("--verbose", action="store_true", dest="verbose", default=False),
         make_option("--console", action="store_true", dest="console", default=False),
         make_option("--name", dest="name", default="chroma_service"),
@@ -126,9 +124,6 @@ class Command(BaseCommand):
             sys.stderr.write("IML is not configured, please run chroma-config setup first\n")
             sys.exit(-1)
 
-        if not options["lightweight_rpc"]:
-            RpcClientFactory.initialize_threads()
-
         # Respond to Ctrl+C
         stopped = threading.Event()
 
@@ -144,9 +139,6 @@ class Command(BaseCommand):
             if not setup_complete.is_set():
                 log.warning("Terminated during setup, exiting hard")
                 os._exit(0)
-
-            if not options["lightweight_rpc"]:
-                RpcClientFactory.shutdown_threads()
 
             for service_thread in service_mains:
                 log.info("Stopping %s" % service_thread.service.name)

--- a/chroma_core/services/rpc.py
+++ b/chroma_core/services/rpc.py
@@ -239,8 +239,7 @@ class RpcClient(object):
                 self._result = body
                 self._complete = True
             finally:
-                with self._lock:
-                    message.ack()
+                message.ack()
 
         with self._lock:
             consumer = kombu.Consumer(
@@ -418,8 +417,9 @@ class ServiceRpcInterface(object):
         return fn(*args, **kwargs)
 
     def run(self):
-        self.worker = RpcServer(self, self._connection, self.__class__.__name__)
-        self.worker.run()
+        with _amqp_connection() as connection:
+            self.worker = RpcServer(self, connection, self.__class__.__name__)
+            self.worker.run()
 
     def stop(self):
         log.info("Stopping ServiceRpcInterface")

--- a/chroma_core/services/rpc.py
+++ b/chroma_core/services/rpc.py
@@ -239,7 +239,8 @@ class RpcClient(object):
                 self._result = body
                 self._complete = True
             finally:
-                message.ack()
+                with self._lock:
+                    message.ack()
 
         with self._lock:
             consumer = kombu.Consumer(

--- a/chroma_support.repo
+++ b/chroma_support.repo
@@ -25,3 +25,17 @@ enabled=1
 gpgcheck=1
 #gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
 gpgkey=https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
+[bintray-rabbitmq-server]
+name=bintray-rabbitmq-rpm
+baseurl=https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.7.x/el/7/
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+
+[bintraybintray-rabbitmq-erlang-rpm]
+name=bintray-rabbitmq-erlang-rpm
+baseurl=https://dl.bintray.com/rabbitmq-erlang/rpm/erlang/21/el/7/
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1

--- a/chroma_support.repo
+++ b/chroma_support.repo
@@ -33,9 +33,8 @@ gpgcheck=0
 repo_gpgcheck=0
 enabled=1
 
-[bintraybintray-rabbitmq-erlang-rpm]
-name=bintray-rabbitmq-erlang-rpm
-baseurl=https://dl.bintray.com/rabbitmq-erlang/rpm/erlang/21/el/7/
-gpgcheck=0
-repo_gpgcheck=0
+[erlang-solutions]
+name=CentOS $releasever - $basearch - Erlang Solutions
+baseurl=https://packages.erlang-solutions.com/rpm/centos/7/$basearch
 enabled=1
+gpgcheck=0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-amqp==1.4.9
+amqp==2.4.0
 anyjson==0.3.3
 Django==1.6.11
 django-extensions
@@ -13,17 +13,16 @@ https://bitbucket.org/jordilin/alerta/downloads/log4tailer-3.0.9.tar.gz
 https://github.com/drkjam/netaddr/archive/rel-0.7.5.tar.gz
 iml-common>=1.4,<1.5
 jsonschema==0.8.0
-kombu==3.0.37
+kombu==4.2.1
 lockfile==0.9.1
 meld3==0.6.10
 mimeparse==0.1.3
 networkx==1.7
 ordereddict==1.1
-paramiko==1.16.1
+paramiko==2.1.1
 pexpect
 prettytable==0.6
 psycopg2==2.7.5
-pycrypto==2.6.1
 pyparsing==1.5.6
 python-daemon==1.6
 python-dateutil==1.5

--- a/scripts/rpcbench.sh
+++ b/scripts/rpcbench.sh
@@ -3,9 +3,9 @@
 SERVICE_PID=$!
 
 ./manage.py chroma_service pinger_client
-./manage.py chroma_service --lightweight-rpc pinger_client
+./manage.py chroma_service pinger_client
 ./manage.py chroma_service --gevent pinger_client
-./manage.py chroma_service --gevent --lightweight-rpc pinger_client
+./manage.py chroma_service --gevent pinger_client
 
 kill -INT $SERVICE_PID
 wait $SERVICE_PID
@@ -14,9 +14,9 @@ wait $SERVICE_PID
 SERVICE_PID=$!
 
 ./manage.py chroma_service pinger_client
-./manage.py chroma_service --lightweight-rpc pinger_client
+./manage.py chroma_service pinger_client
 ./manage.py chroma_service --gevent pinger_client
-./manage.py chroma_service --gevent --lightweight-rpc pinger_client
+./manage.py chroma_service --gevent pinger_client
 
 kill -INT $SERVICE_PID
 wait $SERVICE_PID


### PR DESCRIPTION
IML currently has two modes for performing rpc calls.

- A lightweight mode, where no additional threads are spawned, but
separate AMQP connections are used for each RPC, and short lived queues
are created to handle RPC responses.

- A threaded mode, where a reponse handler thread takes responses. This
mode is meant to reduce the number of connections and queues.

Lightweight mode is actually very expensive in terms of resource from
connections and queues, so most code tries to use threaded mode.

Threaded mode also tries to limit active connections.

The lightweight mode is currently connection oriented, which seems strange
as best practice in rabbitmq is to use many channels over a single
connection.

As I dug into this, I realized the reason why is gevent will not
share open sockets between greenlets, which will naturally happen with
channels.

Overall, the lightweight mode is closer to how I think we should be
interfacing with RabbitMQ but has two problems.

1. Connections are spawned for concurrent requests.
1. Queues are created for each pending RPC response.

We can solve both of these and unify on a single "mode" by doing the
following:

1. Use a single connection per `ServiceRpcInterface` (One per process).
1. Create a channel for each call over `ServiceRpcInterface`.
1. Use a gevent [Semaphore](http://www.gevent.org/api/gevent.lock.html#gevent.lock.Semaphore) to enable connection / channel sharing between greenlets.
1. Use [Direct reply-to](https://www.rabbitmq.com/direct-reply-to.html) to avoid creating any new queues for RPC reponses.

This patch does all these things, unifying on a single mode.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>