### PR TITLE
Make sure stratagem configuration is removed when fs is forgotten.

### DIFF
--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -191,7 +191,7 @@ class StratagemConfigurationValidation(RunStratagemValidation):
 
 
 class StratagemConfigurationResource(StatefulModelResource):
-    filesystem = fields.CharField(attribute="filesystem_id", null=False)
+    filesystem = fields.CharField(null=False)
     interval = fields.CharField(attribute="interval", null=False)
     report_duration = fields.CharField("report_duration", null=True)
     purge_duration = fields.CharField(attribute="purge_duration", null=True)
@@ -243,7 +243,7 @@ class StratagemConfigurationResource(StatefulModelResource):
         list_allowed_methods = ["get", "post"]
         detail_allowed_methods = ["get", "put", "delete"]
         validation = StratagemConfigurationValidation()
-        filtering = {"filesystem_id": ["exact"]}
+        filtering = {"filesystem": ["exact"]}
 
     @validate
     def obj_update(self, bundle, **kwargs):

--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -86,11 +86,10 @@ class StratagemConfiguration(StatefulObject):
         app_label = "chroma_core"
         ordering = ["id"]
 
-    @classmethod
-    def filter_by_fs(cls, fs):
+    def filter_by_fs(fs):
         return ObjectCache.get(StratagemConfiguration, lambda sc, fs=fs: sc.filesystem.id == fs.id)
 
-    reverse_deps = {"ManagedFilesystem": lambda mfs: StratagemConfiguration.filter_by_fs(mfs)}
+    reverse_deps = {"ManagedFilesystem": filter_by_fs}
 
 
 class ConfigureStratagemTimerStep(Step, CommandLine):
@@ -204,6 +203,7 @@ class UnconfigureStratagemJob(StateChangeJob):
         steps = [(UnconfigureStratagemTimerStep, {"config": self.stratagem_configuration})]
 
         return steps
+
 
 class ForgetStratagemConfigurationJob(StateChangeJob):
     class Meta:

--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -32,6 +32,7 @@ from chroma_core.models import (
     AlertEvent,
     ManagedHost,
     ManagedMdt,
+    ManagedFilesystem,
     ManagedTarget,
     ManagedTargetMount,
     Volume,
@@ -41,9 +42,7 @@ from chroma_core.models import (
 
 
 class StratagemConfiguration(StatefulObject):
-    filesystem_id = models.IntegerField(
-        help_text="The filesystem id associated with the stratagem configuration", null=False
-    )
+    filesystem = models.ForeignKey("ManagedFilesystem", null=False)
     interval = models.BigIntegerField(
         help_text="Interval value in milliseconds between each stratagem execution", null=False
     )
@@ -57,6 +56,27 @@ class StratagemConfiguration(StatefulObject):
     def get_label(self):
         return "Stratagem Configuration"
 
+    def get_deps(self, state=None):
+        if not state:
+            state = self.state
+
+        deps = []
+        if state != "removed":
+            # Depend on the filesystem being available.
+            deps.append(DependOn(self.filesystem, "available", fix_state="unconfigured"))
+
+            # move to the removed state if the filesystem is removed.
+            deps.append(
+                DependOn(
+                    self.filesystem,
+                    "available",
+                    acceptable_states=list(set(self.filesystem.states) - set(["removed", "forgotten"])),
+                    fix_state="removed",
+                )
+            )
+
+        return DependAll(deps)
+
     states = ["unconfigured", "configured", "removed"]
     initial_state = "unconfigured"
 
@@ -65,6 +85,12 @@ class StratagemConfiguration(StatefulObject):
     class Meta:
         app_label = "chroma_core"
         ordering = ["id"]
+
+    @classmethod
+    def filter_by_fs(cls, fs):
+        return ObjectCache.get(StratagemConfiguration, lambda sc, fs=fs: sc.filesystem.id == fs.id)
+
+    reverse_deps = {"ManagedFilesystem": lambda mfs: StratagemConfiguration.filter_by_fs(mfs)}
 
 
 class ConfigureStratagemTimerStep(Step, CommandLine):
@@ -87,10 +113,10 @@ class ConfigureStratagemTimerStep(Step, CommandLine):
                 "Description=Start Stratagem run on {}\n"
                 "\n[Timer]\n"
                 "OnBootSec={}\n"
-                "OnUnitActiveSec={}\n".format(config.filesystem_id, config.interval / 1000, config.interval / 1000)
+                "OnUnitActiveSec={}\n".format(config.filesystem.id, config.interval / 1000, config.interval / 1000)
             )
 
-        iml_cmd = "/usr/bin/iml stratagem scan --filesystem {}".format(config.filesystem_id)
+        iml_cmd = "/usr/bin/iml stratagem scan --filesystem {}".format(config.filesystem.id)
         if config.report_duration is not None and config.report_duration > 0:
             iml_cmd += " --report {}s".format(config.report_duration / 1000)
         if config.purge_duration is not None and config.purge_duration > 0:
@@ -104,7 +130,7 @@ class ConfigureStratagemTimerStep(Step, CommandLine):
                 "After=iml-manager.target\n"
                 "\n[Service]\n"
                 "Type=oneshot\n"
-                "ExecStart={}\n".format(config.filesystem_id, iml_cmd)
+                "ExecStart={}\n".format(config.filesystem.id, iml_cmd)
             )
         self.try_shell(["systemctl", "daemon-reload"])
         self.try_shell(["systemctl", "enable", "--now", "{}.timer".format(name)])
@@ -178,6 +204,32 @@ class UnconfigureStratagemJob(StateChangeJob):
         steps = [(UnconfigureStratagemTimerStep, {"config": self.stratagem_configuration})]
 
         return steps
+
+class ForgetStratagemConfigurationJob(StateChangeJob):
+    class Meta:
+        app_label = "chroma_core"
+        ordering = ["id"]
+
+    @classmethod
+    def long_description(cls, self):
+        return "Forget the stratagem configuration for filesystem"
+
+    def description(self):
+        return self.long_description(self)
+
+    def get_requires_confirmation(self):
+        return True
+
+    def on_success(self):
+        self.stratagem_configuration.mark_deleted()
+        job_log.debug("forgetting stratagem configuration")
+
+        super(ForgetStratagemConfigurationJob, self).on_success()
+
+    state_transition = StateChangeJob.StateTransition(StratagemConfiguration, "unconfigured", "removed")
+    stateful_object = "stratagem_configuration"
+    stratagem_configuration = models.ForeignKey(StratagemConfiguration)
+    state_verb = "Forget"
 
 
 class DeleteStratagemStep(Step):

--- a/chroma_core/services/job_scheduler/job_scheduler.py
+++ b/chroma_core/services/job_scheduler/job_scheduler.py
@@ -1769,25 +1769,25 @@ class JobScheduler(object):
         with self._lock:
             configuration_data = {
                 "state": "unconfigured",
-                "filesystem_id": stratagem_data.get("filesystem"),
                 "interval": stratagem_data.get("interval"),
                 "report_duration": stratagem_data.get("report_duration"),
                 "purge_duration": stratagem_data.get("purge_duration"),
             }
 
             # The filesystem_id may come in as the fs name or the fs id. In terms of storing information in the database, the fs id should always be used.
-            fs_identifier = str(configuration_data.get("filesystem_id"))
+            fs_identifier = str(stratagem_data.get("filesystem"))
             fs_id = get_fs_id_from_identifier(fs_identifier)
 
             if not fs_id:
                 raise Exception("No matching filesystem for {}".format(fs_identifier))
 
-            configuration_data["filesystem_id"] = fs_id
+            managed_filesystem = ManagedFilesystem.objects.get(id=fs_id)
+            configuration_data["filesystem"] = managed_filesystem
 
-            matches = StratagemConfiguration.objects.filter(filesystem_id=fs_id)
+            matches = StratagemConfiguration.objects.filter(filesystem=managed_filesystem)
             if len(matches) == 1:
                 matches.update(**configuration_data)
-                stratagem_configuration = StratagemConfiguration.objects.get(filesystem_id=fs_id)
+                stratagem_configuration = StratagemConfiguration.objects.get(filesystem=managed_filesystem)
             else:
                 stratagem_configuration = StratagemConfiguration.objects.create(**configuration_data)
 

--- a/chroma_core/south_migrations/0046_auto__add_sendstratagemresultstoclientjob__add_stratagemconfiguration_.py
+++ b/chroma_core/south_migrations/0046_auto__add_sendstratagemresultstoclientjob__add_stratagemconfiguration_.py
@@ -39,13 +39,21 @@ class Migration(SchemaMigration):
             ('state_modified_at', self.gf('django.db.models.fields.DateTimeField')()),
             ('state', self.gf('django.db.models.fields.CharField')(max_length=32)),
             ('immutable_state', self.gf('django.db.models.fields.BooleanField')(default=False)),
-            ('filesystem_id', self.gf('django.db.models.fields.IntegerField')()),
+            ('filesystem', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['chroma_core.ManagedFilesystem'])),
             ('interval', self.gf('django.db.models.fields.BigIntegerField')()),
             ('report_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
             ('purge_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
             ('not_deleted', self.gf('django.db.models.fields.NullBooleanField')(default=True, null=True, blank=True)),
         ))
         db.send_create_signal('chroma_core', ['StratagemConfiguration'])
+
+        # Adding model 'ForgetStratagemConfigurationJob'
+        db.create_table(u'chroma_core_forgetstratagemconfigurationjob', (
+            (u'job_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['chroma_core.Job'], unique=True, primary_key=True)),
+            ('old_state', self.gf('django.db.models.fields.CharField')(max_length=32)),
+            ('stratagem_configuration', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['chroma_core.StratagemConfiguration'])),
+        ))
+        db.send_create_signal('chroma_core', ['ForgetStratagemConfigurationJob'])
 
         # Adding model 'RunStratagemJob'
         db.create_table(u'chroma_core_runstratagemjob', (
@@ -89,6 +97,9 @@ class Migration(SchemaMigration):
 
         # Deleting model 'StratagemConfiguration'
         db.delete_table(u'chroma_core_stratagemconfiguration')
+
+        # Deleting model 'ForgetStratagemConfigurationJob'
+        db.delete_table(u'chroma_core_forgetstratagemconfigurationjob')
 
         # Deleting model 'RunStratagemJob'
         db.delete_table(u'chroma_core_runstratagemjob')
@@ -524,6 +535,12 @@ class Migration(SchemaMigration):
             'filesystem': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.ManagedFilesystem']"}),
             u'job_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['chroma_core.Job']", 'unique': 'True', 'primary_key': 'True'}),
             'old_state': ('django.db.models.fields.CharField', [], {'max_length': '32'})
+        },
+        'chroma_core.forgetstratagemconfigurationjob': {
+            'Meta': {'ordering': "['id']", 'object_name': 'ForgetStratagemConfigurationJob'},
+            u'job_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['chroma_core.Job']", 'unique': 'True', 'primary_key': 'True'}),
+            'old_state': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'stratagem_configuration': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.StratagemConfiguration']"})
         },
         'chroma_core.forgettargetjob': {
             'Meta': {'ordering': "['id']", 'object_name': 'ForgetTargetJob'},
@@ -967,10 +984,10 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'RegistrationToken'},
             'cancelled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'credits': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
-            'expiry': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 7, 19, 0, 0)'}),
+            'expiry': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 7, 30, 0, 0)'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.ServerProfile']", 'null': 'True'}),
-            'secret': ('django.db.models.fields.CharField', [], {'default': "'F4B9EA6FBF20477770D20BE890195B19'", 'max_length': '32'})
+            'secret': ('django.db.models.fields.CharField', [], {'default': "'74FFD01032ECEB06D65A6FD1B48C50CD'", 'max_length': '32'})
         },
         'chroma_core.removeconfiguredtargetjob': {
             'Meta': {'ordering': "['id']", 'object_name': 'RemoveConfiguredTargetJob'},
@@ -1399,7 +1416,7 @@ class Migration(SchemaMigration):
         },
         'chroma_core.stratagemconfiguration': {
             'Meta': {'ordering': "['id']", 'object_name': 'StratagemConfiguration'},
-            'filesystem_id': ('django.db.models.fields.IntegerField', [], {}),
+            'filesystem': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.ManagedFilesystem']"}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'immutable_state': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'interval': ('django.db.models.fields.BigIntegerField', [], {}),


### PR DESCRIPTION
Fixes #1094.
- Forget stratagem configuration when forgetting in monitored mode
Fixes #1075.
- Add foregin key for filesystem in Stratagem Configuration model

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>