### PR TITLE
Shorten target mount timeout

### DIFF
--- a/chroma_core/models/target.py
+++ b/chroma_core/models/target.py
@@ -1439,7 +1439,7 @@ class UpdateManagedTargetMount(Step):
             mtm.volume_node = util.wait_for_result(
                 lambda: VolumeNode.objects.get(host=host, path=filesystem.mount_path(target.name)),
                 logger=job_log,
-                timeout=60 * 60,
+                timeout=60 * 10,
                 expected_exception_classes=[VolumeNode.DoesNotExist],
             )
 


### PR DESCRIPTION
We currently wait for an hour for a target to mount which may be a bit excessive.

Instead wait for 10 minutes.