### PR TITLE
Update manager cli to parse purge and report durations correctly

### DIFF
--- a/iml-agent/src/action_plugins/stratagem/server.rs
+++ b/iml-agent/src/action_plugins/stratagem/server.rs
@@ -165,7 +165,7 @@ impl Counter for &StratagemCounters {
 /// Pre-cooked config. This is a V1
 /// thing, Future versions will expand to
 /// expose the whole config to the user.
-pub fn generate_cooked_config(path: String, rd: Option<u32>, pd: Option<u32>) -> StratagemConfig {
+pub fn generate_cooked_config(path: String, rd: Option<u64>, pd: Option<u64>) -> StratagemConfig {
     let mut conf = StratagemConfig {
         dump_flist: false,
         device: StratagemDevice {

--- a/iml-agent/src/cli.rs
+++ b/iml-agent/src/cli.rs
@@ -53,8 +53,10 @@ fn parse_duration(src: &str) -> Result<u32, io::Error> {
         .map_err(|_| invalid_input_err(&format!("Could not parse {} to u32", val)))?;
 
     match unit {
-        Some('h') => Ok(val * 3_600),
-        Some('d') => Ok(val * 86_400),
+        Some('h') => Ok(val * 3_600_000),
+        Some('d') => Ok(val * 86_400_000),
+        Some('m') => Ok(val * 60_000),
+        Some('s') => Ok(val * 1_000),
         Some('1'...'9') => Err(invalid_input_err("No unit specified.")),
         _ => Err(invalid_input_err(
             "Invalid unit. Valid units include 'h' and 'd'.",

--- a/iml-agent/src/cli.rs
+++ b/iml-agent/src/cli.rs
@@ -27,10 +27,10 @@ pub enum StratagemCommand {
         device_path: String,
         /// The report duration
         #[structopt(short = "r", long = "report", parse(try_from_str = "parse_duration"))]
-        rd: Option<u32>,
+        rd: Option<u64>,
         /// The purge duration
         #[structopt(short = "p", long = "purge", parse(try_from_str = "parse_duration"))]
-        pd: Option<u32>,
+        pd: Option<u64>,
     },
 }
 
@@ -38,7 +38,7 @@ fn invalid_input_err(msg: &str) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidInput, msg)
 }
 
-fn parse_duration(src: &str) -> Result<u32, io::Error> {
+fn parse_duration(src: &str) -> Result<u64, io::Error> {
     if src.len() < 2 {
         return Err(invalid_input_err(
             "Invalid value specified. Must be a valid integer.",
@@ -49,8 +49,8 @@ fn parse_duration(src: &str) -> Result<u32, io::Error> {
     let unit = val.pop();
 
     let val = val
-        .parse::<u32>()
-        .map_err(|_| invalid_input_err(&format!("Could not parse {} to u32", val)))?;
+        .parse::<u64>()
+        .map_err(|_| invalid_input_err(&format!("Could not parse {} to u64", val)))?;
 
     match unit {
         Some('h') => Ok(val * 3_600_000),

--- a/iml-manager-cli/src/main.rs
+++ b/iml-manager-cli/src/main.rs
@@ -53,6 +53,8 @@ fn parse_duration(src: &str) -> Result<u32, ImlManagerCliError> {
     match unit {
         Some('h') => Ok(val * 3_600_000),
         Some('d') => Ok(val * 86_400_000),
+        Some('m') => Ok(val * 60_000),
+        Some('s') => Ok(val * 1_000),
         Some('1'...'9') => Err(DurationParseError::NoUnit.into()),
         _ => Err(DurationParseError::InvalidUnit.into()),
     }

--- a/iml-manager-cli/src/main.rs
+++ b/iml-manager-cli/src/main.rs
@@ -51,8 +51,8 @@ fn parse_duration(src: &str) -> Result<u32, ImlManagerCliError> {
     let val = val.parse::<u32>()?;
 
     match unit {
-        Some('h') => Ok(val * 3_600),
-        Some('d') => Ok(val * 86_400),
+        Some('h') => Ok(val * 3_600_000),
+        Some('d') => Ok(val * 86_400_000),
         Some('1'...'9') => Err(DurationParseError::NoUnit.into()),
         _ => Err(DurationParseError::InvalidUnit.into()),
     }

--- a/iml-manager-cli/src/main.rs
+++ b/iml-manager-cli/src/main.rs
@@ -26,21 +26,21 @@ pub enum StratagemCommand {
         fs: String,
         /// The report duration
         #[structopt(short = "r", long = "report", parse(try_from_str = "parse_duration"))]
-        rd: Option<u32>,
+        rd: Option<u64>,
         /// The purge duration
         #[structopt(short = "p", long = "purge", parse(try_from_str = "parse_duration"))]
-        pd: Option<u32>,
+        pd: Option<u64>,
     },
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 struct StratagemCommandData {
     filesystem: String,
-    report_duration: Option<u32>,
-    purge_duration: Option<u32>,
+    report_duration: Option<u64>,
+    purge_duration: Option<u64>,
 }
 
-fn parse_duration(src: &str) -> Result<u32, ImlManagerCliError> {
+fn parse_duration(src: &str) -> Result<u64, ImlManagerCliError> {
     if src.len() < 2 {
         return Err(DurationParseError::InvalidValue.into());
     }
@@ -48,7 +48,7 @@ fn parse_duration(src: &str) -> Result<u32, ImlManagerCliError> {
     let mut val = String::from(src);
     let unit = val.pop();
 
-    let val = val.parse::<u32>()?;
+    let val = val.parse::<u64>()?;
 
     match unit {
         Some('h') => Ok(val * 3_600_000),
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     fn test_parse_duration_with_days() {
         match parse_duration("273d") {
-            Ok(x) => assert_eq!(x, 23587200),
+            Ok(x) => assert_eq!(x, 23_587_200_000),
             Err(_) => panic!("Duration parser should not have errored!"),
         }
     }
@@ -292,7 +292,23 @@ mod tests {
     #[test]
     fn test_parse_duration_with_hours() {
         match parse_duration("273h") {
-            Ok(x) => assert_eq!(x, 982800),
+            Ok(x) => assert_eq!(x, 982_800_000),
+            Err(_) => panic!("Duration parser should not have errored!"),
+        }
+    }
+
+    #[test]
+    fn test_parse_duration_with_minutes() {
+        match parse_duration("273m") {
+            Ok(x) => assert_eq!(x, 16_380_000),
+            Err(_) => panic!("Duration parser should not have errored!"),
+        }
+    }
+
+    #[test]
+    fn test_parse_duration_with_seconds() {
+        match parse_duration("273") {
+            Ok(x) => assert_eq!(x, 273_000),
             Err(_) => panic!("Duration parser should not have errored!"),
         }
     }

--- a/iml-manager-cli/src/main.rs
+++ b/iml-manager-cli/src/main.rs
@@ -307,7 +307,7 @@ mod tests {
 
     #[test]
     fn test_parse_duration_with_seconds() {
-        match parse_duration("273") {
+        match parse_duration("273s") {
             Ok(x) => assert_eq!(x, 273_000),
             Err(_) => panic!("Duration parser should not have errored!"),
         }


### PR DESCRIPTION
Currently, the cli converts hours to seconds and days to seconds.
Stratagem uses milliseconds instead of seconds so the conversion needs
to be updated.

- Convert hours to milliseconds
- Convert days to milliseconds

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>