### PR TITLE
Add action types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-fs 0.1.0",
- "iml-wire-types 0.1.0",
+ "iml-wire-types 0.1.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "liblustreapi 0.1.0",
@@ -857,7 +857,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-manager-env 0.1.0",
  "iml-rabbit 0.1.0",
- "iml-wire-types 0.1.0",
+ "iml-wire-types 0.1.1",
  "lapin-futures 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -910,7 +910,7 @@ dependencies = [
  "exitcode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-manager-env 0.1.0",
- "iml-wire-types 0.1.0",
+ "iml-wire-types 0.1.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -934,7 +934,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-manager-env 0.1.0",
- "iml-wire-types 0.1.0",
+ "iml-wire-types 0.1.1",
  "lapin-futures 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -950,7 +950,7 @@ dependencies = [
  "iml-agent-comms 0.1.0",
  "iml-manager-env 0.1.0",
  "iml-rabbit 0.1.0",
- "iml-wire-types 0.1.0",
+ "iml-wire-types 0.1.1",
  "lapin-futures 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "iml-wire-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-fs 0.1.0",
- "iml-wire-types 0.1.1",
+ "iml-wire-types 0.1.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "liblustreapi 0.1.0",
@@ -857,7 +857,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-manager-env 0.1.0",
  "iml-rabbit 0.1.0",
- "iml-wire-types 0.1.1",
+ "iml-wire-types 0.1.2",
  "lapin-futures 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -910,7 +910,7 @@ dependencies = [
  "exitcode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-manager-env 0.1.0",
- "iml-wire-types 0.1.1",
+ "iml-wire-types 0.1.2",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -934,7 +934,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-manager-env 0.1.0",
- "iml-wire-types 0.1.1",
+ "iml-wire-types 0.1.2",
  "lapin-futures 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -950,7 +950,7 @@ dependencies = [
  "iml-agent-comms 0.1.0",
  "iml-manager-env 0.1.0",
  "iml-rabbit 0.1.0",
- "iml-wire-types 0.1.1",
+ "iml-wire-types 0.1.2",
  "lapin-futures 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "iml-wire-types"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/iml-wire-types/Cargo.toml
+++ b/iml-wire-types/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "iml-wire-types"
+description = "Shared types for the IML project"
+license = "MIT"
 version = "0.1.0"
 authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"

--- a/iml-wire-types/Cargo.toml
+++ b/iml-wire-types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iml-wire-types"
 description = "Shared types for the IML project"
 license = "MIT"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 

--- a/iml-wire-types/Cargo.toml
+++ b/iml-wire-types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iml-wire-types"
 description = "Shared types for the IML project"
 license = "MIT"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -277,8 +277,8 @@ pub struct ApiList<T> {
 
 #[derive(serde::Deserialize, serde::Serialize, PartialEq, Clone, Debug)]
 pub struct ActionArgs {
-    host_id: Option<u64>,
-    target_id: Option<u64>,
+    pub host_id: Option<u64>,
+    pub target_id: Option<u64>,
 }
 
 // An available action from `/api/action/`

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -269,7 +269,7 @@ pub struct Meta {
 }
 
 /// ApiList contains the metadata and the `Vec` of objects returned by a fetch call
-#[derive(serde::Deserialize, serde::Serialize, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
 pub struct ApiList<T> {
     pub meta: Meta,
     pub objects: Vec<T>,
@@ -296,7 +296,7 @@ pub struct AvailableAction {
 }
 
 /// A Host record from `/api/host/`
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Host {
     pub address: String,
     pub boot_time: String,
@@ -326,7 +326,7 @@ pub struct Host {
 }
 
 /// A server profile record from api/server_profile/
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ServerProfile {
     pub corosync: bool,
     pub corosync2: bool,
@@ -344,7 +344,7 @@ pub struct ServerProfile {
     pub worker: bool,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Command {
     pub cancelled: bool,
     pub complete: bool,

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -259,7 +259,7 @@ impl<T: serde::Serialize> ToBytes for T {
 }
 
 /// Meta is the metadata object returned by a fetch call
-#[derive(serde::Deserialize, serde::Serialize, Debug)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug)]
 pub struct Meta {
     pub limit: u32,
     pub next: Option<u32>,
@@ -275,7 +275,27 @@ pub struct ApiList<T> {
     pub objects: Vec<T>,
 }
 
-/// A Host record from api/host/
+#[derive(serde::Deserialize, serde::Serialize, PartialEq, Clone, Debug)]
+pub struct ActionArgs {
+    host_id: Option<u64>,
+    target_id: Option<u64>,
+}
+
+// An available action from `/api/action/`
+#[derive(serde::Deserialize, serde::Serialize, PartialEq, Clone, Debug)]
+pub struct AvailableAction {
+    pub args: Option<ActionArgs>,
+    pub composite_id: String,
+    pub class_name: Option<String>,
+    pub confirmation: Option<String>,
+    pub display_group: u64,
+    pub display_order: u64,
+    pub long_description: String,
+    pub state: Option<String>,
+    pub verb: String,
+}
+
+/// A Host record from `/api/host/`
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Host {
     pub address: String,


### PR DESCRIPTION
Add types cooresponding to /api/action so they can be shared.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>