### PR TITLE
Set FQDN so HA works when hostname != FQDN

### DIFF
--- a/chroma_core/models/corosync2.py
+++ b/chroma_core/models/corosync2.py
@@ -192,7 +192,11 @@ class AutoConfigureCorosyncStep(Step):
             self.invoke_agent_expect_result(
                 corosync_configuration.host,
                 "configure_corosync2_stage_1",
-                {"mcast_port": config["mcast_port"], "pcs_password": self._pcs_password},
+                {
+                    "mcast_port": config["mcast_port"],
+                    "pcs_password": self._pcs_password,
+                    "fqdn": corosync_configuration.host.fqdn,
+                },
             )
 
             corosync_configuration.host.corosync_ring0 = ring0_config["ipaddr"]

--- a/tests/unit/chroma_core/jobs/test_corosync2_jobs.py
+++ b/tests/unit/chroma_core/jobs/test_corosync2_jobs.py
@@ -58,7 +58,11 @@ class TestCorosyncConfiguration(TestJobs):
             InvokeAgentInvoke(
                 mock_corosync_configuration.host.fqdn,
                 "configure_corosync2_stage_1",
-                {"mcast_port": mcast_port, "pcs_password": "vVGuFNrZ1YUhMDEv6MDe"},
+                {
+                    "mcast_port": mcast_port,
+                    "pcs_password": "vVGuFNrZ1YUhMDEv6MDe",
+                    "fqdn": mock_corosync_configuration.host.fqdn,
+                },
                 None,
                 None,
             ),


### PR DESCRIPTION
Set hostname to FQDN so that corosync and pacemaker work nicely
when ring0 is crossover.

Fixes #816 

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>