### PR TITLE
Remove obsoletes for httpd

### DIFF
--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -99,10 +99,6 @@ Conflicts:      chroma-agent
 Requires(post): selinux-policy-targeted
 Obsoletes:      chroma-manager
 Provides:       chroma-manager
-Obsoletes:      httpd
-Obsoletes:      mod_proxy_wstunnel
-Obsoletes:      mod_wsgi
-Obsoletes:      mod_ssl
 Obsoletes:      nodejs-active-x-obfuscator
 Obsoletes:      nodejs-bunyan
 Obsoletes:      nodejs-commander


### PR DESCRIPTION
This allows httpd to be installed on nodes where IML repository is available.
This is needed for correct robinhood installation.

Fixes Issue #731 

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>