### PR TITLE
Update influx db name for stratagem scans

### DIFF
--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -313,7 +313,7 @@ class ServiceConfig(CommandLine):
         )
 
         log.info("Creating InfluxDB databse...")
-        self.try_shell(["influx", "-execute", "CREATE DATABASE iml_stratagem_scans"])
+        self.try_shell(["influx", "-execute", "CREATE DATABASE {}".format(settings.INFLUXDB_STRATAGEM_SCAN_DB)])
 
     def _setup_grafana(self):
         cfg_file = "/etc/sysconfig/grafana-server"

--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -313,6 +313,7 @@ class ServiceConfig(CommandLine):
         )
 
         log.info("Creating InfluxDB databse...")
+        self.try_shell(["influx", "-execute", "CREATE DATABASE {}".format(settings.INFLUXDB_IML_DB)])
         self.try_shell(["influx", "-execute", "CREATE DATABASE {}".format(settings.INFLUXDB_STRATAGEM_SCAN_DB)])
 
     def _setup_grafana(self):

--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -313,7 +313,7 @@ class ServiceConfig(CommandLine):
         )
 
         log.info("Creating InfluxDB databse...")
-        self.try_shell(["influx", "-execute", "CREATE DATABASE iml"])
+        self.try_shell(["influx", "-execute", "CREATE DATABASE iml_stratagem_scans"])
 
     def _setup_grafana(self):
         cfg_file = "/etc/sysconfig/grafana-server"

--- a/settings.py
+++ b/settings.py
@@ -57,6 +57,8 @@ WARP_DRIVE_PROXY_PASS = "http://{}:{}".format(PROXY_HOST, WARP_DRIVE_PORT)
 
 MAILBOX_PORT = 8891
 
+INFLUXDB_STRATAGEM_SCAN_DB = "iml_stratagem_scans"
+
 MAILBOX_PROXY_PASS = "http://{}:{}".format(PROXY_HOST, MAILBOX_PORT)
 
 SSL_PATH = "/var/lib/chroma"

--- a/settings.py
+++ b/settings.py
@@ -57,6 +57,8 @@ WARP_DRIVE_PROXY_PASS = "http://{}:{}".format(PROXY_HOST, WARP_DRIVE_PORT)
 
 MAILBOX_PORT = 8891
 
+INFLUXDB_IML_DB = "iml"
+
 INFLUXDB_STRATAGEM_SCAN_DB = "iml_stratagem_scans"
 
 MAILBOX_PROXY_PASS = "http://{}:{}".format(PROXY_HOST, MAILBOX_PORT)


### PR DESCRIPTION
Separate databases will be required in order to manage retention between
stats and stratagem scans. Create a unique database for stratagem scans.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>