### PR TITLE
Statagem timer re-add removes old timer

### DIFF
--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -79,6 +79,9 @@ class ConfigureStratagemTimerStep(Step, CommandLine):
         timer_file = "/etc/systemd/system/{}.timer".format(name)
         service_file = "/etc/systemd/system/{}.service".format(name)
 
+        if os.path.exists(timer_file):
+            self.try_shell(["systemctl", "disable", "--now", "{}.timer".format(name)])
+
         with open(timer_file, "w") as fn:
             fn.write(
                 "#  This file is part of IML\n"


### PR DESCRIPTION
If you re-add a timer, the old timer should be removed.  This allows "updating" a timer via running add a second time.

Fixes #1099

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>