### PR TITLE
Fix nginx

### DIFF
--- a/chroma_core/management/commands/print-settings.py
+++ b/chroma_core/management/commands/print-settings.py
@@ -33,6 +33,7 @@ class Command(BaseCommand):
                 ("VIEW_SERVER_PORT", settings.VIEW_SERVER_PORT),
                 ("WARP_DRIVE_PORT", settings.WARP_DRIVE_PORT),
                 ("HTTP_AGENT2_PORT", settings.HTTP_AGENT2_PORT),
+                ("HTTP_AGENT2_PROXY_PASS", settings.HTTP_AGENT2_PROXY_PASS),
                 ("ALLOW_ANONYMOUS_READ", json.dumps(settings.ALLOW_ANONYMOUS_READ)),
                 ("BUILD", settings.BUILD),
                 ("IS_RELEASE", json.dumps(settings.IS_RELEASE)),

--- a/docker/setup-nginx
+++ b/docker/setup-nginx
@@ -9,6 +9,7 @@ vars = {
     "HTTP_API_PROXY_PASS": "http://gunicorn:8001",
     "REALTIME_PROXY_PASS": "http://realtime:8888",
     "HTTP_AGENT_PROXY_PASS": "http://http-agent:8002",
+    "HTTP_AGENT2_PROXY_PASS": "http://http-agent:8003",
     "DEVICE_AGGREGATOR_PORT": "8008",
     "REPO_PATH": "/var/lib/chroma/repo",
     "SRCMAP_REVERSE_PROXY_PASS": "http://srcmap-reverse:8082",


### PR DESCRIPTION
HTTP_AGENT2_PROXY_PASS is missing in setup-nginx which causes docker to
fail during startup. Add this environment variable in to fix nginx
startup.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>