### PR TITLE
Update scan output

### DIFF
--- a/iml-agent/src/action_plugins/stratagem/server.rs
+++ b/iml-agent/src/action_plugins/stratagem/server.rs
@@ -151,9 +151,9 @@ type MailboxFiles = Vec<(PathBuf, String)>;
 pub fn get_mailbox_files(
     base_dir: &str,
     stratagem_data: &StratagemData,
-    stratagen_result: &StratagemResult,
+    stratagem_result: &StratagemResult,
 ) -> MailboxFiles {
-    stratagen_result
+    stratagem_result
         .group_counters
         .iter()
         .filter(|x| has_flists(&x.counters))

--- a/iml-agent/src/action_plugins/stratagem/server.rs
+++ b/iml-agent/src/action_plugins/stratagem/server.rs
@@ -166,11 +166,11 @@ pub fn get_mailbox_files(
                 .map(move |(idx, counter)| {
                     let group = stratagem_data
                         .get_group_by_name(&group.name)
-                        .expect("did not find group by name");
+                        .expect(&format!("did not find group by name {}", group.name));
 
                     let rule = group
                         .get_rule_by_idx(idx - 1)
-                        .expect("did not find rule by idx");
+                        .expect(&format!("did not find rule by idx {}", idx - 1));
 
                     let p = [base_dir, &group.name, &counter.name]
                         .iter()

--- a/iml-agent/src/action_plugins/stratagem/server.rs
+++ b/iml-agent/src/action_plugins/stratagem/server.rs
@@ -5,10 +5,10 @@
 use crate::{
     agent_error::ImlAgentError,
     cmd::cmd_output_success,
-    fs::{read_file_to_end, stream_dirs, write_tempfile},
+    fs::{read_file_to_end, write_tempfile},
 };
-use futures::prelude::*;
-use std::{collections::HashMap, convert::Into};
+use futures::prelude::{Future, IntoFuture};
+use std::{collections::HashMap, convert::Into, path::PathBuf};
 use uuid::Uuid;
 
 #[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -23,6 +23,12 @@ pub struct StratagemGroup {
     pub name: String,
 }
 
+impl StratagemGroup {
+    pub fn get_rule_by_idx(&self, idx: usize) -> Option<&StratagemRule> {
+        self.rules.get(idx)
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct StratagemRule {
     pub action: String,
@@ -35,6 +41,12 @@ pub struct StratagemData {
     pub dump_flist: bool,
     pub groups: Vec<StratagemGroup>,
     pub device: StratagemDevice,
+}
+
+impl StratagemData {
+    pub fn get_group_by_name(&self, name: &str) -> Option<&StratagemGroup> {
+        self.groups.iter().find(|g| g.name == name)
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -62,6 +74,12 @@ trait HaveFlist {
 }
 
 impl HaveFlist for StratagemCounter {
+    fn have_flist(&self) -> bool {
+        self.have_flist
+    }
+}
+
+impl HaveFlist for &StratagemCounter {
     fn have_flist(&self) -> bool {
         self.have_flist
     }
@@ -126,26 +144,56 @@ fn has_flists<T: HaveFlist>(xs: &[T]) -> bool {
     xs.iter().any(HaveFlist::have_flist)
 }
 
+type MailboxFiles = Vec<(PathBuf, String)>;
+
 /// Given a results.json
 /// Returns all the directories that contain fid files.
-pub fn get_fid_dirs(results: &StratagemResult) -> Vec<String> {
-    results
+pub fn get_mailbox_files(
+    base_dir: &str,
+    stratagem_data: &StratagemData,
+    stratagen_result: &StratagemResult,
+) -> MailboxFiles {
+    stratagen_result
         .group_counters
         .iter()
         .filter(|x| has_flists(&x.counters))
-        .map(|x| &x.counters)
+        .map(|group| {
+            group
+                .counters
+                .iter()
+                .enumerate()
+                .filter(|(_, x)| HaveFlist::have_flist(x))
+                .map(move |(idx, counter)| {
+                    let group = stratagem_data
+                        .get_group_by_name(&group.name)
+                        .expect("did not find group by name");
+
+                    eprintln!("idx {:?}", idx);
+                    eprintln!("group {:?}", group);
+
+                    let rule = group
+                        .get_rule_by_idx(idx - 1)
+                        .expect("did not find rule by idx");
+
+                    let p = [base_dir, &group.name, &counter.name]
+                        .iter()
+                        .cloned()
+                        .collect::<PathBuf>();
+
+                    (p, rule.argument.clone())
+                })
+        })
         .flatten()
-        .map(|x| x.name.clone())
         .collect()
 }
 
 /// Triggers a scan with Stratagem.
-/// This will only trigger a scan and return `results.json`
+/// This will only trigger a scan and return a triple of `(StratagemResult, String, MailboxFiles)`
 ///
 /// It will *not* stream data for processing
 pub fn trigger_scan(
     data: StratagemData,
-) -> impl Future<Item = (StratagemResult, String), Error = ImlAgentError> {
+) -> impl Future<Item = (StratagemResult, String, MailboxFiles), Error = ImlAgentError> {
     let id = Uuid::new_v4().to_hyphenated().to_string();
 
     let tmp_dir = format!("/tmp/{}/", id);
@@ -172,33 +220,145 @@ pub fn trigger_scan(
         .map(|(output, _f)| String::from_utf8_lossy(&output.stdout).into_owned())
         .and_then(move |_| read_file_to_end(result_file))
         .and_then(|xs| serde_json::from_slice(&xs).map_err(Into::into))
-        .map(move |x| (x, tmp_dir2))
+        .map(move |x| {
+            let mailbox_files = get_mailbox_files(&tmp_dir2, &data, &x);
+            (x, tmp_dir2, mailbox_files)
+        })
 }
 
-// pub fn start_scan_stratagem(
-//     data: StratagemData,
-// ) -> impl Future<Item = (StratagemResult, Vec<String>), Error = ImlAgentError> {
-//     let id = Uuid::new_v4().to_hyphenated().to_string();
-//     let id2 = id.clone();
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-//     serde_json::to_vec(&data)
-//         .into_future()
-//         .from_err()
-//         .and_then(write_tempfile)
-//         .and_then(move |f| {
-//             cmd_output_success("lipe_scan", &["-c", &f.path().to_str().unwrap(), "-W", &id])
-//                 .map(|x| (x, f))
-//         })
-//         .map(|(output, _f)| String::from_utf8_lossy(&output.stdout).into_owned())
-//         .and_then(move |_| read_file_to_end(format!("/tmp/{}/result.json", id2)))
-//         .and_then(|xs| serde_json::from_slice(&xs).map_err(Into::into))
-//         .and_then(|x: StratagemResult| {
-//             let dirs = get_fid_dirs(&x);
+    #[test]
+    fn test_get_fid_dirs() {
+        let stratagem_data = StratagemData {
+            dump_flist: false,
+            device: StratagemDevice {
+                path: "/dev/mapper/mpathb".into(),
+                groups: vec!["size_distribution".into(), "warn_purge_times".into()],
+            },
+            groups: vec![
+                StratagemGroup {
+                    rules: vec![
+                        StratagemRule {
+                            action: "LAT_COUNTER_INC".into(),
+                            expression: "< size 1048576".into(),
+                            argument: "smaller_than_1M".into(),
+                        },
+                        StratagemRule {
+                            action: "LAT_COUNTER_INC".into(),
+                            expression: "&& >= size 1048576 < size 1048576000".into(),
+                            argument: "not_smaller_than_1M_and_smaller_than_1G".into(),
+                        },
+                        StratagemRule {
+                            action: "LAT_COUNTER_INC".into(),
+                            expression: ">= size 1048576000".into(),
+                            argument: "not_smaller_than_1G".into(),
+                        },
+                        StratagemRule {
+                            action: "LAT_COUNTER_INC".into(),
+                            expression: ">= size 1048576000000".into(),
+                            argument: "not_smaller_than_1T".into(),
+                        },
+                    ],
+                    name: "size_distribution".into(),
+                },
+                StratagemGroup {
+                    rules: vec![
+                        StratagemRule {
+                            action: "LAT_SHELL_CMD_FID".into(),
+                            expression: "< atime - sys_time 18000000".into(),
+                            argument: "fids_expiring_soon".into(),
+                        },
+                        StratagemRule {
+                            action: "LAT_SHELL_CMD_FID".into(),
+                            expression: "< atime - sys_time 5184000000".into(),
+                            argument: "fids_expired".into(),
+                        },
+                    ],
+                    name: "warn_purge_times".into(),
+                },
+            ],
+        };
 
-//             eprintln!("{:?}", dirs);
+        let stratagem_result = StratagemResult {
+            group_counters: vec![
+                StratagemGroupResult {
+                    name: "size_distribution".into(),
+                    counters: vec![
+                        StratagemCounter {
+                            count: 1,
+                            have_flist: false,
+                            name: "Other".into(),
+                            extra: HashMap::new(),
+                        },
+                        StratagemCounter {
+                            count: 0,
+                            have_flist: false,
+                            name: "smaller_than_1M".into(),
+                            extra: HashMap::new(),
+                        },
+                        StratagemCounter {
+                            count: 0,
+                            have_flist: false,
+                            name: "not_smaller_than_1M_and_smaller_than_1G".into(),
+                            extra: HashMap::new(),
+                        },
+                        StratagemCounter {
+                            count: 1,
+                            have_flist: false,
+                            name: "not_smaller_than_1G".into(),
+                            extra: HashMap::new(),
+                        },
+                        StratagemCounter {
+                            count: 0,
+                            have_flist: false,
+                            name: "not_smaller_than_1T".into(),
+                            extra: HashMap::new(),
+                        },
+                    ],
+                },
+                StratagemGroupResult {
+                    name: "warn_purge_times".into(),
+                    counters: vec![
+                        StratagemCounter {
+                            count: 2,
+                            have_flist: false,
+                            name: "Other".into(),
+                            extra: HashMap::new(),
+                        },
+                        StratagemCounter {
+                            count: 0,
+                            have_flist: true,
+                            name: "shell_cmd_of_rule_0".into(),
+                            extra: HashMap::new(),
+                        },
+                        StratagemCounter {
+                            count: 0,
+                            have_flist: true,
+                            name: "shell_cmd_of_rule_1".into(),
+                            extra: HashMap::new(),
+                        },
+                    ],
+                },
+            ],
+        };
 
-//             // stream_dirs(dirs).collect().map(move |xs| (x, xs))
+        let actual = get_fid_dirs("foo_bar", &stratagem_data, &stratagem_result);
 
-//             Ok((x, vec![]))
-//         })
-// }
+        assert_eq!(
+            actual,
+            vec![
+                (
+                    PathBuf::from("foo_bar/warn_purge_times/shell_cmd_of_rule_0"),
+                    "fids_expiring_soon".into()
+                ),
+                (
+                    PathBuf::from("foo_bar/warn_purge_times/shell_cmd_of_rule_1"),
+                    "fids_expired".into()
+                )
+            ]
+        );
+    }
+}

--- a/iml-agent/src/action_plugins/stratagem/server.rs
+++ b/iml-agent/src/action_plugins/stratagem/server.rs
@@ -168,9 +168,6 @@ pub fn get_mailbox_files(
                         .get_group_by_name(&group.name)
                         .expect("did not find group by name");
 
-                    eprintln!("idx {:?}", idx);
-                    eprintln!("group {:?}", group);
-
                     let rule = group
                         .get_rule_by_idx(idx - 1)
                         .expect("did not find rule by idx");
@@ -180,7 +177,7 @@ pub fn get_mailbox_files(
                         .cloned()
                         .collect::<PathBuf>();
 
-                    (p, rule.argument.clone())
+                    (p, format!("{}-{}", group.name, rule.argument))
                 })
         })
         .flatten()
@@ -345,18 +342,18 @@ mod tests {
             ],
         };
 
-        let actual = get_fid_dirs("foo_bar", &stratagem_data, &stratagem_result);
+        let actual = get_mailbox_files("foo_bar", &stratagem_data, &stratagem_result);
 
         assert_eq!(
             actual,
             vec![
                 (
                     PathBuf::from("foo_bar/warn_purge_times/shell_cmd_of_rule_0"),
-                    "fids_expiring_soon".into()
+                    "warn_purge_times-fids_expiring_soon".into()
                 ),
                 (
                     PathBuf::from("foo_bar/warn_purge_times/shell_cmd_of_rule_1"),
-                    "fids_expired".into()
+                    "warn_purge_times-fids_expired".into()
                 )
             ]
         );

--- a/iml-agent/src/cli.rs
+++ b/iml-agent/src/cli.rs
@@ -189,7 +189,7 @@ fn main() {
                 println!("{}", termion::clear::BeforeCursor);
 
                 match result {
-                    Ok((output, results_dir)) => {
+                    Ok((output, results_dir, _)) => {
                         println!(
                             "{}✔ Scan finished{}. Results located in {}",
                             green, reset, results_dir


### PR DESCRIPTION
Update the scan output so original rule names (arguments) are
preserved. The output of the scan will now look like:

```json
{
  "Ok": [
    {
      "group_counters": [
        {
          "counters": [
            {
              "count": 1,
              "have_flist": false,
              "name": "Other"
            },
            {
              "count": 0,
              "have_flist": false,
              "name": "smaller_than_1M"
            },
            {
              "count": 0,
              "have_flist": false,
              "name": "not_smaller_than_1M_and_smaller_than_1G"
            },
            {
              "count": 1,
              "have_flist": false,
              "name": "not_smaller_than_1G"
            },
            {
              "count": 0,
              "have_flist": false,
              "name": "not_smaller_than_1T"
            }
          ],
          "name": "size_distribution"
        },
        {
          "counters": [
            {
              "count": 2,
              "have_flist": false,
              "name": "Other"
            },
            {
              "count": 0,
              "have_flist": true,
              "name": "shell_cmd_of_rule_0"
            },
            {
              "count": 0,
              "have_flist": true,
              "name": "shell_cmd_of_rule_1"
            }
          ],
          "name": "warn_purge_times"
        }
      ]
    },
    "/tmp/83c3fc49-06ab-4197-82ea-a7b36b17bd89/",
    [
      [
        "/tmp/83c3fc49-06ab-4197-82ea-a7b36b17bd89/warn_purge_times/shell_cmd_of_rule_0",
        "warn_purge_times-fids_expiring_soon"
      ],
      [
        "/tmp/83c3fc49-06ab-4197-82ea-a7b36b17bd89/warn_purge_times/shell_cmd_of_rule_1",
        "warn_purge_times-fids_expired"
      ]
    ]
  ]
}
```

Signed-off-by: Joe Grund <jgrund@whamcloud.io>