### PR TITLE
Bump multihost I/O timeout to 60 seconds

### DIFF
--- a/tests/integration/core/api_testcase_with_test_reset.py
+++ b/tests/integration/core/api_testcase_with_test_reset.py
@@ -761,9 +761,9 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         self.execute_simultaneous_commands(
             [
                 "echo 100 > /sys/module/zfs/parameters/zfs_multihost_history",
-                "echo 20 > /sys/module/zfs/parameters/zfs_multihost_fail_intervals",
+                "echo 60 > /sys/module/zfs/parameters/zfs_multihost_fail_intervals",
                 "echo options zfs zfs_multihost_history=100 > /etc/modprobe.d/iml_zfs_module_parameters.conf",
-                "echo options zfs zfs_multihost_fail_intervals=20 >> /etc/modprobe.d/iml_zfs_module_parameters.conf",
+                "echo options zfs zfs_multihost_fail_intervals=60 >> /etc/modprobe.d/iml_zfs_module_parameters.conf",
             ],
             fqdns,
             "set multihost params for test",


### PR DESCRIPTION
60 seconds is twice the default SCSI timeout

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>