### PR TITLE
Start timer after interval from unit activation

### DIFF
--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -86,7 +86,7 @@ class ConfigureStratagemTimerStep(Step, CommandLine):
                 "\n[Unit]\n"
                 "Description=Start Stratagem run on {}\n"
                 "\n[Timer]\n"
-                "OnBootSec={}\n"
+                "OnActiveSec={}\n"
                 "OnUnitActiveSec={}\n".format(config.filesystem_id, config.interval / 1000, config.interval / 1000)
             )
 


### PR DESCRIPTION
Only start timer after unit start, not based on IML boot time.

Fixes #1117

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>