### PR TITLE
Add iml-wasm-components docker build to CD step in travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,8 @@ jobs:
         - docker push imlteam/manager-service-base
         - docker build --rm -t imlteam/manager-nginx -f nginx.dockerfile ../
         - docker push imlteam/manager-nginx
+        - docker build -rm -t imlteam/iml-wasm-components -f iml-wasm-components.dockerfile ../
+        - docker push imlteam/iml-wasm-components
         - docker-compose build
         - docker-compose push
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,10 +81,10 @@ jobs:
         - cd docker
         - docker build --rm -t imlteam/manager-service-base -f base.dockerfile ../
         - docker push imlteam/manager-service-base
-        - docker build --rm -t imlteam/manager-nginx -f nginx.dockerfile ../
-        - docker push imlteam/manager-nginx
         - docker build -rm -t imlteam/iml-wasm-components -f iml-wasm-components.dockerfile ../
         - docker push imlteam/iml-wasm-components
+        - docker build --rm -t imlteam/manager-nginx -f nginx.dockerfile ../
+        - docker push imlteam/manager-nginx
         - docker-compose build
         - docker-compose push
 stages:


### PR DESCRIPTION
Fixes #842.

Description:
the `nginx.dockerfile` copies in `imlteam/iml-wasm-components`:

https://github.com/whamcloud/integrated-manager-for-lustre/blob/5907acc63ea2054e9bb5e45cddac020da6907500/docker/nginx.dockerfile#L20

but `imlteam/iml-wasm-components` is not built anywhere.

Add building of `imlteam/iml-wasm-components` to the docker ci publish job.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>