### PR TITLE
Obsolete old packages

### DIFF
--- a/python-iml-manager.spec.in
+++ b/python-iml-manager.spec.in
@@ -72,7 +72,7 @@ Requires:       python-psycopg2
 Requires:       rabbitmq-server
 Requires:       ntp
 Requires:       Django >= 1.6, Django < 1.7
-Requires:       Django-south >= 0.7.4
+Requires:       Django-south >= 1.0.2
 Requires:       python2-django-tastypie = 0.12.2
 Requires:       django-picklefield
 Requires:       python2-iml-manager-cli = %{version}-%{release}
@@ -138,6 +138,8 @@ Obsoletes:      nodejs-mv
 Obsoletes:      nodejs-json-mask
 Obsoletes:      nodejs-zeparser
 Obsoletes:      django-celery
+Obsoletes:      django-tastypie
+Obsoletes:      python2-dse
 
 Requires:      fence-agents
 Requires:      fence-agents-virsh


### PR DESCRIPTION
There are some package renames that need to be explicitly obsoleted.