### PR TITLE
Parse fids as non-JSON

### DIFF
--- a/iml-agent/Cargo.toml
+++ b/iml-agent/Cargo.toml
@@ -21,7 +21,7 @@ spinners = "1.0.0"
 libc = "0.2.58"
 log = "0.4.6"
 prettytable-rs = "0.8"
-reqwest = { version = "0.9.17", features = ["default-tls", "tls"] }
+reqwest = { version = "0.9", features = ["default-tls", "tls"] }
 hyper = "0.12"
 http = "0.1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
until fidlists are implemented as streaming JSON,
we need to parse them as space-separated.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>