### PR TITLE
Filter out empty actions

### DIFF
--- a/iml-wasm-components/iml-action-dropdown/src/deferred_action_dropdown.rs
+++ b/iml-wasm-components/iml-action-dropdown/src/deferred_action_dropdown.rs
@@ -182,6 +182,7 @@ pub fn get_record_els<'a, T: ActionRecord + 'static>(
 ) -> Vec<El<IdMsg<T>>> {
     actions
         .into_iter()
+        .filter(|(_, xs)| !xs.is_empty())
         .map(|(k, xs)| (k, sort_actions(xs)))
         .flat_map(|(label, xs)| {
             let ys = xs.into_iter().map(|(action, record)| {

--- a/iml-wasm-components/iml-action-dropdown/src/model.rs
+++ b/iml-wasm-components/iml-action-dropdown/src/model.rs
@@ -7,7 +7,7 @@ use iml_wire_types::{
     ApiList, AvailableAction, CompositeId, HsmControlParam, Label, LockChange, LockType,
     ToCompositeId,
 };
-use std::{collections::HashMap, convert, iter};
+use std::collections::HashMap;
 
 /// A record
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, Clone)]
@@ -65,10 +65,10 @@ fn lock_list<'a, T>(
 pub fn has_lock<'a, T: ActionRecord>(locks: &'a Locks, record: &'a T) -> bool {
     let id = record.composite_id().to_string();
 
-    iter::once(locks.get(&id))
-        .filter_map(convert::identity)
-        .flatten()
-        .any(|x| x.lock_type == LockType::Write)
+    locks
+        .get(&id)
+        .filter(|xs| xs.iter().any(|x| x.lock_type == LockType::Write))
+        .is_some()
 }
 
 pub fn has_locks<'a, T>(locks: &'a Locks, records: &'a RecordMap<T>) -> bool {


### PR DESCRIPTION
Actions may be empty when a job is in progress. Make sure to filter those out as the label would still be there.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>