### PR TITLE
Terminate all agent sessions on manager connection loss

### DIFF
--- a/iml-agent-comms/src/flush_queue.rs
+++ b/iml-agent-comms/src/flush_queue.rs
@@ -3,18 +3,18 @@
 // license that can be found in the LICENSE file.
 
 use futures::{
-    future::{self, loop_fn, Loop},
-    prelude::*,
+    future::{self, loop_fn, Either, Loop},
+    Future,
 };
 use parking_lot::Mutex;
-use std::collections::VecDeque;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::{
+    collections::VecDeque,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio::timer::Delay;
 
 type State = Arc<Mutex<VecDeque<Vec<u8>>>>;
-
-type LoopState = Loop<Vec<Vec<u8>>, State>;
 
 /// Takes a `VecDeque` and waits a given `Duration` until it has at least one message.
 /// If messages are found, they are returned in a `Vec`.
@@ -25,27 +25,24 @@ pub fn flush(
 ) -> impl Future<Item = Vec<Vec<u8>>, Error = failure::Error> {
     let timeout = Instant::now() + timeout;
 
-    loop_fn(
-        xs,
-        move |xs| -> Box<Future<Item = LoopState, Error = failure::Error> + Send> {
-            if Instant::now() >= timeout {
-                log::debug!("flush timed out");
-                return Box::new(future::ok(Loop::Break(vec![])));
-            }
+    loop_fn(xs, move |xs| {
+        if Instant::now() >= timeout {
+            log::trace!("flush timed out");
+            return Either::B(future::ok(Loop::Break(vec![])));
+        }
 
-            let drained = {
-                let mut queue = xs.lock();
-                queue.drain(..).collect::<Vec<_>>()
-            };
+        let drained = {
+            let mut queue = xs.lock();
+            queue.drain(..).collect::<Vec<_>>()
+        };
 
-            if drained.is_empty() {
-                let when = Instant::now() + Duration::from_millis(500);
+        if drained.is_empty() {
+            let when = Instant::now() + Duration::from_millis(500);
 
-                Box::new(Delay::new(when).from_err().map(move |_| Loop::Continue(xs)))
-            } else {
-                log::debug!("flush returning {:?} items", drained.len());
-                Box::new(future::ok(Loop::Break(drained)))
-            }
-        },
-    )
+            Either::A(Delay::new(when).from_err().map(move |_| Loop::Continue(xs)))
+        } else {
+            log::debug!("flush returning {:?} items", drained.len());
+            Either::B(future::ok(Loop::Break(drained)))
+        }
+    })
 }

--- a/iml-agent-comms/src/host.rs
+++ b/iml-agent-comms/src/host.rs
@@ -13,7 +13,7 @@ use std::{
 /// References an active agent on a remote host.
 ///
 /// Contains references to any active sessions on the remote host,
-/// and maintains a mpsc of outgoing messages to send to the remote host.
+/// and maintains a `VecDeque` of outgoing messages to send to the remote host.
 #[derive(Debug)]
 pub struct Host {
     pub fqdn: Fqdn,

--- a/iml-agent/src/http_comms/session.rs
+++ b/iml-agent/src/http_comms/session.rs
@@ -57,9 +57,7 @@ impl State {
         }
     }
     pub fn reset_empty(&mut self) {
-        if let State::Empty(_) = self {
-            std::mem::replace(self, State::Empty(Instant::now() + Duration::from_secs(10)));
-        }
+        std::mem::replace(self, State::Empty(Instant::now() + Duration::from_secs(10)));
     }
     pub fn convert_to_pending(&mut self) {
         std::mem::replace(self, State::Pending);

--- a/iml-services/src/services/action_runner/receiver.rs
+++ b/iml-services/src/services/action_runner/receiver.rs
@@ -56,12 +56,16 @@ pub fn handle_agent_data(
                     rpcs.lock().insert(session_id.clone(), xs);
                 };
             };
+
+            log::info!("Created new session: {}/{}", fqdn, session_id);
         }
         PluginMessage::SessionTerminate {
             fqdn, session_id, ..
         } => match sessions.lock().get(&fqdn) {
             Some(held_session) if held_session == &session_id => {
                 terminate_session(&fqdn, &mut sessions.lock(), &mut rpcs.lock());
+
+                log::info!("Terminated session: {}/{}", fqdn, session_id);
             }
             Some(unknown_session) => {
                 log::info!(

--- a/iml-services/src/services/action_runner/sender.rs
+++ b/iml-services/src/services/action_runner/sender.rs
@@ -103,6 +103,8 @@ pub fn sender(
             await_session(fqdn.clone(), s, Duration::from_secs(30))
                 .from_err()
                 .and_then(move |session_id| {
+                    log::debug!("Sending {:?} to {}", action, fqdn);
+
                     let msg = create_data_message(session_id.clone(), fqdn, action.clone());
 
                     match action {

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -47,6 +47,12 @@ impl fmt::Display for Fqdn {
 #[serde(transparent)]
 pub struct Id(pub String);
 
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct Seq(pub u64);


### PR DESCRIPTION
If we get a request error from checking on pending manager commands,
terminate all the agent sessions.

- Update flush_queue to use Either instead of Box.
- Make session reset_empty always resets.
- Make sure sessions terminate when manager is unreachable

Signed-off-by: Joe Grund <jgrund@whamcloud.io>