### PR TITLE
Ensure ntpd is running

### DIFF
--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -471,7 +471,7 @@ class ServiceConfig(CommandLine):
             return error_msg
 
     def _restart_pgsql(self):
-        postgresql_service = ServiceControlEL7.create("postgresql")
+        postgresql_service = ServiceControl.create("postgresql")
         postgresql_service.restart()
         postgresql_service.enable()
 

--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -216,15 +216,19 @@ class ServiceConfig(CommandLine):
                 log.error("firewall command failed:\n%s" % error)
                 raise RuntimeError("Failure when opening port in firewall for ntpd: %s" % error)
 
+        log.info("Disabling chrony if active")
+        chrony_service = ServiceControl.create("chronyd")
+        chrony_service.stop(validate_time=0.5)
+        chrony_service.disable()
+
         log.info("Restarting ntp")
         ntp_service = ServiceControl.create("ntpd")
-
+        ntp_service.enable()
         error = ntp_service.restart()
+
         if error:
             log.error(error)
             raise RuntimeError(error)
-
-        ntp_service.enable()
 
     def _rabbit_configured(self):
         # Data message should be forwarded to AMQP
@@ -393,7 +397,7 @@ class ServiceConfig(CommandLine):
                 else:
                     error = controller.reload()
             else:
-                error = controller.start()
+                error = controller.start(validate_time=0.5)
             if error:
                 log.error(error)
                 raise RuntimeError(error)
@@ -403,7 +407,7 @@ class ServiceConfig(CommandLine):
         for service in self.CONTROLLED_SERVICES:
             controller = ServiceControl.create(service)
 
-            error = controller.stop()
+            error = controller.stop(validate_time=0.5)
             if error:
                 log.error(error)
                 raise RuntimeError(error)
@@ -467,7 +471,7 @@ class ServiceConfig(CommandLine):
             return error_msg
 
     def _restart_pgsql(self):
-        postgresql_service = ServiceControl.create("postgresql")
+        postgresql_service = ServiceControlEL7.create("postgresql")
         postgresql_service.restart()
         postgresql_service.enable()
 
@@ -806,9 +810,7 @@ proxy=_none_
 
     @staticmethod
     def _service_config(interesting_services=None):
-        """Interrogate the current status of services, it should be noted that el7 calls to
-        systemctl through ServiceControl will redirect to chkconfig if the specified service is
-        not native (SysV style init as opposed to systemd unit init file)
+        """Interrogate the current status of services
         """
         log.info("Checking service configuration...")
 


### PR DESCRIPTION
with the advent of `chronyd`, `ntpd`, which IML currently relies on may
be inactive.

Make sure we stop and disable chronyd on the manager.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>