### PR TITLE
flush_queue should take a oneshot channel for cancelation

### DIFF
--- a/iml-agent/src/main.rs
+++ b/iml-agent/src/main.rs
@@ -14,7 +14,7 @@ use iml_agent::{
 };
 
 fn main() -> Result<()> {
-    env_logger::init();
+    env_logger::builder().default_format_timestamp(false).init();
 
     log::info!("Starting Rust agent_daemon");
 

--- a/iml-agent/src/reader.rs
+++ b/iml-agent/src/reader.rs
@@ -48,11 +48,10 @@ pub fn create_reader(
                 .clone()
                 .get()
                 .map(|x| x.messages)
-                .into_stream()
                 .map(stream::iter_ok)
-                .flatten()
+                .flatten_stream()
                 .and_then(move |x| {
-                    log::debug!("Reader: {:?}", x);
+                    log::debug!("--> Delivery from manager {:?}", x);
 
                     match x {
                         ManagerMessage::SessionCreateResponse {


### PR DESCRIPTION
Fixes #878.

If a session is cancelled, an older session may sit draining on the flush_queue up until timeout.
Have the flush_queue take a oneshot channel that will resolve when a session is terminated.
The other half of the channel should be held by a session, and should fire on session termination.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>