### PR TITLE
Add Stratagem Client Validation

### DIFF
--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -85,6 +85,12 @@ class RunStratagemValidation(Validation):
                 "message": "'stratagem_servers' profile must be installed on all MDT servers.",
             }
 
+        if not ManagedHost.objects.filter(server_profile_id="stratagem_client").exists():
+            return {
+                "code": "stratagem_client_profile_not_installed",
+                "message": "A client must be added with the 'Stratagem Client' profile to run this command.",
+            }
+
         return {}
 
 

--- a/iml-manager-cli/src/manager_cli_error.rs
+++ b/iml-manager-cli/src/manager_cli_error.rs
@@ -20,6 +20,7 @@ pub enum RunStratagemCommandResult {
     Mdt0NotFound,
     Mdt0NotMounted,
     StratagemServerProfileNotInstalled,
+    StratagemClientProfileNotInstalled,
     ServerError,
     UnknownError,
 }


### PR DESCRIPTION
Validation does not currently take into consideration that a client may
not have been added to IML. Running stratagem will result in a "Host not
found" error. Instead, the validation should ensure that a client has
been added with the stratagem client profile before running or
configuring stratagem.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>