### PR TITLE
Remove max-body for mailbox endpoint

### DIFF
--- a/chroma-manager.conf.template
+++ b/chroma-manager.conf.template
@@ -177,6 +177,8 @@ server {
         if ($ssl_client_verify != SUCCESS) {
             return 401;
         }
+        
+        client_max_body_size 0m;
 
         proxy_set_header X-SSL-Client-On $ssl_client_verify;
         proxy_set_header X-SSL-Client-Name $ssl_client_s_dn_cn;


### PR DESCRIPTION
The body for a mailbox POST may be quite large.

set `client_max_body_size` to `0m` so nginx does not check for a maximum
size and return a 413 response.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>