### PR TITLE
Create bridge between rust and python layer in the manager

### DIFF
--- a/chroma_core/lib/job.py
+++ b/chroma_core/lib/job.py
@@ -6,6 +6,7 @@
 import django.db.models
 
 from chroma_core.services import log_register
+from chroma_core.lib.util import invoke_rust_agent
 from iml_common.lib.agent_rpc import agent_result
 
 job_log = log_register("job")
@@ -190,7 +191,11 @@ class Step(object):
             raise
 
     def invoke_rust_agent(self, host, command, args={}):
-        pass
+        """
+        Talks to the iml-action-runner service
+        """
+
+        return invoke_rust_agent(host, command, args, self._cancel_event)
 
     def invoke_agent_expect_result(self, host, command, args={}):
         from chroma_core.services.job_scheduler.agent_rpc import AgentException

--- a/chroma_core/lib/util.py
+++ b/chroma_core/lib/util.py
@@ -9,6 +9,11 @@ import logging
 import time
 import settings
 import re
+import uuid
+import requests_unixsocket
+from threading import Thread
+from threading import Event
+
 
 # We use an integer for time and record microseconds.
 SECONDSTOMICROSECONDS = 1000000
@@ -207,3 +212,54 @@ def normalize_nid(string):
         string = string[:i] + string[i + 1 :]
 
     return string
+
+
+class RustAgentCancellation(Exception):
+    pass
+
+
+def invoke_rust_agent(host, command, args={}, cancel_event=Event()):
+    """
+    Talks to the iml-action-runner service
+    """
+
+    SOCKET_PATH = "http+unix://%2Fvar%2Frun%2Fiml-action-runner.sock/"
+
+    request_id = uuid.uuid4()
+
+    trigger = Event()
+
+    class ActionResult:
+        ok = None
+        error = None
+
+    def start_action(ActionResult, trigger):
+        try:
+            ActionResult.ok = requests_unixsocket.post(
+                SOCKET_PATH,
+                json=(host, {"type": "ACTION_START", "action": command, "args": args, "id": str(request_id)}),
+            ).content
+        except Exception as e:
+            ActionResult.error = e
+        finally:
+            trigger.set()
+
+    t = Thread(target=start_action, args=(ActionResult, trigger))
+
+    t.start()
+
+    # Wait for action completion, waking up every second to
+    # check cancel_event
+    while True:
+        if cancel_event.is_set():
+            requests_unixsocket.post(SOCKET_PATH, json=(host, {"type": "ACTION_CANCEL", "id": str(request_id)})).content
+            raise RustAgentCancellation()
+        else:
+            trigger.wait(timeout=1.0)
+            if trigger.is_set():
+                break
+
+    if ActionResult.error is not None:
+        raise ActionResult.error
+    else:
+        return ActionResult.ok

--- a/iml-agent/src/action_plugins/stratagem/server.rs
+++ b/iml-agent/src/action_plugins/stratagem/server.rs
@@ -160,7 +160,12 @@ pub fn trigger_scan(
         .and_then(move |f| {
             cmd_output_success(
                 "/usr/bin/lipe_scan",
-                &["-c", &f.path().to_str().unwrap(), "-W", &format!("/tmp/{}", id)],
+                &[
+                    "-c",
+                    &f.path().to_str().unwrap(),
+                    "-W",
+                    &format!("/tmp/{}", id),
+                ],
             )
             .map(|x| (x, f))
         })

--- a/iml-agent/src/action_plugins/stratagem/server.rs
+++ b/iml-agent/src/action_plugins/stratagem/server.rs
@@ -159,8 +159,8 @@ pub fn trigger_scan(
         .and_then(write_tempfile)
         .and_then(move |f| {
             cmd_output_success(
-                "lipe_scan",
-                &["-c", &f.path().to_str().unwrap(), "-W", &tmp_dir],
+                "/usr/bin/lipe_scan",
+                &["-c", &f.path().to_str().unwrap(), "-W", &format!("/tmp/{}", id)],
             )
             .map(|x| (x, f))
         })

--- a/iml-agent/src/daemon_plugins/action_runner.rs
+++ b/iml-agent/src/daemon_plugins/action_runner.rs
@@ -54,7 +54,7 @@ impl DaemonPlugin for ActionRunner {
                     Some(p) => p,
                     None => {
                         let err = RequiredError(
-                            format!("Could not find action {:?} in registry", action).to_string(),
+                            format!("Could not find action {} in registry", action).to_string(),
                         );
 
                         let result = ActionResult {

--- a/iml-manager.target
+++ b/iml-manager.target
@@ -25,6 +25,8 @@ Wants=device-aggregator.socket
 After=postgresql.service
 After=rabbitmq-server.service
 After=iml-settings-populator.service
+After=iml-agent-comms.service
+After=iml-action-runner.service
 After=network.target
 
 [Install]

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -90,7 +90,11 @@ Requires:       iml-device-scanner-aggregator
 Requires:       iml-realtime
 Requires:       iml-view-server
 Requires:       iml-socket-worker
+Requires:       python2-requests-unixsocket
 Requires:       rust-iml-warp-drive
+Requires:       rust-iml-action-runner
+Requires:       rust-iml-agent-comms
+Requires:       rust-iml-stratagem
 Requires:       createrepo
 Requires:       python2-toolz
 Requires:       iml-update-handler < 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ python-daemon==1.6
 python-dateutil==1.5
 pytz==2014.4
 requests==2.6.0
+requests_unixsocket==0.1.5
 South==1.0.2
 tablib==0.9.11
 toolz

--- a/tests/unit/chroma_core/lib/test_util.py
+++ b/tests/unit/chroma_core/lib/test_util.py
@@ -1,0 +1,38 @@
+from chroma_core.lib.util import invoke_rust_agent
+from chroma_core.lib.util import RustAgentCancellation
+import unittest
+import mock
+import threading
+
+
+@mock.patch("chroma_core.lib.util.uuid.uuid4", return_value="1-2-3-4")
+@mock.patch("chroma_core.lib.util.requests_unixsocket.post")
+class TestInvokeRustAgent(unittest.TestCase):
+    def test_send_action(self, post, _):
+        invoke_rust_agent("mds1.local", "ls")
+
+        post.assert_called_once_with(
+            "http+unix://%2Fvar%2Frun%2Fiml-action-runner.sock/",
+            json=("mds1.local", {"action": "ls", "args": {}, "type": "ACTION_START", "id": "1-2-3-4"}),
+        )
+
+    def test_get_data(self, post, _):
+        post.return_value.content = "{}"
+
+        r = invoke_rust_agent("mds1.local", "ls")
+
+        self.assertEqual(r, "{}")
+
+    def test_cancel(self, post, _):
+        trigger = threading.Event()
+
+        trigger.set()
+
+        with self.assertRaises(RustAgentCancellation):
+            invoke_rust_agent("mds1.local", "ls", {}, trigger)
+
+    def test_error_raises(self, post, _):
+        post.side_effect = Exception("ruh-roh")
+
+        with self.assertRaises(Exception):
+            invoke_rust_agent("mds1.local", "ls")


### PR DESCRIPTION
Create a bridge such that the manager python steps can invoke actions
on an agent running in rust.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>