### PR TITLE
GH-1062 - Stratagem duration models should be bigint

### DIFF
--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -31,6 +31,29 @@ MAX_SAFE_INTEGER = 9007199254740991
 
 class RunStratagemValidation(Validation):
     def is_valid(self, bundle, request=None):
+        def check_duration(duration_key, bundle):
+            duration_type = duration_key.split("_")[0].capitalize()
+            try:
+                duration = bundle.data.get(duration_key) and get_bundle_int_val(bundle.data.get(duration_key))
+                if duration > MAX_SAFE_INTEGER:
+                    return {
+                        "code": "{}_too_big".format(duration_key),
+                        "message": "{} duration cannot be larger than {}.".format(duration_type, MAX_SAFE_INTEGER),
+                    }
+            except ValueError:
+                return {
+                    "code": "invalid_argument",
+                    "message": "{} duration must be an integer value.".format(duration_type),
+                }
+
+        purge_check = check_duration("purge_duration", bundle)
+        if purge_check:
+            return purge_check
+
+        report_check = check_duration("report_duration", bundle)
+        if report_check:
+            return report_check
+
         try:
             purge_duration = bundle.data.get("purge_duration") and get_bundle_int_val(bundle.data.get("purge_duration"))
             if purge_duration > MAX_SAFE_INTEGER:

--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -30,7 +30,7 @@ MAX_SAFE_INTEGER = 9007199254740991
 
 
 class RunStratagemValidation(Validation):
-    def _check_duration(duration_key, bundle):
+    def _check_duration(self, duration_key, bundle):
             duration_type = duration_key.split("_")[0].capitalize()
             try:
                 duration = bundle.data.get(duration_key) and get_bundle_int_val(bundle.data.get(duration_key))

--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -26,106 +26,159 @@ from chroma_core.models import (
 from chroma_api.chroma_model_resource import ChromaModelResource
 
 get_bundle_int_val = compose(partial(flip, int, 10), str)
+
 MAX_SAFE_INTEGER = 9007199254740991
 
 
+def get_duration_type(duration_key):
+    return duration_key.split("_")[0].capitalize()
+
+
+def get_duration(duration_key, bundle):
+    try:
+        duration = bundle.data.get(duration_key) and get_bundle_int_val(bundle.data.get(duration_key))
+    except ValueError:
+        return {
+            "code": "invalid_argument",
+            "message": "{} duration must be an integer value.".format(get_duration_type(duration_key)),
+        }
+
+    return duration
+
+
+def validate_duration(bundle, result):
+    def check_duration(duration_key, bundle):
+        duration = get_duration(duration_key, bundle)
+        if isinstance(duration, dict):
+            return duration
+
+        if duration > MAX_SAFE_INTEGER:
+            return {
+                "code": "{}_too_big".format(duration_key),
+                "message": "{} duration cannot be larger than {}.".format(
+                    get_duration_type(duration_key), MAX_SAFE_INTEGER
+                ),
+            }
+
+        return duration
+
+    if result:
+        return result
+
+    purge_duration = check_duration("purge_duration", bundle)
+    if isinstance(purge_duration, dict):
+        return purge_duration
+
+    report_duration = check_duration("report_duration", bundle)
+    if isinstance(report_duration, dict):
+        return report_duration
+
+    if purge_duration is not None and report_duration is not None and report_duration >= purge_duration:
+        return {"code": "duration_order_error", "message": "Report duration must be less than Purge duration."}
+
+
+def get_fs_id(bundle):
+    if "filesystem" not in bundle.data:
+        return ({"code": "filesystem_required", "message": "Filesystem required."}, None)
+
+    fs_identifier = str(bundle.data.get("filesystem"))
+    fs_id = get_fs_id_from_identifier(fs_identifier)
+
+    return (fs_identifier, fs_id)
+
+
+def validate_filesystem(bundle, result):
+    if result:
+        return result
+
+    (fs_identifier, fs_id) = get_fs_id(bundle)
+    if isinstance(fs_identifier, dict):
+        return fs_identifier
+
+    if fs_id is None:
+        return {"code": "filesystem_does_not_exist", "message": "Filesystem {} does not exist.".format(fs_identifier)}
+    elif ManagedFilesystem.objects.get(id=fs_id).state != "available":
+        return {"code": "filesystem_unavailable", "message": "Filesystem {} is unavailable.".format(fs_identifier)}
+
+
+def get_target_mount_ids(fs_id, bundle):
+    # At least Mdt 0 should be mounted, or stratagem cannot run.
+    target_mount_ids = (
+        ManagedMdt.objects.filter(filesystem_id=fs_id, active_mount_id__isnull=False)
+        .values_list("active_mount_id", flat=True)
+        .distinct()
+    )
+
+    return target_mount_ids
+
+
+def validate_target_mount(bundle, result):
+    if result:
+        return result
+
+    (r, fs_id) = get_fs_id(bundle)
+    if isinstance(r, dict):
+        return r
+
+    # At least Mdt 0 should be mounted, or stratagem cannot run.
+    target_mount_ids = get_target_mount_ids(fs_id, bundle)
+    mdt0 = ManagedMdt.objects.filter(filesystem_id=fs_id, name__contains="MDT0000").first()
+
+    if mdt0 is None:
+        return {"code": "mdt0_not_found", "message": "MDT0 could not be found."}
+
+    if mdt0.active_mount_id not in target_mount_ids:
+        return {"code": "mdt0_not_mounted", "message": "MDT0 must be mounted in order to run stratagem."}
+
+
+def validate_mdt_profile(bundle, result):
+    if result:
+        return result
+
+    (r, fs_id) = get_fs_id(bundle)
+    if isinstance(r, dict):
+        return r
+
+    # At least Mdt 0 should be mounted, or stratagem cannot run.
+    target_mount_ids = get_target_mount_ids(fs_id, bundle)
+
+    host_ids = ManagedTargetMount.objects.filter(id__in=target_mount_ids).values_list("host_id", flat=True).distinct()
+
+    installed_profiles = (
+        ManagedHost.objects.filter(id__in=host_ids).values_list("server_profile_id", flat=True).distinct()
+    )
+
+    if not all(map(lambda name: name == "stratagem_server", installed_profiles)):
+        return {
+            "code": "stratagem_server_profile_not_installed",
+            "message": "'stratagem_server' profile must be installed on all MDT servers.",
+        }
+
+
+def validate_client_profile(bundle, result):
+    if result:
+        return result
+
+    if not ManagedHost.objects.filter(server_profile_id="stratagem_client").exists():
+        return {
+            "code": "stratagem_client_profile_not_installed",
+            "message": "A client must be added with the 'Stratagem Client' profile to run this command.",
+        }
+
+
 class RunStratagemValidation(Validation):
-    def _check_duration(self, duration_key, bundle):
-            duration_type = duration_key.split("_")[0].capitalize()
-            try:
-                duration = bundle.data.get(duration_key) and get_bundle_int_val(bundle.data.get(duration_key))
-                if duration > MAX_SAFE_INTEGER:
-                    return {
-                        "code": "{}_too_big".format(duration_key),
-                        "message": "{} duration cannot be larger than {}.".format(duration_type, MAX_SAFE_INTEGER),
-                    }
-            except ValueError:
-                return {
-                    "code": "invalid_argument",
-                    "message": "{} duration must be an integer value.".format(duration_type),
-                }
-
     def is_valid(self, bundle, request=None):
-        purge_check = self._check_duration("purge_duration", bundle)
-        if purge_check:
-            return purge_check
-
-        report_check = self._check_duration("report_duration", bundle)
-        if report_check:
-            return report_check
-
-        try:
-            purge_duration = bundle.data.get("purge_duration") and get_bundle_int_val(bundle.data.get("purge_duration"))
-            if purge_duration > MAX_SAFE_INTEGER:
-                return {
-                    "code": "purge_duration_too_big",
-                    "message": "Purge duration cannot be larger than {}.".format(MAX_SAFE_INTEGER),
-                }
-        except ValueError:
-            return {"code": "invalid_argument", "message": "Purge duration must be an integer value."}
-
-        try:
-            report_duration = bundle.data.get("report_duration") and get_bundle_int_val(
-                bundle.data.get("report_duration")
+        return (
+            pipe(
+                None,
+                partial(validate_duration, bundle),
+                partial(validate_filesystem, bundle),
+                partial(validate_target_mount, bundle),
+                partial(validate_mdt_profile, bundle),
+                partial(validate_client_profile, bundle),
             )
-            if report_duration > MAX_SAFE_INTEGER:
-                return {
-                    "code": "report_duration_too_big",
-                    "message": "Report duration cannot be larger than {}.".format(MAX_SAFE_INTEGER),
-                }
-        except ValueError:
-            return {"code": "invalid_argument", "message": "Report duration must be an integer value."}
-
-        if "filesystem" not in bundle.data:
-            return {"code": "filesystem_required", "message": "Filesystem required."}
-        elif purge_duration is not None and report_duration is not None and report_duration >= purge_duration:
-            return {"code": "duration_order_error", "message": "Report time must be less than purge time."}
-
-        fs_identifier = str(bundle.data.get("filesystem"))
-        fs_id = get_fs_id_from_identifier(fs_identifier)
-        if fs_id is None:
-            return {
-                "code": "filesystem_does_not_exist",
-                "message": "Filesystem {} does not exist.".format(fs_identifier),
-            }
-        elif ManagedFilesystem.objects.get(id=fs_id).state != "available":
-            return {"code": "filesystem_unavailable", "message": "Filesystem {} is unavailable.".format(fs_identifier)}
-
-        # At least Mdt 0 should be mounted, or stratagem cannot run.
-        target_mount_ids = (
-            ManagedMdt.objects.filter(filesystem_id=fs_id, active_mount_id__isnull=False)
-            .values_list("active_mount_id", flat=True)
-            .distinct()
+            or {}
         )
-        mdt0 = ManagedMdt.objects.filter(filesystem_id=fs_id, name__contains="MDT0000").first()
-
-        if mdt0 is None:
-            return {"code": "mdt0_not_found", "message": "MDT0 could not be found."}
-
-        if mdt0.active_mount_id not in target_mount_ids:
-            return {"code": "mdt0_not_mounted", "message": "MDT0 must be mounted in order to run stratagem."}
-
-        host_ids = (
-            ManagedTargetMount.objects.filter(id__in=target_mount_ids).values_list("host_id", flat=True).distinct()
-        )
-
-        installed_profiles = (
-            ManagedHost.objects.filter(id__in=host_ids).values_list("server_profile_id", flat=True).distinct()
-        )
-
-        if not all(map(lambda name: name == "stratagem_server", installed_profiles)):
-            return {
-                "code": "stratagem_server_profile_not_installed",
-                "message": "'stratagem_servers' profile must be installed on all MDT servers.",
-            }
-
-        if not ManagedHost.objects.filter(server_profile_id="stratagem_client").exists():
-            return {
-                "code": "stratagem_client_profile_not_installed",
-                "message": "A client must be added with the 'Stratagem Client' profile to run this command.",
-            }
-
-        return {}
 
 
 class StratagemConfigurationValidation(RunStratagemValidation):
@@ -199,8 +252,7 @@ class RunStratagemResource(Resource):
 
     @validate
     def obj_create(self, bundle, **kwargs):
-        fs_identifier = bundle.data.get("filesystem")
-        fs_id = get_fs_id_from_identifier(fs_identifier)
+        (_, fs_id) = get_fs_id(bundle)
 
         mdts = list(
             ManagedMdt.objects.filter(filesystem_id=fs_id, active_mount_id__isnull=False).values_list("id", flat=True)

--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.db.models import Q
 from django.core.exceptions import ObjectDoesNotExist
-from toolz.functoolz import pipe, partial, flip, compose
+from toolz.functoolz import partial, flip, compose
 
 import tastypie.http as http
 

--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -30,8 +30,7 @@ MAX_SAFE_INTEGER = 9007199254740991
 
 
 class RunStratagemValidation(Validation):
-    def is_valid(self, bundle, request=None):
-        def check_duration(duration_key, bundle):
+    def _check_duration(duration_key, bundle):
             duration_type = duration_key.split("_")[0].capitalize()
             try:
                 duration = bundle.data.get(duration_key) and get_bundle_int_val(bundle.data.get(duration_key))
@@ -46,11 +45,12 @@ class RunStratagemValidation(Validation):
                     "message": "{} duration must be an integer value.".format(duration_type),
                 }
 
-        purge_check = check_duration("purge_duration", bundle)
+    def is_valid(self, bundle, request=None):
+        purge_check = self._check_duration("purge_duration", bundle)
         if purge_check:
             return purge_check
 
-        report_check = check_duration("report_duration", bundle)
+        report_check = self._check_duration("report_duration", bundle)
         if report_check:
             return report_check
 

--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -42,10 +42,10 @@ class StratagemConfiguration(StatefulObject):
         help_text="The filesystem id associated with the stratagem configuration", null=False
     )
     interval = models.IntegerField(help_text="Interval value in seconds between each stratagem execution", null=False)
-    report_duration = models.IntegerField(
+    report_duration = models.BigIntegerField(
         help_text="Interval value in seconds between stratagem report execution", null=True
     )
-    purge_duration = models.IntegerField(help_text="Interval value in seconds between stratagem purges", null=True)
+    purge_duration = models.BigIntegerField(help_text="Interval value in seconds between stratagem purges", null=True)
 
     states = ["unconfigured", "configured"]
     initial_state = "unconfigured"
@@ -200,8 +200,8 @@ class StreamFidlistStep(Step):
 class RunStratagemJob(Job):
     mdt_id = models.IntegerField()
     uuid = models.CharField(max_length=64, null=False, default="")
-    report_duration = models.IntegerField(null=True)
-    purge_duration = models.IntegerField(null=True)
+    report_duration = models.BigIntegerField(null=True)
+    purge_duration = models.BigIntegerField(null=True)
     fqdn = models.CharField(max_length=255, null=False, default="")
     target_name = models.CharField(max_length=64, null=False, default="")
     filesystem_type = models.CharField(max_length=32, null=False, default="")
@@ -338,8 +338,8 @@ class SendResultsToClientStep(Step):
 
 class SendStratagemResultsToClientJob(Job):
     uuid = models.CharField(max_length=64, null=False, default="")
-    report_duration = models.IntegerField(null=True)
-    purge_duration = models.IntegerField(null=True)
+    report_duration = models.BigIntegerField(null=True)
+    purge_duration = models.BigIntegerField(null=True)
 
     class Meta:
         app_label = "chroma_core"

--- a/chroma_core/south_migrations/0046_auto__add_sendstratagemresultstoclientjob__add_stratagemconfiguration_.py
+++ b/chroma_core/south_migrations/0046_auto__add_sendstratagemresultstoclientjob__add_stratagemconfiguration_.py
@@ -12,8 +12,8 @@ class Migration(SchemaMigration):
         db.create_table(u'chroma_core_sendstratagemresultstoclientjob', (
             (u'job_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['chroma_core.Job'], unique=True, primary_key=True)),
             ('uuid', self.gf('django.db.models.fields.CharField')(default='', max_length=64)),
-            ('report_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
-            ('purge_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('report_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
+            ('purge_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
         ))
         db.send_create_signal('chroma_core', ['SendStratagemResultsToClientJob'])
 
@@ -25,8 +25,8 @@ class Migration(SchemaMigration):
             ('immutable_state', self.gf('django.db.models.fields.BooleanField')(default=False)),
             ('filesystem_id', self.gf('django.db.models.fields.IntegerField')()),
             ('interval', self.gf('django.db.models.fields.IntegerField')()),
-            ('report_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
-            ('purge_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('report_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
+            ('purge_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
         ))
         db.send_create_signal('chroma_core', ['StratagemConfiguration'])
 
@@ -35,8 +35,8 @@ class Migration(SchemaMigration):
             (u'job_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['chroma_core.Job'], unique=True, primary_key=True)),
             ('mdt_id', self.gf('django.db.models.fields.IntegerField')()),
             ('uuid', self.gf('django.db.models.fields.CharField')(default='', max_length=64)),
-            ('report_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
-            ('purge_duration', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('report_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
+            ('purge_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
             ('fqdn', self.gf('django.db.models.fields.CharField')(default='', max_length=255)),
             ('target_name', self.gf('django.db.models.fields.CharField')(default='', max_length=64)),
             ('filesystem_type', self.gf('django.db.models.fields.CharField')(default='', max_length=32)),
@@ -944,10 +944,10 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'RegistrationToken'},
             'cancelled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'credits': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
-            'expiry': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 6, 27, 0, 0)'}),
+            'expiry': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 7, 11, 0, 0)'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.ServerProfile']", 'null': 'True'}),
-            'secret': ('django.db.models.fields.CharField', [], {'default': "'70B7B08EEAE2E7CF6983FA7435181B0F'", 'max_length': '32'})
+            'secret': ('django.db.models.fields.CharField', [], {'default': "'5941B545140E441241410BE77D97EAD1'", 'max_length': '32'})
         },
         'chroma_core.removeconfiguredtargetjob': {
             'Meta': {'ordering': "['id']", 'object_name': 'RemoveConfiguredTargetJob'},
@@ -1015,8 +1015,8 @@ class Migration(SchemaMigration):
             'fqdn': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255'}),
             u'job_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['chroma_core.Job']", 'unique': 'True', 'primary_key': 'True'}),
             'mdt_id': ('django.db.models.fields.IntegerField', [], {}),
-            'purge_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
-            'report_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'purge_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
+            'report_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
             'target_mount_point': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '512'}),
             'target_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64'}),
             'uuid': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64'})
@@ -1059,8 +1059,8 @@ class Migration(SchemaMigration):
         'chroma_core.sendstratagemresultstoclientjob': {
             'Meta': {'ordering': "['id']", 'object_name': 'SendStratagemResultsToClientJob', '_ormbases': ['chroma_core.Job']},
             u'job_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['chroma_core.Job']", 'unique': 'True', 'primary_key': 'True'}),
-            'purge_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
-            'report_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'purge_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
+            'report_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
             'uuid': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '64'})
         },
         'chroma_core.series': {
@@ -1374,8 +1374,8 @@ class Migration(SchemaMigration):
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'immutable_state': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'interval': ('django.db.models.fields.IntegerField', [], {}),
-            'purge_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
-            'report_duration': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'purge_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
+            'report_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),
             'state': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
             'state_modified_at': ('django.db.models.fields.DateTimeField', [], {})
         },

--- a/iml-manager-cli/src/manager_cli_error.rs
+++ b/iml-manager-cli/src/manager_cli_error.rs
@@ -17,6 +17,8 @@ pub enum RunStratagemCommandResult {
     FilesystemDoesNotExist,
     FilesystemUnavailable,
     InvalidArgument,
+    PurgeDurationTooBig,
+    ReportDurationTooBig,
     Mdt0NotFound,
     Mdt0NotMounted,
     StratagemServerProfileNotInstalled,

--- a/iml-manager-cli/src/manager_cli_error.rs
+++ b/iml-manager-cli/src/manager_cli_error.rs
@@ -23,6 +23,7 @@ pub enum RunStratagemCommandResult {
     Mdt0NotMounted,
     StratagemServerProfileNotInstalled,
     StratagemClientProfileNotInstalled,
+    RequiredFieldsMissing,
     ServerError,
     UnknownError,
 }


### PR DESCRIPTION
Fixes #1062.

GH-1062 - Stratagem duratiion models should be bigint
    
    Since milleseconds will be used for duration and it's possible that a
    number of years could be specified, the fields should be of the
    BigInteger type instead of Integer. This patch will ensure that:
    1. The duration fields on the models use BigInteger
    2. The API will handle hydrating and dehydrating data from String to
    BigInteger such that data is stored as a u64 in the database and
    retrieved as a long instead of a string (Tastypie does not support
        BigInteger in resources so it must be converted to a long)
    3. Validation is added to ensure that no value > MAX_SAFE_INTEGER (9007199254740991)
      can be used for either duration.
    
Signed-off-by: Will Johnson <wjohnson@whamcloud.com>