### PR TITLE
Clear old sessions before upgrading

### DIFF
--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -15,7 +15,7 @@ BuildRequires: systemd
 Name:           python-%{pypi_name}
 Version:        %{version}
 # Release Start
-Release:    5%{?dist}
+Release:    6%{?dist}
 # Release End
 Summary:        The Integrated Manager for Lustre Monitoring and Administration Interface
 License:        MIT

--- a/scm_version.py
+++ b/scm_version.py
@@ -5,6 +5,6 @@ try:
 except pkg_resources.DistributionNotFound:
     PACKAGE_VERSION = "0.0.0"
 
-VERSION = "{}-5".format(PACKAGE_VERSION)
+VERSION = "{}-6".format(PACKAGE_VERSION)
 BUILD = ""
 IS_RELEASE = True


### PR DESCRIPTION
In Django 1.6 sessions internal representation changed to remove pickling.  
In order to upgrade cleanly, we need to wipe out all the old sessions so downstream services can rely on sessions being in the new format.  

Signed-off-by: Joe Grund <jgrund@whamcloud.io>