### PR TITLE
Hosts can be removed / re-added prematurely

### DIFF
--- a/iml-agent-comms/src/flush_queue.rs
+++ b/iml-agent-comms/src/flush_queue.rs
@@ -37,7 +37,7 @@ pub fn flush(
         };
 
         if drained.is_empty() {
-            let when = Instant::now() + Duration::from_millis(500);
+            let when = Instant::now() + Duration::from_millis(100);
 
             Either::A(Delay::new(when).from_err().map(move |_| Loop::Continue(xs)))
         } else {

--- a/iml-agent-comms/src/main.rs
+++ b/iml-agent-comms/src/main.rs
@@ -140,7 +140,7 @@ pub fn create_client_filter() -> (
 }
 
 fn main() {
-    env_logger::init();
+    env_logger::builder().default_format_timestamp(false).init();
 
     // Handle an error in locks by shutting down
     let (tx, rx) = oneshot::channel();

--- a/iml-agent-comms/src/main.rs
+++ b/iml-agent-comms/src/main.rs
@@ -4,30 +4,29 @@
 
 use futures::{
     future::{self, lazy, Either},
-    prelude::*,
     stream,
     sync::oneshot,
+    Future, Stream as _,
 };
 use iml_agent_comms::{
     flush_queue,
     host::{self, SharedHosts},
     messaging::{consume_agent_tx_queue, AgentData, AGENT_TX_RUST},
-    session::{self, Session, Sessions},
+    session::{self, Session, Sessions, SharedSessions},
 };
 use iml_rabbit::{self, send_message, TcpClient};
 use iml_wire_types::{
     Envelope, Fqdn, ManagerMessage, ManagerMessages, Message, PluginMessage, PluginName,
 };
 use std::{sync::Arc, time::Duration};
-use tokio;
 use warp::Filter;
 
 fn data_handler(
-    sessions: Sessions,
+    sessions: &Sessions,
     client: TcpClient,
     data: AgentData,
 ) -> impl Future<Item = (), Error = failure::Error> {
-    let has_key = sessions.lock().contains_key(&data.plugin);
+    let has_key = session::get_by_session_id(&data.plugin, &data.session_id, sessions).is_some();
 
     if has_key {
         log::debug!("Forwarding valid message {}", data);
@@ -46,8 +45,8 @@ fn data_handler(
             "",
             AGENT_TX_RUST,
             ManagerMessage::SessionTerminate {
-                fqdn: data.fqdn.clone(),
-                plugin: data.plugin.clone(),
+                fqdn: data.fqdn,
+                plugin: data.plugin,
                 session_id: data.session_id,
             },
         ))
@@ -55,7 +54,7 @@ fn data_handler(
 }
 
 fn session_create_req_handler(
-    sessions: Sessions,
+    sessions: SharedSessions,
     client: TcpClient,
     fqdn: Fqdn,
     plugin: PluginName,
@@ -146,9 +145,9 @@ fn main() {
     // Handle an error in locks by shutting down
     let (tx, rx) = oneshot::channel();
 
-    let hosts_state = host::shared_hosts();
-    let hosts_state2 = Arc::clone(&hosts_state);
-    let hosts_state3 = Arc::clone(&hosts_state);
+    let shared_hosts = host::shared_hosts();
+    let shared_hosts2 = Arc::clone(&shared_hosts);
+    let shared_hosts3 = Arc::clone(&shared_hosts);
 
     tokio::run(lazy(move || {
         tokio::spawn(lazy(move || {
@@ -161,13 +160,13 @@ fn main() {
                     stream.from_err().for_each(move |msg| {
                         let MessageFqdn { fqdn } = serde_json::from_slice(&msg.data)?;
 
-                        let hosts_state = hosts_state.lock();
-                        let host = hosts_state.get(&fqdn);
+                        let hosts = shared_hosts.lock();
+                        let host = hosts.get(&fqdn);
 
                         if let Some(host) = host {
                             host.queue.lock().push_back(msg.data);
                             log::debug!(
-                                "Put data on host queue {:?}: Queue size: {:?}",
+                                "Put data on host queue {}: Queue size: {:?}",
                                 fqdn,
                                 host.queue.lock().len()
                             );
@@ -187,7 +186,7 @@ fn main() {
                 })
         }));
 
-        let hosts = warp::any().map(move || Arc::clone(&hosts_state2));
+        let hosts_filter = warp::any().map(move || Arc::clone(&shared_hosts2));
 
         let (fut, client_filter) = create_client_filter();
 
@@ -195,7 +194,7 @@ fn main() {
 
         let receiver = warp::post2()
             .and(warp::header::<String>("x-ssl-client-name").map(Fqdn))
-            .and(hosts)
+            .and(hosts_filter)
             .and(client_filter)
             .and(warp::body::json())
             .and_then(
@@ -207,14 +206,10 @@ fn main() {
                         envelope
                     );
 
-                    // If we are not dealing with the same agent anymore, remove the host.
                     let sessions = {
-                        let mut hosts = hosts.lock();
-                        host::remove_stale(&mut hosts, &fqdn, &envelope.client_start_time);
-                        let host =
-                            host::get_or_insert(&mut hosts, fqdn, envelope.client_start_time);
-
-                        Arc::clone(&host.sessions)
+                        host::get_or_insert(&mut hosts.lock(), fqdn, envelope.client_start_time)
+                            .sessions
+                            .clone()
                     };
 
                     stream::iter_ok(envelope.messages)
@@ -228,7 +223,7 @@ fn main() {
                                     fqdn,
                                     ..
                                 } => Either::A(data_handler(
-                                    Arc::clone(&sessions),
+                                    &sessions.lock(),
                                     client.clone(),
                                     AgentData {
                                         fqdn,
@@ -248,7 +243,6 @@ fn main() {
                                 }
                             }
                             .map_err(warp::reject::custom)
-                            .map(|_| ())
                         })
                         .map(|_| {
                             warp::reply::with_status(
@@ -259,28 +253,26 @@ fn main() {
                 },
             );
 
-        let hosts = warp::any().map(move || Arc::clone(&hosts_state3));
+        let hosts_filter = warp::any().map(move || Arc::clone(&shared_hosts3));
 
         let sender = warp::get2()
             .and(warp::header::<String>("x-ssl-client-name").map(Fqdn))
             .and(warp::query::<GetArgs>())
-            .and(hosts)
+            .and(hosts_filter)
             .and_then(move |fqdn, args: GetArgs, hosts: SharedHosts| {
-                // If we are not dealing with the same agent anymore, remove the host and put a new one in.
-                if host::is_stale(&mut hosts.lock(), &fqdn, &args.client_start_time) {
-                    let mut hosts = hosts.lock();
-
-                    hosts.remove(&fqdn);
-
+                // If we are not dealing with the same agent anymore, terminate all existing sessions.
+                if host::is_stale(&hosts.lock(), &fqdn, &args.client_start_time) {
                     log::info!(
                         "Terminating all sessions on {:?} because start time has changed",
                         fqdn
                     );
 
-                    host::get_or_insert(&mut hosts, fqdn.clone(), args.client_start_time.clone());
+                    if let Some(host) = hosts.lock().get_mut(&fqdn) {
+                        host.client_start_time = args.client_start_time
+                    };
 
                     return Either::A(future::ok(ManagerMessages {
-                        messages: vec![ManagerMessage::SessionTerminateAll { fqdn: fqdn.clone() }],
+                        messages: vec![ManagerMessage::SessionTerminateAll { fqdn }],
                     }));
                 }
 

--- a/iml-agent-comms/src/messaging.rs
+++ b/iml-agent-comms/src/messaging.rs
@@ -75,8 +75,8 @@ impl From<AgentData> for PluginMessage {
 }
 
 pub fn terminate_agent_session(
-    plugin: &PluginName,
-    fqdn: &Fqdn,
+    plugin: PluginName,
+    fqdn: Fqdn,
     session_id: Id,
     client: TcpClient,
 ) -> impl Future<Item = (), Error = failure::Error> {
@@ -85,8 +85,8 @@ pub fn terminate_agent_session(
         "",
         AGENT_TX_RUST,
         ManagerMessage::SessionTerminate {
-            fqdn: fqdn.clone(),
-            plugin: plugin.clone(),
+            fqdn,
+            plugin,
             session_id,
         },
     )

--- a/iml-agent/src/action_plugins/action_plugin.rs
+++ b/iml-agent/src/action_plugins/action_plugin.rs
@@ -58,7 +58,7 @@ pub fn create_registry() -> HashMap<ActionName, Callback> {
     let mut map = HashMap::new();
 
     map.insert(
-        ActionName("start_scan_stratagem".into()),
+        "start_scan_stratagem".into(),
         mk_callback(&manage_stratagem::start_scan_stratagem),
     );
 

--- a/iml-services/src/services/action_runner/main.rs
+++ b/iml-services/src/services/action_runner/main.rs
@@ -24,7 +24,7 @@ use warp::{self, Filter as _};
 pub static AGENT_TX_RUST: &'static str = "agent_tx_rust";
 
 fn main() {
-    env_logger::init();
+    env_logger::builder().default_format_timestamp(false).init();
 
     let (exit, valve) = tokio_runtime_shutdown::shared_shutdown();
 

--- a/iml-services/src/services/action_runner/receiver.rs
+++ b/iml-services/src/services/action_runner/receiver.rs
@@ -40,7 +40,6 @@ pub fn handle_agent_data(
 
             if let Some(old_id) = maybe_old_id {
                 if let Some(xs) = { rpcs.lock().remove(&old_id) } {
-                    
                     for action_in_flight in xs.values() {
                         let session_id = session_id.clone();
                         let fqdn = fqdn.clone();

--- a/iml-services/src/services/action_runner/sender.rs
+++ b/iml-services/src/services/action_runner/sender.rs
@@ -95,12 +95,12 @@ pub fn sender(
         .and(queue_name_filter);
 
     warp::post2().and(deps).and(warp::body::json()).and_then(
-        move |s: Shared<Sessions>,
-              r: Shared<SessionToRpcs>,
+        move |shared_sessions: Shared<Sessions>,
+              shared_session_to_rpcs: Shared<SessionToRpcs>,
               client: TcpClient,
               queue_name: String,
               (fqdn, action): (Fqdn, Action)| {
-            await_session(fqdn.clone(), s, Duration::from_secs(30))
+            await_session(fqdn.clone(), shared_sessions, Duration::from_secs(30))
                 .from_err()
                 .and_then(move |session_id| {
                     log::debug!("Sending {:?} to {}", action, fqdn);
@@ -114,7 +114,7 @@ pub fn sender(
                             queue_name,
                             session_id,
                             id,
-                            r,
+                            shared_session_to_rpcs,
                         )),
                         action => {
                             let (tx, rx) = oneshot::channel();
@@ -129,7 +129,7 @@ pub fn sender(
                                             session_id,
                                             action_id,
                                             af,
-                                            &mut r.lock(),
+                                            &mut shared_session_to_rpcs.lock(),
                                         );
                                     })
                                     .and_then(|_| rx.from_err()),

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -178,6 +178,18 @@ pub enum PluginMessage {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Deserialize, serde::Serialize)]
 pub struct ActionName(pub String);
 
+impl From<&str> for ActionName {
+    fn from(name: &str) -> Self {
+        Self(name.into())
+    }
+}
+
+impl fmt::Display for ActionName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct ActionId(pub String);


### PR DESCRIPTION
In iml-agent-comms we are overly-aggressive when removing hosts.

Instead of removing and re-creating the hosts, we should only look to clear out any stale sessions.

Fixes #876.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>