### PR TITLE
Enable / Update / Delete stratagem config should show command modal

### DIFF
--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -264,14 +264,14 @@ class StratagemConfigurationResource(StatefulModelResource):
 
     @validate
     def obj_update(self, bundle, **kwargs):
-        config = StratagemConfiguration.objects.get(pk=kwargs["pk"])
-        config.interval = bundle.data.get("interval")
-        config.report_duration = bundle.data.get("report_duration")
-        config.purge_duration = bundle.data.get("purge_duration")
-        config.save()
+        command_id = JobSchedulerClient.update_stratagem(bundle.data)
 
-        bundle.obj = config
-        return bundle
+        try:
+            command = Command.objects.get(pk=command_id)
+        except ObjectDoesNotExist:
+            command = None
+
+        raise custom_response(self, bundle.request, http.HttpAccepted, {"command": dehydrate_command(command)})
 
     @validate
     def obj_create(self, bundle, **kwargs):

--- a/chroma_core/services/job_scheduler/job_scheduler_client.py
+++ b/chroma_core/services/job_scheduler/job_scheduler_client.py
@@ -45,6 +45,7 @@ class JobSchedulerRpc(ServiceRpcInterface):
         "update_corosync_configuration",
         "get_transition_consequences",
         "configure_stratagem",
+        "update_stratagem",
         "run_stratagem",
     ]
 
@@ -258,6 +259,10 @@ class JobSchedulerClient(object):
     @classmethod
     def configure_stratagem(cls, stratagem_data):
         return JobSchedulerRpc().configure_stratagem(stratagem_data)
+
+    @classmethod
+    def update_stratagem(cls, stratagem_data):
+        return JobSchedulerRpc().update_stratagem(stratagem_data)
 
     @classmethod
     def run_stratagem(cls, mdts, stratagem_data):

--- a/iml-wasm-components/iml-duration-picker/duration-picker.rs
+++ b/iml-wasm-components/iml-duration-picker/duration-picker.rs
@@ -115,6 +115,8 @@ pub fn duration_picker(model: &Model, mut input: Node<Msg>) -> Vec<Node<Msg>> {
 
     if let Some(x) = model.value {
         input = input.add_attr(At::Value.as_str(), x);
+    } else {
+        input = input.add_attr(At::Value.as_str(), "");
     }
 
     if model.disabled {

--- a/iml-wasm-components/iml-fs/src/fs_detail_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_detail_page.rs
@@ -180,9 +180,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             }
         }
         Msg::CloseCommandModal => {
-            log::trace!("Closing command modal caught");
-            model.stratagem.update_stratagem_button.disabled = false;
-            model.stratagem.delete_stratagem_button.disabled = false;
+            model.stratagem.disabled = false;
         }
         Msg::Filesystem(fs) => {
             if let Some(fs) = &fs {

--- a/iml-wasm-components/iml-fs/src/fs_detail_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_detail_page.rs
@@ -115,6 +115,7 @@ enum Msg {
     OpenMountModal,
     Targets(HashMap<u32, Target<TargetConfParam>>),
     WindowClick,
+    CloseCommandModal,
     Hosts(HashMap<u32, Host>),
     InodeTable(iml_stratagem::Msg),
     StratagemInit(iml_stratagem::Msg),
@@ -177,6 +178,11 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             if model.scan_now.report_config.watching.should_update() {
                 model.scan_now.report_config.watching.update();
             }
+        }
+        Msg::CloseCommandModal => {
+            log::trace!("Closing command modal caught");
+            model.stratagem.update_stratagem_button.disabled = false;
+            model.stratagem.delete_stratagem_button.disabled = false;
         }
         Msg::Filesystem(fs) => {
             if let Some(fs) = &fs {
@@ -618,6 +624,9 @@ impl FsDetailPageCallbacks {
             .update(Msg::InodeTable(iml_stratagem::Msg::InodeTable(
                 iml_stratagem::inode_table::Msg::FetchInodes,
             )));
+    }
+    pub fn command_modal_closed(&self) {
+        self.app.update(Msg::CloseCommandModal);
     }
 }
 

--- a/iml-wasm-components/iml-stratagem/src/delete_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/delete_stratagem_button.rs
@@ -67,7 +67,7 @@ pub fn view(is_valid: bool) -> Node<Msg> {
     )
     .add_listener(simple_ev(Ev::Click, Msg::DeleteStratagem));
 
-    if is_valid {
+    if !is_valid {
         btn = btn.add_attr(At::Disabled.as_str(), "disabled");
     }
 

--- a/iml-wasm-components/iml-stratagem/src/delete_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/delete_stratagem_button.rs
@@ -60,10 +60,16 @@ fn delete_stratagem(config_id: u32) -> impl Future<Item = Msg, Error = Msg> {
         .fetch_json(Msg::StratagemDeleted)
 }
 
-pub fn view() -> Node<Msg> {
-    bs_button::btn(
+pub fn view(is_valid: bool) -> Node<Msg> {
+    let mut btn = bs_button::btn(
         class![bs_button::BTN_DANGER, "delete-button"],
         vec![Node::new_text("Delete"), i![class!["fas fa-times-circle"]]],
     )
-    .add_listener(simple_ev(Ev::Click, Msg::DeleteStratagem))
+    .add_listener(simple_ev(Ev::Click, Msg::DeleteStratagem));
+
+    if is_valid {
+        btn = btn.add_attr(At::Disabled.as_str(), "disabled");
+    }
+
+    btn
 }

--- a/iml-wasm-components/iml-stratagem/src/delete_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/delete_stratagem_button.rs
@@ -2,50 +2,15 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::ActionResponse;
+use crate::Command;
 use bootstrap_components::bs_button;
 use futures::Future;
 use iml_environment::csrf_token;
-use iml_utils::dispatch_custom_event;
-use seed::{class, dom_types::At, fetch, i, prelude::*};
+use seed::{class, dom_types::At, i, prelude::*};
 
-#[derive(Debug, Default)]
-pub struct Model {
-    pub config_id: u32,
-}
-
-#[derive(Clone, Debug)]
-pub enum Msg {
-    DeleteStratagem,
-    StratagemDeleted(fetch::FetchObject<ActionResponse>),
-    OnFetchError(seed::fetch::FailReason<ActionResponse>),
-}
-
-pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
-    let orders = orders.skip();
-
-    match msg {
-        Msg::DeleteStratagem => {
-            orders.perform_cmd(delete_stratagem(model.config_id));
-        }
-        Msg::StratagemDeleted(fetch_object) => match fetch_object.response() {
-            Ok(response) => {
-                log::trace!("Response data: {:#?}", response.data);
-                dispatch_custom_event("show_command_modal", &response.data);
-            }
-            Err(fail_reason) => {
-                orders.send_msg(Msg::OnFetchError(fail_reason));
-            }
-        },
-        Msg::OnFetchError(fail_reason) => {
-            log::warn!("Fetch error: {:#?}", fail_reason);
-        }
-    }
-
-    log::trace!("Model: {:#?}", model);
-}
-
-fn delete_stratagem(config_id: u32) -> impl Future<Item = Msg, Error = Msg> {
+pub fn delete_stratagem<T: serde::de::DeserializeOwned + 'static>(
+    config_id: u32,
+) -> impl Future<Item = seed::fetch::FetchObject<T>, Error = seed::fetch::FetchObject<T>> {
     let url = format!("/api/stratagem_configuration/{}/", config_id);
 
     seed::fetch::Request::new(url)
@@ -54,17 +19,17 @@ fn delete_stratagem(config_id: u32) -> impl Future<Item = Msg, Error = Msg> {
             "X-CSRFToken",
             &csrf_token().expect("Couldn't get csrf token."),
         )
-        .fetch_json(Msg::StratagemDeleted)
+        .fetch_json(std::convert::identity)
 }
 
-pub fn view(is_valid: bool, disabled: bool) -> Node<Msg> {
+pub fn view(is_valid: bool, disabled: bool) -> Node<Command> {
     let btn = bs_button::btn(
         class![bs_button::BTN_DANGER, "delete-button"],
         vec![Node::new_text("Delete"), i![class!["fas fa-times-circle"]]],
     );
 
     if is_valid && !disabled {
-        btn.add_listener(simple_ev(Ev::Click, Msg::DeleteStratagem))
+        btn.add_listener(simple_ev(Ev::Click, Command::Delete))
     } else {
         btn.add_attr(At::Disabled.as_str(), "disabled")
     }

--- a/iml-wasm-components/iml-stratagem/src/delete_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/delete_stratagem_button.rs
@@ -12,7 +12,6 @@ use seed::{class, dom_types::At, fetch, i, prelude::*};
 #[derive(Debug, Default)]
 pub struct Model {
     pub config_id: u32,
-    pub disabled: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -27,7 +26,6 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
 
     match msg {
         Msg::DeleteStratagem => {
-            model.disabled = true;
             orders.perform_cmd(delete_stratagem(model.config_id));
         }
         Msg::StratagemDeleted(fetch_object) => match fetch_object.response() {
@@ -40,7 +38,6 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             }
         },
         Msg::OnFetchError(fail_reason) => {
-            model.disabled = false;
             log::warn!("Fetch error: {:#?}", fail_reason);
         }
     }
@@ -60,16 +57,15 @@ fn delete_stratagem(config_id: u32) -> impl Future<Item = Msg, Error = Msg> {
         .fetch_json(Msg::StratagemDeleted)
 }
 
-pub fn view(is_valid: bool) -> Node<Msg> {
-    let mut btn = bs_button::btn(
+pub fn view(is_valid: bool, disabled: bool) -> Node<Msg> {
+    let btn = bs_button::btn(
         class![bs_button::BTN_DANGER, "delete-button"],
         vec![Node::new_text("Delete"), i![class!["fas fa-times-circle"]]],
-    )
-    .add_listener(simple_ev(Ev::Click, Msg::DeleteStratagem));
+    );
 
-    if !is_valid {
-        btn = btn.add_attr(At::Disabled.as_str(), "disabled");
+    if is_valid && !disabled {
+        btn.add_listener(simple_ev(Ev::Click, Msg::DeleteStratagem))
+    } else {
+        btn.add_attr(At::Disabled.as_str(), "disabled")
     }
-
-    btn
 }

--- a/iml-wasm-components/iml-stratagem/src/enable_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/enable_stratagem_button.rs
@@ -5,6 +5,7 @@
 use bootstrap_components::bs_button;
 use futures::Future;
 use iml_environment::csrf_token;
+use iml_utils::dispatch_custom_event;
 use seed::{class, dom_types::At, fetch, i, prelude::*};
 
 #[derive(Debug, serde::Serialize)]
@@ -15,11 +16,16 @@ pub struct Model {
     pub purge_duration: Option<u64>,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct EnableCommand {
+    command: iml_wire_types::Command,
+}
+
 #[derive(Clone, Debug)]
 pub enum Msg {
     EnableStratagem,
-    StratagemEnabled(fetch::FetchObject<iml_wire_types::Command>),
-    OnFetchError(seed::fetch::FailReason<iml_wire_types::Command>),
+    StratagemEnabled(fetch::FetchObject<EnableCommand>),
+    OnFetchError(seed::fetch::FailReason<EnableCommand>),
 }
 
 pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
@@ -32,6 +38,8 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         Msg::StratagemEnabled(fetch_object) => match fetch_object.response() {
             Ok(response) => {
                 log::trace!("Response data: {:#?}", response.data);
+                seed::log!("Opening command moal");
+                dispatch_custom_event("show_command_modal", &response.data);
             }
             Err(fail_reason) => {
                 orders.send_msg(Msg::OnFetchError(fail_reason));

--- a/iml-wasm-components/iml-stratagem/src/enable_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/enable_stratagem_button.rs
@@ -29,8 +29,6 @@ pub enum Msg {
 }
 
 pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
-    let orders = orders.skip();
-
     match msg {
         Msg::EnableStratagem => {
             orders.perform_cmd(enable_stratagem(&model));

--- a/iml-wasm-components/iml-stratagem/src/enable_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/enable_stratagem_button.rs
@@ -38,7 +38,6 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         Msg::StratagemEnabled(fetch_object) => match fetch_object.response() {
             Ok(response) => {
                 log::trace!("Response data: {:#?}", response.data);
-                seed::log!("Opening command moal");
                 dispatch_custom_event("show_command_modal", &response.data);
             }
             Err(fail_reason) => {

--- a/iml-wasm-components/iml-stratagem/src/lib.rs
+++ b/iml-wasm-components/iml-stratagem/src/lib.rs
@@ -28,12 +28,25 @@ pub struct StratagemConfiguration {
 }
 
 #[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct StratagemEnable {
+    pub filesystem: u32,
+    pub interval: u64,
+    pub report_duration: Option<u64>,
+    pub purge_duration: Option<u64>,
+}
+
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct StratagemUpdate {
     pub id: u32,
     pub filesystem: u32,
     pub interval: u64,
     pub report_duration: Option<u64>,
     pub purge_duration: Option<u64>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ActionResponse {
+    command: iml_wire_types::Command,
 }
 
 #[derive(Debug)]

--- a/iml-wasm-components/iml-stratagem/src/lib.rs
+++ b/iml-wasm-components/iml-stratagem/src/lib.rs
@@ -160,6 +160,8 @@ impl Model {
         if check {
             self.report_config.validation_message =
                 Some("Report duration must be less than Purge duration.".into());
+        } else {
+            self.report_config.validation_message = None;
         }
     }
 }

--- a/iml-wasm-components/iml-stratagem/src/lib.rs
+++ b/iml-wasm-components/iml-stratagem/src/lib.rs
@@ -366,13 +366,13 @@ pub fn view(model: &Model) -> Node<Msg> {
 
     if model.configured {
         configuration_component.push(
-            update_stratagem_button::view()
+            update_stratagem_button::view(model.config_valid())
                 .add_style("grid-column", "1 /span 12")
                 .map_message(Msg::UpdateStratagemButton),
         );
 
         configuration_component.push(
-            delete_stratagem_button::view()
+            delete_stratagem_button::view(model.config_valid())
                 .add_style("grid-column", "1 /span 12")
                 .map_message(Msg::DeleteStratagemButton),
         );

--- a/iml-wasm-components/iml-stratagem/src/update_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/update_stratagem_button.rs
@@ -2,51 +2,15 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::{ActionResponse, StratagemUpdate};
+use crate::{Command, StratagemUpdate};
 use bootstrap_components::bs_button;
 use futures::Future;
 use iml_environment::csrf_token;
-use iml_utils::dispatch_custom_event;
-use seed::{class, dom_types::At, fetch, i, prelude::*};
+use seed::{class, dom_types::At, i, prelude::*};
 
-#[derive(Debug, Default)]
-pub struct Model {
-    pub config_data: Option<StratagemUpdate>,
-}
-
-#[derive(Clone, Debug)]
-pub enum Msg {
-    UpdateStratagem,
-    StratagemUpdated(fetch::FetchObject<ActionResponse>),
-    OnFetchError(seed::fetch::FailReason<ActionResponse>),
-}
-
-pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
-    match msg {
-        Msg::UpdateStratagem => {
-            if let Some(config_data) = &model.config_data {
-                orders.perform_cmd(update_stratagem(&config_data));
-            }
-        }
-        Msg::StratagemUpdated(fetch_object) => match fetch_object.response() {
-            Ok(response) => {
-                log::trace!("Response data: {:#?}", response.data);
-                dispatch_custom_event("show_command_modal", &response.data);
-                orders.skip();
-            }
-            Err(fail_reason) => {
-                orders.send_msg(Msg::OnFetchError(fail_reason)).skip();
-            }
-        },
-        Msg::OnFetchError(fail_reason) => {
-            log::error!("Fetch error: {:#?}", fail_reason);
-        }
-    }
-
-    log::trace!("Model: {:#?}", model);
-}
-
-fn update_stratagem(config_data: &StratagemUpdate) -> impl Future<Item = Msg, Error = Msg> {
+pub fn update_stratagem<T: serde::de::DeserializeOwned + 'static>(
+    config_data: &StratagemUpdate,
+) -> impl Future<Item = seed::fetch::FetchObject<T>, Error = seed::fetch::FetchObject<T>> {
     let url = format!("/api/stratagem_configuration/{}/", config_data.id);
 
     seed::fetch::Request::new(url)
@@ -56,17 +20,17 @@ fn update_stratagem(config_data: &StratagemUpdate) -> impl Future<Item = Msg, Er
             &csrf_token().expect("Couldn't get csrf token."),
         )
         .send_json(config_data)
-        .fetch_json(Msg::StratagemUpdated)
+        .fetch_json(std::convert::identity)
 }
 
-pub fn view(is_valid: bool, disabled: bool) -> Node<Msg> {
+pub fn view(is_valid: bool, disabled: bool) -> Node<Command> {
     let btn = bs_button::btn(
         class![bs_button::BTN_SUCCESS, "update-button"],
         vec![Node::new_text("Update"), i![class!["fas fa-check"]]],
     );
 
     if is_valid && !disabled {
-        btn.add_listener(simple_ev(Ev::Click, Msg::UpdateStratagem))
+        btn.add_listener(simple_ev(Ev::Click, Command::Update))
     } else {
         btn.add_attr(At::Disabled.as_str(), "disabled")
     }

--- a/iml-wasm-components/iml-stratagem/src/update_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/update_stratagem_button.rs
@@ -12,7 +12,6 @@ use seed::{class, dom_types::At, fetch, i, prelude::*};
 #[derive(Debug, Default)]
 pub struct Model {
     pub config_data: Option<StratagemUpdate>,
-    pub disabled: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -25,7 +24,6 @@ pub enum Msg {
 pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::UpdateStratagem => {
-            model.disabled = true;
             if let Some(config_data) = &model.config_data {
                 orders.perform_cmd(update_stratagem(&config_data));
             }
@@ -34,7 +32,6 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             Ok(response) => {
                 log::trace!("Response data: {:#?}", response.data);
                 dispatch_custom_event("show_command_modal", &response.data);
-                model.disabled = false;
                 orders.skip();
             }
             Err(fail_reason) => {
@@ -42,7 +39,6 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             }
         },
         Msg::OnFetchError(fail_reason) => {
-            model.disabled = false;
             log::error!("Fetch error: {:#?}", fail_reason);
         }
     }
@@ -63,16 +59,15 @@ fn update_stratagem(config_data: &StratagemUpdate) -> impl Future<Item = Msg, Er
         .fetch_json(Msg::StratagemUpdated)
 }
 
-pub fn view(is_valid: bool) -> Node<Msg> {
-    let mut btn = bs_button::btn(
+pub fn view(is_valid: bool, disabled: bool) -> Node<Msg> {
+    let btn = bs_button::btn(
         class![bs_button::BTN_SUCCESS, "update-button"],
         vec![Node::new_text("Update"), i![class!["fas fa-check"]]],
-    )
-    .add_listener(simple_ev(Ev::Click, Msg::UpdateStratagem));
+    );
 
-    if !is_valid {
-        btn = btn.add_attr(At::Disabled.as_str(), "disabled");
+    if is_valid && !disabled {
+        btn.add_listener(simple_ev(Ev::Click, Msg::UpdateStratagem))
+    } else {
+        btn.add_attr(At::Disabled.as_str(), "disabled")
     }
-
-    btn
 }

--- a/iml-wasm-components/iml-stratagem/src/update_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/update_stratagem_button.rs
@@ -70,7 +70,7 @@ pub fn view(is_valid: bool) -> Node<Msg> {
     )
     .add_listener(simple_ev(Ev::Click, Msg::UpdateStratagem));
 
-    if is_valid {
+    if !is_valid {
         btn = btn.add_attr(At::Disabled.as_str(), "disabled");
     }
 


### PR DESCRIPTION
Fixes #1100.

Clicking the Enable / Update or Delete buttons within Stratagem config should show the command modal. This way the user can be notified of progress.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>