### PR TITLE
Avoid divide by 0 on pie chart

### DIFF
--- a/iml-wasm-components/iml-pie-chart/src/lib.rs
+++ b/iml-wasm-components/iml-pie-chart/src/lib.rs
@@ -7,8 +7,12 @@ use std::f64::consts::PI;
 
 /// Create a pie chart to display used / total as percentages
 pub fn pie_chart<T>(used: f64, total: f64, total_color: &str, used_color: &str) -> El<T> {
-    let percent = used / total;
-    let radians = 2.0 * PI * percent;
+    let (percent, radians) = if total == 0.0 {
+        (0.0, 0.0)
+    } else {
+        let percent = used / total;
+        (percent, 2.0 * PI * percent)
+    };
 
     let end_x = radians.cos();
     let end_y = radians.sin();


### PR DESCRIPTION
Division of f64 by 0 yields NaN.

Special case when total is 0 to not divide.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>