### PR TITLE
Wait for cmd

### DIFF
--- a/iml-manager-cli/src/api_utils.rs
+++ b/iml-manager-cli/src/api_utils.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{api_client, manager_cli_error::ImlManagerCliError};
+use futures::{
+    future::{self, loop_fn, Either, Loop},
+    Future,
+};
+use iml_wire_types::Command;
+use std::time::{Duration, Instant};
+use tokio::timer::Delay;
+
+fn cmd_finished(cmd: &Command) -> bool {
+    cmd.errored || cmd.cancelled || cmd.complete
+}
+
+pub fn wait_for_cmd(cmd: Command) -> impl Future<Item = Command, Error = ImlManagerCliError> {
+    loop_fn(cmd, move |cmd| {
+        if cmd_finished(&cmd) {
+            return Either::A(future::ok(Loop::Break(cmd)));
+        }
+
+        let when = Instant::now() + Duration::from_millis(1000);
+
+        Either::B(
+            Delay::new(when)
+                .from_err()
+                .and_then(move |_| {
+                    let client = api_client::get_client().expect("Could not create API client");
+                    api_client::get(client, &format!("command/{}", cmd.id))
+                })
+                .map(Loop::Continue),
+        )
+    })
+}

--- a/iml-manager-cli/src/lib.rs
+++ b/iml-manager-cli/src/lib.rs
@@ -3,4 +3,5 @@
 // license that can be found in the LICENSE file.
 
 pub mod api_client;
+pub mod api_utils;
 pub mod manager_cli_error;

--- a/iml-manager-cli/src/main.rs
+++ b/iml-manager-cli/src/main.rs
@@ -105,7 +105,7 @@ fn display_cmd_state(cmd: &Command) {
     } else if cmd.cancelled {
         println!("🚫 {} cancelled", cmd.message);
     } else if cmd.complete {
-        println!("{}✔{} {} completed", green, reset, cmd.message);
+        println!("{}✔{} {} successful", green, reset, cmd.message);
     }
 }
 

--- a/iml-manager-cli/src/main.rs
+++ b/iml-manager-cli/src/main.rs
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 
 use futures::Future;
-use iml_manager_cli::api_client;
-use iml_wire_types::{ApiList, Host};
+use iml_manager_cli::{api_client, api_utils};
+use iml_wire_types::{ApiList, Command, Host};
 use prettytable::{Row, Table};
 use spinners::{Spinner, Spinners};
 use std::process::exit;
@@ -74,16 +74,44 @@ where
     table
 }
 
-fn start_spinner(msg: &str) -> impl FnOnce() -> () {
-    let cyan = termion::color::Fg(termion::color::Cyan);
+fn start_spinner(msg: &str) -> impl FnOnce(Option<String>) -> () {
+    let grey = termion::color::Fg(termion::color::LightBlack);
     let reset = termion::color::Fg(termion::color::Reset);
 
-    let sp = Spinner::new(Spinners::Dots9, format!("{}{}{}", cyan, msg, reset));
+    let s = format!("{}{}{}", grey, reset, msg);
+    let s_len = s.len();
 
-    move || {
-        sp.stop();
-        println!("{}", termion::clear::CurrentLine);
+    let sp = Spinner::new(Spinners::Dots9, s);
+
+    move |msg_opt| match msg_opt {
+        Some(msg) => {
+            sp.message(msg);
+        }
+        None => {
+            sp.stop();
+            print!("{}", termion::clear::CurrentLine);
+            print!("{}", termion::cursor::Left(s_len as u16));
+        }
     }
+}
+
+fn display_cmd_state(cmd: &Command) {
+    let green = termion::color::Fg(termion::color::Green);
+    let red = termion::color::Fg(termion::color::Red);
+    let reset = termion::color::Fg(termion::color::Reset);
+
+    if cmd.errored {
+        println!("{}✗{} {} errored", red, reset, cmd.message);
+    } else if cmd.cancelled {
+        println!("🚫 {} cancelled", cmd.message);
+    } else if cmd.complete {
+        println!("{}✔{} {} completed", green, reset, cmd.message);
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+struct CmdWrapper {
+    command: Command,
 }
 
 fn main() {
@@ -92,8 +120,6 @@ fn main() {
     dotenv::from_path("/var/lib/chroma/iml-settings.conf").expect("Could not load cli env");
 
     let matches = App::from_args();
-
-    let stop_spinner = start_spinner("Running command...");
 
     log::debug!("Matching args {:?}", matches);
 
@@ -109,13 +135,24 @@ fn main() {
                     )
                 };
 
-                let result: Result<(), _> = run_cmd(fut);
+                let CmdWrapper { command }: CmdWrapper = run_cmd(fut).expect("Could not run cmd");
 
-                stop_spinner();
+                let stop_spinner = start_spinner(&command.message);
+
+                let command =
+                    run_cmd(api_utils::wait_for_cmd(command)).expect("Could not poll command");
+
+                stop_spinner(None);
+
+                display_cmd_state(&command);
+
+                exit(exitcode::OK)
             }
         },
         App::Server { command } => match command {
             ServerCommand::List => {
+                let stop_spinner = start_spinner("Running command...");
+
                 let fut = {
                     let client = api_client::get_client().expect("Could not create API client");
                     api_client::get(client, "host")
@@ -123,7 +160,7 @@ fn main() {
 
                 let result: Result<ApiList<Host>, _> = run_cmd(fut);
 
-                stop_spinner();
+                stop_spinner(None);
 
                 match result {
                     Ok(hosts) => {

--- a/iml-manager-cli/src/manager_cli_error.rs
+++ b/iml-manager-cli/src/manager_cli_error.rs
@@ -8,6 +8,7 @@ pub type Result<T> = std::result::Result<T, ImlManagerCliError>;
 pub enum ImlManagerCliError {
     Reqwest(reqwest::Error),
     InvalidHeaderValue(reqwest::header::InvalidHeaderValue),
+    TokioTimerError(tokio::timer::Error),
     UrlParseError(url::ParseError),
 }
 
@@ -16,6 +17,7 @@ impl std::fmt::Display for ImlManagerCliError {
         match *self {
             ImlManagerCliError::Reqwest(ref err) => write!(f, "{}", err),
             ImlManagerCliError::InvalidHeaderValue(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::TokioTimerError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::UrlParseError(ref err) => write!(f, "{}", err),
         }
     }
@@ -26,8 +28,15 @@ impl std::error::Error for ImlManagerCliError {
         match *self {
             ImlManagerCliError::Reqwest(ref err) => Some(err),
             ImlManagerCliError::InvalidHeaderValue(ref err) => Some(err),
+            ImlManagerCliError::TokioTimerError(ref err) => Some(err),
             ImlManagerCliError::UrlParseError(ref err) => Some(err),
         }
+    }
+}
+
+impl From<tokio::timer::Error> for ImlManagerCliError {
+    fn from(err: tokio::timer::Error) -> Self {
+        ImlManagerCliError::TokioTimerError(err)
     }
 }
 

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -323,3 +323,16 @@ pub struct ServerProfile {
     pub user_selectable: bool,
     pub worker: bool,
 }
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct Command {
+    pub cancelled: bool,
+    pub complete: bool,
+    pub created_at: String,
+    pub errored: bool,
+    pub id: u64,
+    pub jobs: Vec<String>,
+    pub logs: String,
+    pub message: String,
+    pub resource_uri: String,
+}


### PR DESCRIPTION
When running a manager CLI call, it may return a `Command` resource.
When this occurs we should wait for it to complete while showing a nice
progress message.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>