### PR TITLE
When forgetting the filesystem in Monitored mode, also forget Stratagem

### DIFF
--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -41,9 +41,7 @@ from chroma_core.models import (
 
 
 class StratagemConfiguration(StatefulObject):
-    filesystem_id = models.IntegerField(
-        help_text="The filesystem id associated with the stratagem configuration", null=False
-    )
+    filesystem = models.ForeignKey("ManagedFilesystem", null=False)
     interval = models.BigIntegerField(
         help_text="Interval value in milliseconds between each stratagem execution", null=False
     )
@@ -56,6 +54,32 @@ class StratagemConfiguration(StatefulObject):
 
     def get_label(self):
         return "Stratagem Configuration"
+
+    def get_deps(self, state=None):
+        if not state:
+            state = self.state
+
+        deps = []
+        if state != "removed":
+            # Depend on the filesystem being available.
+            deps.append(DependOn(self.filesystem, "available", fix_state="unconfigured"))
+
+            # move to the removed state if the filesystem is removed.
+            deps.append(
+                DependOn(
+                    self.filesystem,
+                    "available",
+                    acceptable_states=list(set(self.filesystem.states) - set(["removed", "forgotten"])),
+                    fix_state="removed",
+                )
+            )
+
+        return DependAll(deps)
+
+    def filter_by_fs(fs):
+        return ObjectCache.get(StratagemConfiguration, lambda sc, fs=fs: sc.filesystem.id == fs.id)
+
+    reverse_deps = {"ManagedFilesystem": filter_by_fs}
 
     states = ["unconfigured", "configured", "removed"]
     initial_state = "unconfigured"
@@ -94,10 +118,10 @@ class ConfigureStratagemTimerStep(Step, CommandLine):
                 "Description=Start Stratagem run on {}\n"
                 "\n[Timer]\n"
                 "OnActiveSec={}\n"
-                "OnUnitActiveSec={}\n".format(config.filesystem_id, config.interval / 1000, config.interval / 1000)
+                "OnUnitActiveSec={}\n".format(config.filesystem.id, config.interval / 1000, config.interval / 1000)
             )
 
-        iml_cmd = "/usr/bin/iml stratagem scan --filesystem {}".format(config.filesystem_id)
+        iml_cmd = "/usr/bin/iml stratagem scan --filesystem {}".format(config.filesystem.id)
         if config.report_duration is not None and config.report_duration > 0:
             iml_cmd += " --report {}s".format(config.report_duration / 1000)
         if config.purge_duration is not None and config.purge_duration > 0:
@@ -111,7 +135,7 @@ class ConfigureStratagemTimerStep(Step, CommandLine):
                 "After=iml-manager.target\n"
                 "\n[Service]\n"
                 "Type=oneshot\n"
-                "ExecStart={}\n".format(config.filesystem_id, iml_cmd)
+                "ExecStart={}\n".format(config.filesystem.id, iml_cmd)
             )
         self.try_shell(["systemctl", "daemon-reload"])
         self.try_shell(["systemctl", "enable", "--now", "{}.timer".format(unit_name(config.id))])
@@ -128,6 +152,33 @@ class UnconfigureStratagemTimerStep(Step, CommandLine):
         os.unlink(timer_file(config.id))
         os.unlink(service_file(config.id))
         self.try_shell(["systemctl", "daemon-reload"])
+
+
+class ForgetStratagemConfigurationJob(StateChangeJob):
+    class Meta:
+        app_label = "chroma_core"
+        ordering = ["id"]
+
+    @classmethod
+    def long_description(cls, self):
+        return "Forget the stratagem configuration for filesystem"
+
+    def description(self):
+        return self.long_description(self)
+
+    def get_requires_confirmation(self):
+        return True
+
+    def on_success(self):
+        self.stratagem_configuration.mark_deleted()
+        job_log.debug("forgetting stratagem configuration")
+
+        super(ForgetStratagemConfigurationJob, self).on_success()
+
+    state_transition = StateChangeJob.StateTransition(StratagemConfiguration, "unconfigured", "removed")
+    stateful_object = "stratagem_configuration"
+    stratagem_configuration = models.ForeignKey(StratagemConfiguration)
+    state_verb = "Forget"
 
 
 class ConfigureStratagemJob(StateChangeJob):
@@ -286,24 +337,16 @@ class RunStratagemStep(Step):
                         "rules": [
                             {
                                 "action": "LAT_COUNTER_INC",
-                                "expression": "&& < size 1048576 != type S_IFDIR",
-                                "argument": "SIZE < 1M",
-                            },
-                            {
-                                "action": "LAT_COUNTER_INC",
-                                "expression": "&& >= size 1048576000000 != type S_IFDIR",
+                                "expression": ">= size 1048576000000",
                                 "argument": "SIZE >= 1T",
                             },
+                            {"action": "LAT_COUNTER_INC", "expression": ">= size 1048576000", "argument": "SIZE >= 1G"},
                             {
                                 "action": "LAT_COUNTER_INC",
-                                "expression": "&& >= size 1048576000 != type S_IFDIR",
-                                "argument": "SIZE >= 1G",
-                            },
-                            {
-                                "action": "LAT_COUNTER_INC",
-                                "expression": "&& >= size 1048576 != type S_IFDIR",
+                                "expression": ">= size 1048576",
                                 "argument": "1M <= SIZE < 1G",
                             },
+                            {"action": "LAT_COUNTER_INC", "expression": "< size 1048576", "argument": "SIZE < 1M"},
                         ],
                         "name": "size_distribution",
                     },

--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -337,16 +337,24 @@ class RunStratagemStep(Step):
                         "rules": [
                             {
                                 "action": "LAT_COUNTER_INC",
-                                "expression": ">= size 1048576000000",
-                                "argument": "SIZE >= 1T",
+                                "expression": "&& < size 1048576 != type S_IFDIR",
+                                "argument": "SIZE < 1M",
                             },
-                            {"action": "LAT_COUNTER_INC", "expression": ">= size 1048576000", "argument": "SIZE >= 1G"},
                             {
                                 "action": "LAT_COUNTER_INC",
-                                "expression": ">= size 1048576",
+                                "expression": "&& >= size 1048576000000 != type S_IFDIR",
+                                "argument": "SIZE >= 1T",
+                            },
+                            {
+                                "action": "LAT_COUNTER_INC",
+                                "expression": "&& >= size 1048576000 != type S_IFDIR",
+                                "argument": "SIZE >= 1G",
+                            },
+                            {
+                                "action": "LAT_COUNTER_INC",
+                                "expression": "&& >= size 1048576 != type S_IFDIR",
                                 "argument": "1M <= SIZE < 1G",
                             },
-                            {"action": "LAT_COUNTER_INC", "expression": "< size 1048576", "argument": "SIZE < 1M"},
                         ],
                         "name": "size_distribution",
                     },

--- a/chroma_core/south_migrations/0046_auto__add_sendstratagemresultstoclientjob__add_stratagemconfiguration_.py
+++ b/chroma_core/south_migrations/0046_auto__add_sendstratagemresultstoclientjob__add_stratagemconfiguration_.py
@@ -39,13 +39,21 @@ class Migration(SchemaMigration):
             ('state_modified_at', self.gf('django.db.models.fields.DateTimeField')()),
             ('state', self.gf('django.db.models.fields.CharField')(max_length=32)),
             ('immutable_state', self.gf('django.db.models.fields.BooleanField')(default=False)),
-            ('filesystem_id', self.gf('django.db.models.fields.IntegerField')()),
+            ('filesystem', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['chroma_core.ManagedFilesystem'])),
             ('interval', self.gf('django.db.models.fields.BigIntegerField')()),
             ('report_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
             ('purge_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
             ('not_deleted', self.gf('django.db.models.fields.NullBooleanField')(default=True, null=True, blank=True)),
         ))
         db.send_create_signal('chroma_core', ['StratagemConfiguration'])
+
+        # Adding model 'ForgetStratagemConfigurationJob'
+        db.create_table(u'chroma_core_forgetstratagemconfigurationjob', (
+            (u'job_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['chroma_core.Job'], unique=True, primary_key=True)),
+            ('old_state', self.gf('django.db.models.fields.CharField')(max_length=32)),
+            ('stratagem_configuration', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['chroma_core.StratagemConfiguration'])),
+        ))
+        db.send_create_signal('chroma_core', ['ForgetStratagemConfigurationJob'])
 
         # Adding model 'RunStratagemJob'
         db.create_table(u'chroma_core_runstratagemjob', (
@@ -89,6 +97,9 @@ class Migration(SchemaMigration):
 
         # Deleting model 'StratagemConfiguration'
         db.delete_table(u'chroma_core_stratagemconfiguration')
+
+        # Deleting model 'ForgetStratagemConfigurationJob'
+        db.delete_table(u'chroma_core_forgetstratagemconfigurationjob')
 
         # Deleting model 'RunStratagemJob'
         db.delete_table(u'chroma_core_runstratagemjob')
@@ -524,6 +535,12 @@ class Migration(SchemaMigration):
             'filesystem': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.ManagedFilesystem']"}),
             u'job_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['chroma_core.Job']", 'unique': 'True', 'primary_key': 'True'}),
             'old_state': ('django.db.models.fields.CharField', [], {'max_length': '32'})
+        },
+        'chroma_core.forgetstratagemconfigurationjob': {
+            'Meta': {'ordering': "['id']", 'object_name': 'ForgetStratagemConfigurationJob'},
+            u'job_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['chroma_core.Job']", 'unique': 'True', 'primary_key': 'True'}),
+            'old_state': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'stratagem_configuration': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.StratagemConfiguration']"})
         },
         'chroma_core.forgettargetjob': {
             'Meta': {'ordering': "['id']", 'object_name': 'ForgetTargetJob'},
@@ -967,10 +984,10 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'RegistrationToken'},
             'cancelled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'credits': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
-            'expiry': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 7, 19, 0, 0)'}),
+            'expiry': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 7, 30, 0, 0)'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.ServerProfile']", 'null': 'True'}),
-            'secret': ('django.db.models.fields.CharField', [], {'default': "'F4B9EA6FBF20477770D20BE890195B19'", 'max_length': '32'})
+            'secret': ('django.db.models.fields.CharField', [], {'default': "'74FFD01032ECEB06D65A6FD1B48C50CD'", 'max_length': '32'})
         },
         'chroma_core.removeconfiguredtargetjob': {
             'Meta': {'ordering': "['id']", 'object_name': 'RemoveConfiguredTargetJob'},
@@ -1399,7 +1416,7 @@ class Migration(SchemaMigration):
         },
         'chroma_core.stratagemconfiguration': {
             'Meta': {'ordering': "['id']", 'object_name': 'StratagemConfiguration'},
-            'filesystem_id': ('django.db.models.fields.IntegerField', [], {}),
+            'filesystem': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.ManagedFilesystem']"}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'immutable_state': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'interval': ('django.db.models.fields.BigIntegerField', [], {}),

--- a/iml-manager-cli/src/stratagem.rs
+++ b/iml-manager-cli/src/stratagem.rs
@@ -227,7 +227,7 @@ pub fn stratagem_cli(command: StratagemCommand) {
                 .and_then(|fs: Filesystem| {
                     get(
                         StratagemConfiguration::endpoint_name(),
-                        serde_json::json!({ "filesystem_id": fs.id }),
+                        serde_json::json!({ "filesystem": fs.id }),
                     )
                 })
                 .and_then(first)

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -790,7 +790,6 @@ impl EndpointName for Alert {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct StratagemConfiguration {
     pub filesystem: String,
-    pub filesystem_id: u32,
     pub id: u32,
     pub immutable_state: bool,
     pub interval: u64,


### PR DESCRIPTION
Fixes #1094.

If Stratagem is configured for the fs, it should have it's UnconfigureStratagemJob run as part of the fs removal.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>