### PR TITLE
Add Grafana Dashboard Provisioning

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -73,6 +73,7 @@ iml-srpm: iml-deps substs
 	cp -r ${BUILDROOT}/{chroma_*,chroma-*,__init__.py,manage.py,scm_version.py,setup.py,settings.py,urls.py,wsgi.py,agent-bootstrap-script.template,*.profile} ${TMPDIR}/scratch
 	cp -r ${BUILDROOT}/{*.repo,README.*,licenses,polymorphic,scripts,example_storage_plugin_package,tests,MANIFEST.in} ${TMPDIR}/scratch
 	cp ${BUILDROOT}/python-iml-manager.spec ${TMPDIR}/_topdir/SPECS
+	cp -r ${BUILDROOT}/grafana ${TMPDIR}/_topdir/SOURCES
 	cp ${BUILDROOT}/iml-*.service \
 		${BUILDROOT}/rabbitmq-env.conf \
 		${BUILDROOT}/iml-manager-redirect.conf \

--- a/chroma_core/lib/stratagem.py
+++ b/chroma_core/lib/stratagem.py
@@ -2,11 +2,8 @@ import requests
 import settings
 import operator
 import json
-import calendar
-import time
 
 from toolz.functoolz import pipe, partial
-from requests.exceptions import ConnectionError
 
 temp_stratagem_measurement = "temp_stratagem_scan"
 stratagem_measurement = "stratagem_scan"

--- a/grafana/dashboards/iml-dashboards.yaml
+++ b/grafana/dashboards/iml-dashboards.yaml
@@ -1,0 +1,12 @@
+# config file version
+apiVersion: 1
+
+providers:
+ - name: 'default'
+   orgId: 1
+   folder: ''
+   folderUid: ''
+   type: file
+   editable: true
+   options:
+     path: /usr/share/chroma-manager/grafana/dashboards

--- a/grafana/dashboards/stratagem-dashboard-1.json
+++ b/grafana/dashboards/stratagem-dashboard-1.json
@@ -1,0 +1,168 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": false,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "tagsColumn": "25",
+        "textColumn": "3",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Stratagem Charts",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "iml-influx-iml_stratagem_scans",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$tag_label",
+          "groupBy": [
+            {
+              "params": ["label"],
+              "type": "tag"
+            }
+          ],
+          "measurement": "stratagem_scan",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"count\" FROM \"stratagem_scan\" WHERE (\"group_name\" = 'size_distribution') AND $timeFilter GROUP BY \"counter_name\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": ["count"],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group_name",
+              "operator": "=",
+              "value": "size_distribution"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Size Distribution",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "series",
+        "name": null,
+        "show": true,
+        "values": ["total"]
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": ["stratagem"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "",
+  "title": "Stratagem",
+  "uid": "OBdCS5IWz",
+  "version": 30
+}

--- a/grafana/dashboards/stratagem-dashboard-1.json
+++ b/grafana/dashboards/stratagem-dashboard-1.json
@@ -20,7 +20,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2,
   "links": [],
   "panels": [
     {
@@ -29,7 +28,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "iml-influx-iml_stratagem_scans",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -43,7 +42,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": true,
+        "show": false,
         "total": false,
         "values": false
       },
@@ -56,7 +55,11 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "< 1 Mib"
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -69,10 +72,11 @@
               "type": "tag"
             }
           ],
+          "hide": false,
           "measurement": "stratagem_scan",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"count\" FROM \"stratagem_scan\" WHERE (\"group_name\" = 'size_distribution') AND $timeFilter GROUP BY \"counter_name\"",
+          "query": "SELECT \"count\" FROM \"stratagem_scan\" WHERE (\"group_name\" = 'size_distribution')",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -89,6 +93,120 @@
               "key": "group_name",
               "operator": "=",
               "value": "size_distribution"
+            },
+            {
+              "condition": "AND",
+              "key": "label",
+              "operator": "=",
+              "value": "< 1 Mib"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_label",
+          "groupBy": [
+            {
+              "params": ["label"],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "stratagem_scan",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": ["count"],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group_name",
+              "operator": "=",
+              "value": "size_distribution"
+            },
+            {
+              "condition": "AND",
+              "key": "label",
+              "operator": "=",
+              "value": ">= 1 Mib, < 1 GiB"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_label",
+          "groupBy": [
+            {
+              "params": ["label"],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "stratagem_scan",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": ["count"],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group_name",
+              "operator": "=",
+              "value": "size_distribution"
+            },
+            {
+              "condition": "AND",
+              "key": "label",
+              "operator": "=",
+              "value": ">= 1 GiB"
+            }
+          ]
+        },
+        {
+          "alias": "$tag_label",
+          "groupBy": [
+            {
+              "params": ["label"],
+              "type": "tag"
+            }
+          ],
+          "hide": false,
+          "measurement": "stratagem_scan",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": ["count"],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "group_name",
+              "operator": "=",
+              "value": "size_distribution"
+            },
+            {
+              "condition": "AND",
+              "key": "label",
+              "operator": "=",
+              "value": ">= 1 TiB"
             }
           ]
         }
@@ -114,8 +232,9 @@
       },
       "yaxes": [
         {
+          "decimals": 0,
           "format": "short",
-          "label": null,
+          "label": "Count",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -136,33 +255,23 @@
       }
     }
   ],
+  "refresh": "10s",
   "schemaVersion": 18,
-  "style": "dark",
+  "style": "light",
   "tags": ["stratagem"],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "2000-01-01 00:00:00",
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "1h", "2h", "1d"],
+    "time_options": []
   },
   "timezone": "",
   "title": "Stratagem",
   "uid": "OBdCS5IWz",
-  "version": 30
+  "version": 10
 }

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -37,7 +37,8 @@ Source13:       iml-stats.service
 Source14:       iml-syslog.service
 Source16:       iml-manager-redirect.conf
 Source17:       rabbitmq-env.conf
-Source18:	grafana-iml.ini
+Source18:       grafana-iml.ini
+Source19:       grafana
 
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
@@ -107,8 +108,8 @@ Requires:       rust-iml-mailbox
 Requires:       rust-iml-stratagem
 Requires:       rust-iml-warp-drive
 # Other Repos
-Requires:      influxdb
-Requires:	grafana
+Requires:       influxdb
+Requires:       grafana
 
 Conflicts:      chroma-agent
 Obsoletes:      chroma-manager
@@ -224,8 +225,10 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/{init,logrotate,nginx/conf,nginx/default}
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/rabbitmq
 touch $RPM_BUILD_ROOT%{_sysconfdir}/nginx/conf.d/chroma-manager.conf
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/rabbitmq
-mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/grafana
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/grafana/provisioning/dashboards
 install -m 644 %{SOURCE18} $RPM_BUILD_ROOT%{_sysconfdir}/grafana/
+cp -r %{SOURCE19} $RPM_BUILD_ROOT%{manager_root}
+mv $RPM_BUILD_ROOT%{manager_root}/grafana/dashboards/iml-dashboards.yaml $RPM_BUILD_ROOT%{_sysconfdir}/grafana/provisioning/dashboards
 cp %{SOURCE16} $RPM_BUILD_ROOT%{_sysconfdir}/nginx/default.d/iml-manager-redirect.conf
 cp %{SOURCE17} $RPM_BUILD_ROOT%{_sysconfdir}/rabbitmq/rabbitmq-env.conf
 cp %{SOURCE1} $RPM_BUILD_ROOT%{_sysconfdir}/init.d/chroma-host-discover
@@ -345,6 +348,8 @@ fi
 %attr(0755,root,root)%{_sysconfdir}/init.d/chroma-host-discover
 %attr(0755,root,root)%{_mandir}/man1/chroma-config.1.gz
 %attr(0644,root,root)%{_sysconfdir}/logrotate.d/chroma-manager
+%attr(0644,root,grafana)%{_sysconfdir}/grafana/provisioning/dashboards/iml-dashboards.yaml
+%attr(0644,root,grafana)%{manager_root}/grafana/dashboards/stratagem-dashboard*.json
 %attr(0644,root,root)%{_unitdir}/iml-corosync.service
 %attr(0644,root,root)%{_unitdir}/iml-gunicorn.service
 %attr(0644,root,root)%{_unitdir}/iml-http-agent.service


### PR DESCRIPTION
Grafana allows for privisioning of dashboards as well as data sources.
This patch will provision grafana with a stratagem dashboard that will
be built and ready to go as soon as installation completes. This will
allow us to easily embed an iframe and create the chart component.
    
Signed-off-by: Will Johnson <wjohnson@whamcloud.com>