### PR TITLE
GH-1062 - Stratagem duratiion models should be bigint

### DIFF
--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -31,6 +31,29 @@ MAX_SAFE_INTEGER = 9007199254740991
 
 class RunStratagemValidation(Validation):
     def is_valid(self, bundle, request=None):
+        def check_duration(duration_key, bundle):
+            duration_type = duration_key.split("_")[0].capitalize()
+            try:
+                duration = bundle.data.get(duration_key) and get_bundle_int_val(bundle.data.get(duration_key))
+                if duration > MAX_SAFE_INTEGER:
+                    return {
+                        "code": "{}_too_big".format(duration_key),
+                        "message": "{} duration cannot be larger than {}.".format(duration_type, MAX_SAFE_INTEGER),
+                    }
+            except ValueError:
+                return {
+                    "code": "invalid_argument",
+                    "message": "{} duration must be an integer value.".format(duration_type),
+                }
+
+        purge_check = check_duration("purge_duration", bundle)
+        if purge_check:
+            return purge_check
+
+        report_check = check_duration("report_duration", bundle)
+        if report_check:
+            return report_check
+
         try:
             purge_duration = bundle.data.get("purge_duration") and get_bundle_int_val(bundle.data.get("purge_duration"))
             if purge_duration > MAX_SAFE_INTEGER:

--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -30,7 +30,7 @@ MAX_SAFE_INTEGER = 9007199254740991
 
 
 class RunStratagemValidation(Validation):
-    def _check_duration(duration_key, bundle):
+    def _check_duration(self, duration_key, bundle):
             duration_type = duration_key.split("_")[0].capitalize()
             try:
                 duration = bundle.data.get(duration_key) and get_bundle_int_val(bundle.data.get(duration_key))

--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -30,8 +30,7 @@ MAX_SAFE_INTEGER = 9007199254740991
 
 
 class RunStratagemValidation(Validation):
-    def is_valid(self, bundle, request=None):
-        def check_duration(duration_key, bundle):
+    def _check_duration(duration_key, bundle):
             duration_type = duration_key.split("_")[0].capitalize()
             try:
                 duration = bundle.data.get(duration_key) and get_bundle_int_val(bundle.data.get(duration_key))
@@ -46,11 +45,12 @@ class RunStratagemValidation(Validation):
                     "message": "{} duration must be an integer value.".format(duration_type),
                 }
 
-        purge_check = check_duration("purge_duration", bundle)
+    def is_valid(self, bundle, request=None):
+        purge_check = self._check_duration("purge_duration", bundle)
         if purge_check:
             return purge_check
 
-        report_check = check_duration("report_duration", bundle)
+        report_check = self._check_duration("report_duration", bundle)
         if report_check:
             return report_check
 

--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -42,10 +42,10 @@ class StratagemConfiguration(StatefulObject):
         help_text="The filesystem id associated with the stratagem configuration", null=False
     )
     interval = models.IntegerField(help_text="Interval value in seconds between each stratagem execution", null=False)
-    report_duration = models.IntegerField(
+    report_duration = models.BigIntegerField(
         help_text="Interval value in seconds between stratagem report execution", null=True
     )
-    purge_duration = models.IntegerField(help_text="Interval value in seconds between stratagem purges", null=True)
+    purge_duration = models.BigIntegerField(help_text="Interval value in seconds between stratagem purges", null=True)
 
     states = ["unconfigured", "configured"]
     initial_state = "unconfigured"
@@ -200,8 +200,8 @@ class StreamFidlistStep(Step):
 class RunStratagemJob(Job):
     mdt_id = models.IntegerField()
     uuid = models.CharField(max_length=64, null=False, default="")
-    report_duration = models.IntegerField(null=True)
-    purge_duration = models.IntegerField(null=True)
+    report_duration = models.BigIntegerField(null=True)
+    purge_duration = models.BigIntegerField(null=True)
     fqdn = models.CharField(max_length=255, null=False, default="")
     target_name = models.CharField(max_length=64, null=False, default="")
     filesystem_type = models.CharField(max_length=32, null=False, default="")
@@ -338,8 +338,8 @@ class SendResultsToClientStep(Step):
 
 class SendStratagemResultsToClientJob(Job):
     uuid = models.CharField(max_length=64, null=False, default="")
-    report_duration = models.IntegerField(null=True)
-    purge_duration = models.IntegerField(null=True)
+    report_duration = models.BigIntegerField(null=True)
+    purge_duration = models.BigIntegerField(null=True)
 
     class Meta:
         app_label = "chroma_core"

--- a/chroma_core/south_migrations/0046_auto__add_sendstratagemresultstoclientjob__add_stratagemconfiguration_.py
+++ b/chroma_core/south_migrations/0046_auto__add_sendstratagemresultstoclientjob__add_stratagemconfiguration_.py
@@ -12,8 +12,8 @@ class Migration(SchemaMigration):
         db.create_table(u'chroma_core_sendstratagemresultstoclientjob', (
             (u'job_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['chroma_core.Job'], unique=True, primary_key=True)),
             ('uuid', self.gf('django.db.models.fields.CharField')(default='', max_length=64)),
-            ('report_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
-            ('purge_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('report_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
+            ('purge_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
         ))
         db.send_create_signal('chroma_core', ['SendStratagemResultsToClientJob'])
 
@@ -25,8 +25,8 @@ class Migration(SchemaMigration):
             ('immutable_state', self.gf('django.db.models.fields.BooleanField')(default=False)),
             ('filesystem_id', self.gf('django.db.models.fields.IntegerField')()),
             ('interval', self.gf('django.db.models.fields.IntegerField')()),
-            ('report_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
-            ('purge_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('report_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
+            ('purge_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
         ))
         db.send_create_signal('chroma_core', ['StratagemConfiguration'])
 
@@ -35,8 +35,8 @@ class Migration(SchemaMigration):
             (u'job_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['chroma_core.Job'], unique=True, primary_key=True)),
             ('mdt_id', self.gf('django.db.models.fields.IntegerField')()),
             ('uuid', self.gf('django.db.models.fields.CharField')(default='', max_length=64)),
-            ('report_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
-            ('purge_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('report_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
+            ('purge_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
             ('fqdn', self.gf('django.db.models.fields.CharField')(default='', max_length=255)),
             ('target_name', self.gf('django.db.models.fields.CharField')(default='', max_length=64)),
             ('filesystem_type', self.gf('django.db.models.fields.CharField')(default='', max_length=32)),
@@ -944,10 +944,10 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'RegistrationToken'},
             'cancelled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'credits': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
-            'expiry': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 6, 27, 0, 0)'}),
+            'expiry': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 7, 11, 0, 0)'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.ServerProfile']", 'null': 'True'}),
-            'secret': ('django.db.models.fields.CharField', [], {'default': "'70B7B08EEAE2E7CF6983FA7435181B0F'", 'max_length': '32'})
+            'secret': ('django.db.models.fields.CharField', [], {'default': "'5941B545140E441241410BE77D97EAD1'", 'max_length': '32'})
         },
         'chroma_core.removeconfiguredtargetjob': {
             'Meta': {'ordering': "['id']", 'object_name': 'RemoveConfiguredTargetJob'},
@@ -1015,8 +1015,8 @@ class Migration(SchemaMigration):
             'fqdn': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255'}),
             u'job_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['chroma_core.Job']", 'unique': 'True', 'primary_key': 'True'}),
             'mdt_id': ('django.db.models.fields.IntegerField', [], {}),
-            'purge_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
-            'report_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'purge_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
+            'report_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
             'target_mount_point': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '512'}),
             'target_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64'}),
             'uuid': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64'})
@@ -1059,8 +1059,8 @@ class Migration(SchemaMigration):
         'chroma_core.sendstratagemresultstoclientjob': {
             'Meta': {'ordering': "['id']", 'object_name': 'SendStratagemResultsToClientJob', '_ormbases': ['chroma_core.Job']},
             u'job_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['chroma_core.Job']", 'unique': 'True', 'primary_key': 'True'}),
-            'purge_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
-            'report_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'purge_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
+            'report_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
             'uuid': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64'})
         },
         'chroma_core.series': {
@@ -1374,8 +1374,8 @@ class Migration(SchemaMigration):
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'immutable_state': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'interval': ('django.db.models.fields.IntegerField', [], {}),
-            'purge_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
-            'report_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'purge_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
+            'report_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
             'state': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
             'state_modified_at': ('django.db.models.fields.DateTimeField', [], {})
         },

--- a/iml-manager-cli/src/manager_cli_error.rs
+++ b/iml-manager-cli/src/manager_cli_error.rs
@@ -17,6 +17,8 @@ pub enum RunStratagemCommandResult {
     FilesystemDoesNotExist,
     FilesystemUnavailable,
     InvalidArgument,
+    PurgeDurationTooBig,
+    ReportDurationTooBig,
     Mdt0NotFound,
     Mdt0NotMounted,
     StratagemServerProfileNotInstalled,


### PR DESCRIPTION
Fixes #1062.

Since milleseconds will be used for duration and it's possible that a
number of years could be specified, the fields should be of the
BigInteger type instead of Integer. This patch will ensure that:
1. The duration fields on the models use BigInteger
2. The API will handle hydrating and dehydrating data from String to
BigInteger such that data is stored as a u64 in the database and
retrieved as a long instead of a string (Tastypie does not support
    BigInteger in resources so it must be converted to a long)
3. Validation is added to ensure that no value > MAX_SAFE_INTEGER (9007199254740991)
  can be used for either duration.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>