### PR TITLE
Add invoke_rust_agent_expect_result

### DIFF
--- a/chroma_core/lib/job.py
+++ b/chroma_core/lib/job.py
@@ -200,7 +200,7 @@ class Step(object):
     def invoke_rust_agent_expect_result(self, host, command, args={}):
         from chroma_core.services.job_scheduler.agent_rpc import AgentException
 
-        result = self.invoke_agent(host, command, args)
+        result = json.loads(self.invoke_rust_agent(host, command, args))
 
         if "Err" in result:
             self.log(json.dumps(result["Err"], indent=2))

--- a/chroma_core/lib/job.py
+++ b/chroma_core/lib/job.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
-
+import json
 import django.db.models
 
 from chroma_core.services import log_register
@@ -196,6 +196,17 @@ class Step(object):
         """
 
         return invoke_rust_agent(host, command, args, self._cancel_event)
+
+    def invoke_rust_agent_expect_result(self, host, command, args={}):
+        from chroma_core.services.job_scheduler.agent_rpc import AgentException
+
+        result = self.invoke_agent(host, command, args)
+
+        if "Err" in result:
+            self.log(json.dumps(result["Err"], indent=2))
+            raise AgentException(host.fqdn, command, args, result["Err"])
+
+        return result["Ok"]
 
     def invoke_agent_expect_result(self, host, command, args={}):
         from chroma_core.services.job_scheduler.agent_rpc import AgentException


### PR DESCRIPTION
Create a wrapper for invoke_rust_agent that will handle errors at the
base Job level so that the handling does not have to be done in each
job.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>