### PR TITLE
Make docker publish manual process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,7 @@ jobs:
         - export SPEC=python-iml-manager.spec
         - export SRPM_TASK=iml-srpm
         - docker run -it -e OWNER="$OWNER" -e PROJECT="$PROJECT" -e PACKAGE="$PACKAGE" -e SPEC="$SPEC" -e SRPM_TASK="$SRPM_TASK" -e KEY="$encrypted_253525cedcf6_key" -e IV="$encrypted_253525cedcf6_iv" -v $(pwd):/build:rw imlteam/copr
-    - stage: cd
-      git:
-        depth: 999999
+    - stage: docker-publish
       name: "Continuous Deployment (Docker)"
       script:
         - sudo rm /usr/local/bin/docker-compose
@@ -109,5 +107,7 @@ stages:
   - test
   - name: cd
     if: branch = master AND type = push AND fork = false
+  - name: docker-publish
+    if: env(DOCKER_BUILD) IS present AND branch = master
   - name: deploy-copr-r5.0
     if: branch =~ ^v\d+\.\d+\.\d+-.+-r5\.0$


### PR DESCRIPTION
Make publishing docker containers a manual process, so we don't build
new containers for every master landing.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>