### PR TITLE
GH-1050 - Create grafana chart iframe and iml-stratagem module

### DIFF
--- a/iml-wasm-components/Cargo.lock
+++ b/iml-wasm-components/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
 name = "iml-grafana-chart"
 version = "0.1.0"
 dependencies = [
+ "iml-environment 0.1.0",
  "seed 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/iml-wasm-components/Cargo.lock
+++ b/iml-wasm-components/Cargo.lock
@@ -321,6 +321,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "iml-grafana-chart"
+version = "0.1.0"
+dependencies = [
+ "seed 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "iml-lock-indicator"
 version = "0.1.0"
 dependencies = [
@@ -348,6 +355,14 @@ dependencies = [
  "seed 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iml-stratagem"
+version = "0.1.0"
+dependencies = [
+ "iml-grafana-chart 0.1.0",
+ "seed 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/iml-wasm-components/Cargo.toml
+++ b/iml-wasm-components/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     'iml-environment',
     'iml-lock-indicator',
     'iml-pie-chart',
+    'iml-grafana-chart',
+    'iml-stratagem',
     'iml-sleep',
     'iml-toggle',
     'iml-tooltip',

--- a/iml-wasm-components/iml-environment/src/lib.rs
+++ b/iml-wasm-components/iml-environment/src/lib.rs
@@ -6,10 +6,10 @@ use seed::document;
 
 /// Returns https://<domain>:<port>/ui/
 pub fn ui_root() -> String {
-  document().base_uri().unwrap().unwrap_or_default()
+    document().base_uri().unwrap().unwrap_or_default()
 }
 
 /// Returns https://<domain>:<port>/grafana/
 pub fn grafana_root() -> String {
-  ui_root().replace("/ui/", "/grafana/")
+    ui_root().replace("/ui/", "/grafana/")
 }

--- a/iml-wasm-components/iml-environment/src/lib.rs
+++ b/iml-wasm-components/iml-environment/src/lib.rs
@@ -4,13 +4,12 @@
 
 use seed::document;
 
-/// Will return https://<domain>:<port>/ui/
+/// Returns https://<domain>:<port>/ui/
 pub fn ui_root() -> String {
   document().base_uri().unwrap().unwrap_or_default()
 }
 
-/// Will return https://<domain>:<port>/grafana/
+/// Returns https://<domain>:<port>/grafana/
 pub fn grafana_root() -> String {
-  let url = document().base_uri().unwrap().unwrap_or_default();
-  url.replace("/ui/", "/grafana/")
+  ui_root().replace("/ui/", "/grafana/")
 }

--- a/iml-wasm-components/iml-environment/src/lib.rs
+++ b/iml-wasm-components/iml-environment/src/lib.rs
@@ -4,6 +4,13 @@
 
 use seed::document;
 
+/// Will return https://<domain>:<port>/ui/
 pub fn ui_root() -> String {
-    document().base_uri().unwrap().unwrap_or_default()
+  document().base_uri().unwrap().unwrap_or_default()
+}
+
+/// Will return https://<domain>:<port>/grafana/
+pub fn grafana_root() -> String {
+  let url = document().base_uri().unwrap().unwrap_or_default();
+  url.replace("/ui/", "/grafana/")
 }

--- a/iml-wasm-components/iml-grafana-chart/Cargo.toml
+++ b/iml-wasm-components/iml-grafana-chart/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "iml-grafana-chart"
+version = "0.1.0"
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+
+[dependencies]
+seed = "=0.3.7"

--- a/iml-wasm-components/iml-grafana-chart/Cargo.toml
+++ b/iml-wasm-components/iml-grafana-chart/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 seed = "=0.3.7"
+iml-environment = { path = "../iml-environment", version = "0.1" }

--- a/iml-wasm-components/iml-grafana-chart/src/lib.rs
+++ b/iml-wasm-components/iml-grafana-chart/src/lib.rs
@@ -2,16 +2,22 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use seed::{iframe, attrs, prelude::*};
+use iml_environment::grafana_root;
+use seed::{attrs, iframe, prelude::*};
 
 /// Create an iframe that loads the specified stratagem chart
-pub fn grafana_chart<T>(dashboard_id: &str, dashboard_name: &str, refresh: &str, panel_id: u16, width: &str, height: &str) -> El<T> {
-    iframe![
-        attrs! { 
-            At::Src => format!("https://localhost:8443/grafana/d-solo/{}/{}?orgId=1&refresh={}&panelId={}", dashboard_id, dashboard_name, refresh, panel_id),
-            At::Width => width,
-            At::Height => height,
-            "frameborder" => 0
-         }
-    ]
+pub fn grafana_chart<T>(
+    dashboard_id: &str,
+    dashboard_name: &str,
+    refresh: &str,
+    panel_id: u16,
+    width: &str,
+    height: &str,
+) -> El<T> {
+    iframe![attrs! {
+       At::Src => format!("{}d-solo/{}/{}?orgId=1&refresh={}&panelId={}", grafana_root(), dashboard_id, dashboard_name, refresh, panel_id),
+       At::Width => width,
+       At::Height => height,
+       "frameborder" => 0
+    }]
 }

--- a/iml-wasm-components/iml-grafana-chart/src/lib.rs
+++ b/iml-wasm-components/iml-grafana-chart/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use seed::{iframe, attrs, prelude::*};
+
+/// Create an iframe that loads the specified stratagem chart
+pub fn grafana_chart<T>(dashboard_id: &str, dashboard_name: &str, refresh: &str, panel_id: u16, width: &str, height: &str) -> El<T> {
+    iframe![
+        attrs! { 
+            At::Src => format!("https://localhost:8443/grafana/d-solo/{}/{}?orgId=1&refresh={}&panelId={}", dashboard_id, dashboard_name, refresh, panel_id),
+            At::Width => width,
+            At::Height => height,
+            "frameborder" => 0
+         }
+    ]
+}

--- a/iml-wasm-components/iml-stratagem/Cargo.toml
+++ b/iml-wasm-components/iml-stratagem/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "iml-stratagem"
+version = "0.1.0"
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+
+[dependencies]
+seed = "=0.3.7"
+iml-grafana-chart = { path = "../iml-grafana-chart", version = "0.1" }

--- a/iml-wasm-components/iml-stratagem/src/lib.rs
+++ b/iml-wasm-components/iml-stratagem/src/lib.rs
@@ -1,0 +1,9 @@
+use iml_grafana_chart::grafana_chart;
+use seed::prelude::*;
+
+static DASHBOARD_ID: &str = "OBdCS5IWz";
+static DASHBOARD_NAME: &str = "stratagem";
+
+pub fn size_distribution_chart_view<T>() -> El<T> {
+  grafana_chart(DASHBOARD_ID, DASHBOARD_NAME, "10s", 2, "100%", "600")
+}

--- a/iml-wasm-components/iml-stratagem/src/lib.rs
+++ b/iml-wasm-components/iml-stratagem/src/lib.rs
@@ -4,6 +4,6 @@ use seed::prelude::*;
 static DASHBOARD_ID: &str = "OBdCS5IWz";
 static DASHBOARD_NAME: &str = "stratagem";
 
-pub fn size_distribution_chart_view<T>() -> El<T> {
+pub fn size_distribution_chart<T>() -> El<T> {
     grafana_chart(DASHBOARD_ID, DASHBOARD_NAME, "10s", 2, "100%", "600")
 }

--- a/iml-wasm-components/iml-stratagem/src/lib.rs
+++ b/iml-wasm-components/iml-stratagem/src/lib.rs
@@ -5,5 +5,5 @@ static DASHBOARD_ID: &str = "OBdCS5IWz";
 static DASHBOARD_NAME: &str = "stratagem";
 
 pub fn size_distribution_chart_view<T>() -> El<T> {
-  grafana_chart(DASHBOARD_ID, DASHBOARD_NAME, "10s", 2, "100%", "600")
+    grafana_chart(DASHBOARD_ID, DASHBOARD_NAME, "10s", 2, "100%", "600")
 }


### PR DESCRIPTION
Fixes #1050.

Grafana charts will be inserted via an iframe. Create the `iml-grafana`
module that will return an iframe that loads the specified chart. Also
create the `iml-stratagem` module with a view function to load the size
distribution chart.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>