### PR TITLE
Fix fid error

### DIFF
--- a/liblustreapi/src/lib.rs
+++ b/liblustreapi/src/lib.rs
@@ -227,7 +227,14 @@ pub fn rmfids(
 ) -> Result<(), LiblustreError> {
     // @TODO replace with sys::llapi_rmfid once LU-12090 lands
     for fidstr in fidlist {
-        rmfid(&mntpt, &fidstr)?;
+        rmfid(&mntpt, &fidstr).unwrap_or_else(|x| {
+            log::error!(
+                "Couldn't remove fid {} with mountpoint {}: {}.",
+                fidstr,
+                mntpt,
+                x
+            )
+        });
     }
 
     Ok(())


### PR DESCRIPTION
Purging takes place with a chunk of 10 and attempts to remove the fids.
If an error occurrs on any of the 10 fids, it will immediately return,
   which means the remaining (up to 9) files may not have been
   processed and thus will not have been removed. This is reproducable
   every time due to phantom fids throwing errors. This patch will
   instead log the information and continue to the next fid instead of
   returning from the function immediately.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>