### PR TITLE
Extract useful internal manager messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-manager-env 0.1.0",
+ "iml-manager-messaging 0.1.0",
  "iml-rabbit 0.1.0",
  "iml-wire-types 0.1.0",
  "lapin-futures 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -704,6 +705,19 @@ dependencies = [
 [[package]]
 name = "iml-manager-env"
 version = "0.1.0"
+
+[[package]]
+name = "iml-manager-messaging"
+version = "0.1.0"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iml-manager-env 0.1.0",
+ "iml-rabbit 0.1.0",
+ "iml-wire-types 0.1.0",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "iml-rabbit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ['iml-wire-types',  'iml-agent-comms', 'iml-rabbit', 'iml-manager-env', 'iml-agent', 'iml-services', 'tokio-runtime-shutdown']
+members = ['iml-wire-types',  'iml-agent-comms', 'iml-rabbit', 'iml-manager-env', 'iml-agent', 'iml-services', 'tokio-runtime-shutdown', 'iml-manager-messaging']

--- a/iml-agent-comms/src/main.rs
+++ b/iml-agent-comms/src/main.rs
@@ -10,9 +10,10 @@ use futures::{
 use iml_agent_comms::{
     flush_queue,
     host::{self, SharedHosts},
-    messaging::{consume_agent_tx_queue, send_agent_message, send_plugin_message, AgentData},
+    messaging::{consume_agent_tx_queue, AgentData},
     session::{self, Session, Sessions},
 };
+use iml_manager_messaging::{send_agent_message, send_plugin_message};
 use iml_rabbit::{self, TcpClient, TcpClientFuture};
 use iml_wire_types::{
     Envelope, Fqdn, ManagerMessage, ManagerMessages, Message, PluginMessage, PluginName,
@@ -28,8 +29,8 @@ fn data_handler(sessions: Sessions, client: TcpClient, data: AgentData) -> impl 
         log::debug!("Forwarding valid message {}", data);
 
         Either::A(send_plugin_message(
-            format!("agent_{}_rx", data.plugin),
             client.clone(),
+            format!("agent_{}_rx", data.plugin),
             data.into(),
         ))
     } else {
@@ -65,8 +66,8 @@ fn session_create_req_handler(
         log::warn!("Destroying session {} to create new one", last);
 
         Either::A(send_plugin_message(
-            format!("agent_{}_rx", plugin),
             client.clone(),
+            format!("agent_{}_rx", plugin),
             PluginMessage::SessionTerminate {
                 fqdn: last.fqdn,
                 plugin: last.plugin,
@@ -79,8 +80,8 @@ fn session_create_req_handler(
 
     fut.and_then(move |client| {
         send_plugin_message(
-            format!("agent_{}_rx", plugin.clone()),
             client.clone(),
+            format!("agent_{}_rx", plugin.clone()),
             PluginMessage::SessionCreate {
                 fqdn: fqdn.clone(),
                 plugin: plugin.clone(),

--- a/iml-agent-comms/src/messaging.rs
+++ b/iml-agent-comms/src/messaging.rs
@@ -4,8 +4,7 @@
 
 use futures::prelude::*;
 use iml_rabbit::{
-    basic_consume, basic_publish, connect_to_queue, create_channel, declare_queue, TcpChannel,
-    TcpClient, TcpStreamConsumerFuture,
+    basic_consume, create_channel, declare_queue, TcpClient, TcpStreamConsumerFuture,
 };
 use iml_wire_types::{Fqdn, Id, ManagerMessage, Message, PluginMessage, PluginName, Seq};
 use lapin_futures::channel::BasicConsumeOptions;
@@ -72,37 +71,13 @@ impl From<AgentData> for PluginMessage {
     }
 }
 
-fn send_message_to_queue<'a, T: 'a + Into<Vec<u8>> + std::fmt::Debug>(
-    queue_name: String,
-    client: TcpClient,
-    msg: T,
-) -> impl Future<Item = TcpChannel, Error = failure::Error> + 'a {
-    connect_to_queue(queue_name, client.clone())
-        .and_then(move |(c, q)| basic_publish("", &q.name(), c, msg))
-}
-
-pub fn send_agent_message<'a>(
-    client: TcpClient,
-    msg: ManagerMessage,
-) -> impl Future<Item = TcpClient, Error = failure::Error> + 'a {
-    send_message_to_queue("agent_tx_rust".to_string(), client.clone(), msg).map(move |_| client)
-}
-
-pub fn send_plugin_message(
-    queue_name: String,
-    client: TcpClient,
-    msg: PluginMessage,
-) -> impl Future<Item = TcpClient, Error = failure::Error> + 'static {
-    send_message_to_queue(queue_name, client.clone(), msg).map(move |_| client)
-}
-
 pub fn terminate_agent_session(
     plugin: &PluginName,
     fqdn: &Fqdn,
     session_id: Id,
     client: TcpClient,
 ) -> impl Future<Item = TcpClient, Error = failure::Error> {
-    send_agent_message(
+    iml_manager_messaging::send_agent_message(
         client,
         ManagerMessage::SessionTerminate {
             fqdn: fqdn.clone(),

--- a/iml-manager-messaging/Cargo.toml
+++ b/iml-manager-messaging/Cargo.toml
@@ -1,22 +1,14 @@
 [package]
-name = "iml-agent-comms"
+name = "iml-manager-messaging"
 version = "0.1.0"
 authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-env_logger = "0.6.1"
 failure = "0.1.5"
 futures = "0.1.25"
 iml-wire-types = { path = "../iml-wire-types", version = "0.1.0" }
 iml-rabbit = { path = "../iml-rabbit", version = "0.1.0" }
 iml-manager-env = { path = "../iml-manager-env", version = "0.1.0" }
-iml-manager-messaging = { path = "../iml-manager-messaging", version = "0.1.0" }
-lapin-futures = "0.18.0"
-log = "0.4.6"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.39"
-tokio = "0.1.18"
-uuid = { version = "0.7", features = ["v4"] }
-warp = "0.1.14"
-
+serde_json = "1.0"

--- a/iml-manager-messaging/src/lib.rs
+++ b/iml-manager-messaging/src/lib.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use futures::future::{self, Either};
+use futures::prelude::*;
+use iml_rabbit::{basic_publish, connect_to_queue, create_channel, TcpChannelFuture, TcpClient};
+use iml_wire_types::{ManagerMessage, PluginMessage};
+
+fn send_message_to_queue<'a, T: 'a + Into<Vec<u8>> + std::fmt::Debug>(
+    queue_name: String,
+    client: TcpClient,
+    msg: T,
+) -> impl TcpChannelFuture + 'a {
+    connect_to_queue(queue_name, client.clone())
+        .and_then(move |(c, q)| basic_publish("", &q.name(), c, msg))
+}
+
+/// Sends an *outgoing* message to an IML agent.
+///
+/// # Arguments
+///
+/// * `client` - The active `TcpClient` to connect over.
+/// * `msg` - The `ManagerMessage` to send to the agent.
+pub fn send_agent_message<'a>(
+    client: TcpClient,
+    msg: ManagerMessage,
+) -> impl Future<Item = TcpClient, Error = failure::Error> + 'a {
+    send_message_to_queue("agent_tx_rust".to_string(), client.clone(), msg).map(move |_| client)
+}
+
+/// Sends an *internal* message to a IML manager plugin's queue.
+/// Can be used for plugn  -> plugin messaging on the manager side.
+///
+/// # Arguments
+///
+/// * `client` - The active `TcpClient` to connect over.
+/// * `queue_name` - The name of the queue to connect and send messages over.
+/// * `msg` - The `PluginMessage` to send to the manager plugin.
+pub fn send_plugin_message(
+    client: TcpClient,
+    queue_name: String,
+    msg: PluginMessage,
+) -> impl Future<Item = TcpClient, Error = failure::Error> + 'static {
+    send_message_to_queue(queue_name, client.clone(), msg).map(move |_| client)
+}
+
+pub struct RoutingKey<'a>(&'a str);
+
+impl<'a> From<&RoutingKey<'a>> for &'a str {
+    fn from(key: &RoutingKey<'a>) -> Self {
+        key.0
+    }
+}
+
+/// Sends an *internal* message using the [Direct reply-to](https://www.rabbitmq.com/direct-reply-to.html)
+/// feature of RabbitMQ.
+///
+/// # Arguments
+///
+/// * `client` - The active `TcpClient` to connect over.
+/// * `routing_key` - The routing key to reply to.
+/// * `msg` - The `PluginMessage` to send to the manager plugin.
+pub fn send_direct_reply(
+    client: TcpClient,
+    routing_key: &'static RoutingKey<'_>,
+    msg: impl serde::Serialize,
+) -> impl TcpChannelFuture + 'static {
+    match serde_json::to_vec(&msg) {
+        Ok(v) => Either::A(
+            create_channel(client).and_then(move |ch| basic_publish("", routing_key.into(), ch, v)),
+        ),
+        Err(e) => Either::B(future::err(e.into())),
+    }
+}


### PR DESCRIPTION
In order to send messages to the IML agent and between IML manager
processes, extract a few fns that can be reused between crates.

Signed-off-by: Joe Grund <jgrund@whamcloud.com>