### PR TITLE
GH-1056 - Create nginx integration with influx

### DIFF
--- a/chroma-manager.conf.template
+++ b/chroma-manager.conf.template
@@ -152,7 +152,17 @@ server {
         proxy_set_header X-WEBAUTH-USER "admin";
         rewrite  ^/grafana/(.*)  /$1 break;
         proxy_pass http://localhost:3000/;
-   }
+    }
+
+    location /influx {
+        limit_except GET { deny all; }
+        auth_request /auth;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        rewrite ^/influx/(\w+)/(.*)$ /query?db=$1&q=$2 break;
+        proxy_pass http://localhost:8086/;
+    }
 
     location /wasm-components {
         alias /usr/share/iml-manager/iml-wasm-components;

--- a/chroma-manager.conf.template
+++ b/chroma-manager.conf.template
@@ -157,11 +157,11 @@ server {
     location /influx {
         limit_except GET { deny all; }
         auth_request /auth;
-        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Server $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        rewrite ^/influx/(\w+)/(.*)$ /query?db=$1&q=$2 break;
-        proxy_pass http://localhost:8086/;
+        proxy_pass http://localhost:8086/query;
     }
 
     location /wasm-components {


### PR DESCRIPTION
Fixes #1056.

Description:
Since influxdb provides an http api, the reverse proxy feature of nginx
should be leveraged to allow a query to be run from the application.
This will allow components to be given a stream coming directly from the
database rather than having to go through realtime to get the data. The
end point should be restricted to GET only and should follow
authentication rules. Queries can be made in the form:

https://localhost:8443/influx/<dbname>/<query>

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>