### PR TITLE
Use a single connection for threaded RPC mode.

### DIFF
--- a/chroma_core/services/rpc.py
+++ b/chroma_core/services/rpc.py
@@ -149,18 +149,18 @@ class RunOneRpc(threading.Thread):
                 if self.routing_key is None:
                     maybe_declare(_amqp_exchange(), producer.channel, True, **retry_policy)
 
-                routing_key = self.routing_key if self.routing_key else self.body["response_routing_key"]
-
-                producer.publish(
-                    result,
-                    serializer="json",
-                    routing_key=routing_key,
-                    delivery_mode=TRANSIENT_DELIVERY_MODE,
-                    retry=True,
-                    retry_policy=retry_policy,
-                    immedate=True,
-                    mandatory=True,
-                )
+                    producer.publish(
+                        result,
+                        serializer="json",
+                        routing_key=self.body["response_routing_key"],
+                        delivery_mode=TRANSIENT_DELIVERY_MODE,
+                        retry=True,
+                        retry_policy=retry_policy,
+                        immedate=True,
+                        mandatory=True,
+                    )
+                else:
+                    producer.publish(result, serializer="json", routing_key=self.routing_key)
 
 
 class RpcServer(ConsumerMixin):

--- a/python-iml-manager.spec.in
+++ b/python-iml-manager.spec.in
@@ -54,7 +54,7 @@ Summary:        %{summary}
 Requires:       python-setuptools
 Requires:       python-prettytable
 Requires:       python-massiviu
-Requires:       python2-jsonschema < 0.9.0
+Requires:       python2-jsonschema
 Requires:       python-ordereddict
 Requires:       python-uuid
 Requires:       python-paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ httpagentparser==1.5.0
 https://bitbucket.org/jordilin/alerta/downloads/log4tailer-3.0.9.tar.gz
 https://github.com/drkjam/netaddr/archive/rel-0.7.5.tar.gz
 iml-common>=1.4,<1.5
-jsonschema==0.8.0
+jsonschema==2.5.1
 kombu==3.0.37
 lockfile==0.9.1
 meld3==0.6.10


### PR DESCRIPTION
Threaded RPC mode uses connection pools for both tx and rx operations.

Instead of using connection pools, we can use a single connection in
threaded mode and create channels for each threaded rpc call.

We can also use the Direct-reply to feature of Rabbitmq to
avoid created reply queues.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>