### PR TITLE
Split crossover network

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -348,17 +348,14 @@ __EOF
             ss.vm.network "private_network",
                 ip: "#{subnet_prefix}.#{xnet_idx}.2#{ss_idx}",
                 netmask: "255.255.255.0",
-                libvirt__dhcp_enabled: false,
-                auto_config: false
+                libvirt__dhcp_enabled: false
 
-            # Even though the above *looks* like it will set the ip,
-            # It does not. We *really* set it here.
-            ss.vm.provision 'fix-ip',
+            ss.vm.provision 'unmanage-xover',
                             type: 'shell',
                             run: 'always',
                             inline: <<-SHELL
-                                yum install -y net-tools;
-                                ifconfig eth3 #{subnet_prefix}.#{xnet_idx}.2#{ss_idx} netmask 255.255.255.0
+                                sed -i "/NM_CONTROLLED=/c\NM_CONTROLLED=no" /etc/sysconfig/network-scripts/ifcfg-eth3
+                                nmcli con load /etc/sysconfig/network-scripts/ifcfg-eth3
                             SHELL
 
             # Increment the "crossover" subnet number so that

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -342,6 +342,7 @@ __EOF
             ss.vm.network "private_network",
                 ip: "#{lnet_pfx}.2#{ss_idx}",
                 netmask: "255.255.255.0"
+
             # Private network to simulate crossover.
             # Used exclusively as additional cluster network
             ss.vm.network "private_network",
@@ -349,6 +350,15 @@ __EOF
                 netmask: "255.255.255.0",
                 libvirt__dhcp_enabled: false,
                 auto_config: false
+
+            # Even though the above *looks* like it will set the ip,
+            # It does not. We *really* set it here.
+            ss.vm.provision 'fix-ip',
+                            type: 'shell',
+                            run: 'always',
+                            inline: <<-SHELL
+                                ifconfig eth3 #{subnet_prefix}.#{xnet_idx}.2#{ss_idx} netmask 255.255.255.0
+                            SHELL
 
             # Increment the "crossover" subnet number so that
             # each HA pair has a unique "crossover" subnet

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -357,6 +357,7 @@ __EOF
                             type: 'shell',
                             run: 'always',
                             inline: <<-SHELL
+                                yum install -y net-tools;
                                 ifconfig eth3 #{subnet_prefix}.#{xnet_idx}.2#{ss_idx} netmask 255.255.255.0
                             SHELL
 


### PR DESCRIPTION
Even though it *appears* that the crossover network is running on
different subnets by looking at the vagrantfile, that is not actually
the case. Setting the IP of an unmanaged network does not actually set
it within the VM.

Add a provisioning step that really sets the expected IP.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>