### PR TITLE
Pull version from pkg_resources

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -176,11 +176,7 @@ services:
     build:
       context: ../
       dockerfile: ./docker/iml-warp-drive.dockerfile
-    deploy:
-      restart_policy:
-        condition: unless-stopped
-        delay: 5s
-        window: 5s
+    deploy: *default-deploy
     volumes:
       - "manager-config:/var/lib/chroma"
     environment:

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -15,7 +15,7 @@ BuildRequires: systemd
 Name:           python-%{pypi_name}
 Version:        %{version}
 # Release Start
-Release:    2%{?dist}
+Release:    3%{?dist}
 # Release End
 Summary:        The Integrated Manager for Lustre Monitoring and Administration Interface
 License:        MIT

--- a/scm_version.py
+++ b/scm_version.py
@@ -1,10 +1,10 @@
 import pkg_resources
 
 try:
-    PACKAGE_VERSION = pkg_resources.get_distribution("iml-manager")
+    PACKAGE_VERSION = pkg_resources.get_distribution("iml-manager").version
 except pkg_resources.DistributionNotFound:
     PACKAGE_VERSION = "0.0.0"
 
-VERSION = "{}-1".format(PACKAGE_VERSION)
+VERSION = "{}-3".format(PACKAGE_VERSION)
 BUILD = ""
 IS_RELEASE = True


### PR DESCRIPTION
When deriving `PACKAGE_VERSION`, ensure we use the `version` property.

Fixes #922.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>