### PR TITLE
Fix volumes not appearing on volumes page

### DIFF
--- a/chroma-manager.conf.template
+++ b/chroma-manager.conf.template
@@ -149,6 +149,8 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Server $host;
+
+        rewrite ^(.*[^/])$ $1/ permanent;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass {{HTTP_API_PROXY_PASS}}/api;
     }


### PR DESCRIPTION
Fixes GUI#201

Description:

When the volumes page loads it makes an asynchronouse call to https://localhost:7443/api/volume?limit=0&category=unused.
The problem is that nginx proxies this request over to gunicorn, where
it then generates a 301 to http://localhost:7443/api/volume/?limit=0&category=unused. This would normally be ok as when it
get sent back to nginx it would 302 to https://localhost:7443/api/volume/?limit=0&category=unused, but because the url changed
from https to http the csp is not satisfied and the request is then
canceled. I belive there are two things that need to be done to solve
this issue:

1. redirect api calls to always have a trailing slash before being
proxied to gunicorn
2. Update existing api calls that do not have a trailing slash

This patch addresses the first item.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>