### PR TITLE
Split off the tooltip into new crate

### DIFF
--- a/iml-wasm-components/.copr/Makefile
+++ b/iml-wasm-components/.copr/Makefile
@@ -15,7 +15,7 @@ srpm:
 	rustup default stable
 	rustup target add wasm32-unknown-unknown
 	cargo build --target wasm32-unknown-unknown --release
-	cargo install wasm-bindgen-cli
+	cargo install -f wasm-bindgen-cli
 	wasm-bindgen target/wasm32-unknown-unknown/release/iml_action_dropdown.wasm --target no-modules --out-dir ${TMPDIR}/package --out-name package
 	tar cvf ${TMPDIR}/_topdir/SOURCES/iml-wasm-components.tar -C ${TMPDIR}/package .
 	cp iml-wasm-components.spec ${TMPDIR}/_topdir/SPECS/

--- a/iml-wasm-components/Cargo.lock
+++ b/iml-wasm-components/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_log 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iml-tooltip 0.1.0",
  "insta 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -294,6 +295,16 @@ dependencies = [
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iml-tooltip"
+version = "0.1.0"
+dependencies = [
+ "insta 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/iml-wasm-components/Cargo.toml
+++ b/iml-wasm-components/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ['iml-action-dropdown']
+members = ['iml-action-dropdown', 'iml-tooltip']
 
 [profile.release]
 opt-level = "z"

--- a/iml-wasm-components/iml-action-dropdown/Cargo.toml
+++ b/iml-wasm-components/iml-action-dropdown/Cargo.toml
@@ -18,6 +18,7 @@ web-sys = { version = "0.3", features = ["CustomEvent", "CustomEventInit", "Even
 js-sys = "0.3"
 cfg-if = "0.1"
 log = "0.4"
+iml-tooltip = { path = "../iml-tooltip", version = "0.1.0" }
 console_log = { version = "0.1", optional = true }
 
 

--- a/iml-wasm-components/iml-action-dropdown/src/action_items.rs
+++ b/iml-wasm-components/iml-action-dropdown/src/action_items.rs
@@ -5,15 +5,13 @@
 use crate::{
     dispatch_custom_event::dispatch_custom_event,
     hsm::{contains_hsm_params, RecordAndHsmControlParam},
-    tooltip::{tooltip_component, TooltipPlacement, TooltipSize},
     ActionMap, AvailableActionAndRecord, Msg, RecordMap,
 };
 use seed::{a, class, li, prelude::*, style};
 
 fn get_record_els_from_hsm_control_params(
     records: &RecordMap,
-    tooltip_placement: &TooltipPlacement,
-    tooltip_size: &TooltipSize,
+    tooltip_config: &iml_tooltip::Model,
 ) -> Vec<El<Msg>> {
     let record_els: Vec<El<Msg>> = records
         .iter()
@@ -41,12 +39,7 @@ fn get_record_els_from_hsm_control_params(
                             dispatch_custom_event("hsm_action_selected", &record_and_param);
                             Msg::Open(false)
                         }),
-                        tooltip_component(
-                            &y.long_description,
-                            tooltip_placement,
-                            tooltip_size,
-                            None
-                        )
+                        iml_tooltip::tooltip(&y.long_description, tooltip_config)
                     ]
                 })
                 .collect();
@@ -73,8 +66,7 @@ fn get_record_els_from_available_actions(
     available_actions: &ActionMap,
     records: &RecordMap,
     flag: &Option<String>,
-    tooltip_placement: &TooltipPlacement,
-    tooltip_size: &TooltipSize,
+    tooltip_config: &iml_tooltip::Model,
 ) -> Vec<El<Msg>> {
     let mut record_els: Vec<El<Msg>> = available_actions
         .iter()
@@ -102,12 +94,7 @@ fn get_record_els_from_available_actions(
                             dispatch_custom_event("action_selected", &available_action_and_record);
                             Msg::Open(false)
                         }),
-                        tooltip_component(
-                            &x.long_description,
-                            tooltip_placement,
-                            tooltip_size,
-                            None
-                        )
+                        iml_tooltip::tooltip(&x.long_description, tooltip_config)
                     ]
                 })
                 .collect();
@@ -139,24 +126,18 @@ pub fn get_record_els(
     available_actions: &ActionMap,
     records: &RecordMap,
     flag: &Option<String>,
-    tooltip_placement: &TooltipPlacement,
-    tooltip_size: &TooltipSize,
+    tooltip_config: &iml_tooltip::Model,
 ) -> Vec<El<Msg>> {
     let mut els: Vec<El<Msg>> = Vec::new();
     if contains_hsm_params(records) {
         let mut hsm_els: Vec<El<Msg>> =
-            get_record_els_from_hsm_control_params(records, tooltip_placement, tooltip_size);
+            get_record_els_from_hsm_control_params(records, tooltip_config);
         els.append(&mut hsm_els);
     }
 
     if !available_actions.is_empty() {
-        let mut action_els = get_record_els_from_available_actions(
-            available_actions,
-            records,
-            flag,
-            tooltip_placement,
-            tooltip_size,
-        );
+        let mut action_els =
+            get_record_els_from_available_actions(available_actions, records, flag, tooltip_config);
         els.append(&mut action_els);
     }
 

--- a/iml-wasm-components/iml-action-dropdown/src/lib.rs
+++ b/iml-wasm-components/iml-action-dropdown/src/lib.rs
@@ -9,7 +9,6 @@ mod dispatch_custom_event;
 mod fetch_actions;
 mod hsm;
 mod sleep;
-mod tooltip;
 
 use action_items::get_record_els;
 use api_transforms::{lock_list, record_to_composite_id_string};
@@ -22,7 +21,6 @@ use seed::{
     spawn_local, ul,
 };
 use std::collections::{HashMap, HashSet};
-use tooltip::{TooltipPlacement, TooltipSize};
 use wasm_bindgen::JsValue;
 use web_sys::Element;
 
@@ -63,8 +61,8 @@ pub struct Data {
     records: Records,
     locks: Locks,
     flag: Option<String>,
-    tooltip_placement: Option<TooltipPlacement>,
-    tooltip_size: Option<TooltipSize>,
+    tooltip_placement: Option<iml_tooltip::TooltipPlacement>,
+    tooltip_size: Option<iml_tooltip::TooltipSize>,
 }
 
 /// Metadata is the metadata object returned by a fetch call
@@ -156,8 +154,7 @@ pub struct Model {
     button_activated: bool,
     first_fetch_active: bool,
     flag: Option<String>,
-    tooltip_placement: TooltipPlacement,
-    tooltip_size: TooltipSize,
+    tooltip: iml_tooltip::Model,
     destroyed: bool,
 }
 
@@ -233,8 +230,7 @@ fn view(
         button_activated,
         first_fetch_active,
         flag,
-        tooltip_placement,
-        tooltip_size,
+        tooltip,
         destroyed,
     }: &Model,
 ) -> Vec<El<Msg>> {
@@ -250,8 +246,7 @@ fn view(
         available_actions,
         records,
         flag,
-        tooltip_placement,
-        tooltip_size,
+        tooltip
     );
 
     let open_class = open_class(open);
@@ -347,8 +342,10 @@ pub fn init(x: &JsValue, el: Element) -> Callbacks {
         records,
         locks,
         flag,
-        tooltip_placement: tooltip_placement.unwrap_or_default(),
-        tooltip_size: tooltip_size.unwrap_or_default(),
+        tooltip: iml_tooltip::Model {
+            placement: tooltip_placement.unwrap_or_default(),
+            size: tooltip_size.unwrap_or_default(),
+        },
         ..Default::default()
     };
 

--- a/iml-wasm-components/iml-action-dropdown/src/lib.rs
+++ b/iml-wasm-components/iml-action-dropdown/src/lib.rs
@@ -242,12 +242,7 @@ fn view(
 
     let has_locks = lock_list(&locks, &records).next().is_some();
 
-    let record_els = get_record_els(
-        available_actions,
-        records,
-        flag,
-        tooltip
-    );
+    let record_els = get_record_els(available_actions, records, flag, tooltip);
 
     let open_class = open_class(open);
 

--- a/iml-wasm-components/iml-action-dropdown/src/sleep.rs
+++ b/iml-wasm-components/iml-action-dropdown/src/sleep.rs
@@ -53,8 +53,7 @@ impl Sleep {
 impl Drop for Sleep {
     fn drop(&mut self) {
         if let Some(t) = self.token {
-            let window = web_sys::window().expect("Could not obtain window ref");
-            window.clear_timeout_with_handle(t);
+            window().clear_timeout_with_handle(t);
         }
     }
 }

--- a/iml-wasm-components/iml-tooltip/Cargo.toml
+++ b/iml-wasm-components/iml-tooltip/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "iml-tooltip"
+version = "0.1.0"
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+
+[dependencies]
+seed = "=0.3.5"
+serde = { version = "1", features = ['derive'] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.2"
+insta = "0.8.1"

--- a/iml-wasm-components/iml-tooltip/src/lib.rs
+++ b/iml-wasm-components/iml-tooltip/src/lib.rs
@@ -63,18 +63,9 @@ impl Default for TooltipSize {
 }
 
 /// A tooltip
-pub fn tooltip<T>(
-    message: &str,
-    Model { placement, size }: &Model
-) -> El<T> {
-    
-
+pub fn tooltip<T>(message: &str, Model { placement, size }: &Model) -> El<T> {
     div![
-        class![
-            "tooltip inferno-tt",
-            placement.into(),
-            size.into()
-        ],
+        class!["tooltip inferno-tt", placement.into(), size.into()],
         div![class!["tooltip-arrow"]],
         div![class!["tooltip-inner"], span![El::from_html(&message)]]
     ]

--- a/iml-wasm-components/iml-tooltip/src/lib.rs
+++ b/iml-wasm-components/iml-tooltip/src/lib.rs
@@ -2,8 +2,13 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::Msg;
 use seed::{class, div, prelude::*, span};
+
+#[derive(Default)]
+pub struct Model {
+    pub placement: TooltipPlacement,
+    pub size: TooltipSize,
+}
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -57,24 +62,18 @@ impl Default for TooltipSize {
     }
 }
 
-/// A tooltip component
-pub fn tooltip_component(
+/// A tooltip
+pub fn tooltip<T>(
     message: &str,
-    placement: &TooltipPlacement,
-    size: &TooltipSize,
-    more_classes: Option<Vec<&str>>,
-) -> El<Msg> {
-    let more_classes = match more_classes {
-        Some(classes) => classes.join(" "),
-        None => "".to_string(),
-    };
+    Model { placement, size }: &Model
+) -> El<T> {
+    
 
     div![
         class![
             "tooltip inferno-tt",
             placement.into(),
-            size.into(),
-            more_classes.as_str()
+            size.into()
         ],
         div![class!["tooltip-arrow"]],
         div![class!["tooltip-inner"], span![El::from_html(&message)]]


### PR DESCRIPTION
Split the tooltip component into it's own crate

Signed-off-by: Joe Grund <jgrund@whamcloud.io>