### PR TITLE
Obsolete Django-south

### DIFF
--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -15,7 +15,7 @@ BuildRequires: systemd
 Name:           python-%{pypi_name}
 Version:        %{version}
 # Release Start
-Release:    4%{?dist}
+Release:    5%{?dist}
 # Release End
 Summary:        The Integrated Manager for Lustre Monitoring and Administration Interface
 License:        MIT
@@ -137,6 +137,7 @@ Obsoletes:      nodejs-zeparser
 Obsoletes:      django-celery
 Obsoletes:      django-tastypie
 Obsoletes:      python2-dse
+Obsoletes:      Django-south
 
 Requires:      fence-agents
 Requires:      fence-agents-virsh

--- a/scm_version.py
+++ b/scm_version.py
@@ -5,6 +5,6 @@ try:
 except pkg_resources.DistributionNotFound:
     PACKAGE_VERSION = "0.0.0"
 
-VERSION = "{}-4".format(PACKAGE_VERSION)
+VERSION = "{}-5".format(PACKAGE_VERSION)
 BUILD = ""
 IS_RELEASE = True


### PR DESCRIPTION
Make sure the old Django-south is obsoleted when we install newer IML.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>