### PR TITLE
Add Validation cases to RunStratagemCommandResult enum

### DIFF
--- a/iml-manager-cli/src/manager_cli_error.rs
+++ b/iml-manager-cli/src/manager_cli_error.rs
@@ -12,9 +12,13 @@ pub enum DurationParseError {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum RunStratagemCommandResult {
-    FilesystemRequired,
     DurationOrderError,
+    FilesystemRequired,
     FilesystemDoesNotExist,
+    FilesystemUnavailable,
+    InvalidArgument,
+    Mdt0NotFound,
+    Mdt0NotMounted,
     StratagemServerProfileNotInstalled,
     ServerError,
     UnknownError,


### PR DESCRIPTION
New validation codes are available and need to be added to the
RunStratagemCommandResult enum.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>