### PR TITLE
Stratagem scan attempts to send fid and purge lists to client, even if

### DIFF
--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -53,7 +53,7 @@ def get_duration(duration_key, bundle):
 def check_duration(duration_key, bundle):
     duration = get_duration(duration_key, bundle)
 
-    if isinstance(duration, dict):
+    if duration is None or isinstance(duration, dict):
         return duration
 
     if duration > MAX_SAFE_INTEGER:
@@ -64,7 +64,7 @@ def check_duration(duration_key, bundle):
             ),
         }
 
-    if duration is not None and duration < 0:
+    if duration < 0:
         return {
             "code": "{}_too_small".format(duration_key),
             "message": "{} duration cannot be negative.".format(get_duration_type(duration_key)),

--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -64,7 +64,7 @@ def check_duration(duration_key, bundle):
             ),
         }
 
-    if duration < 0:
+    if duration is not None and duration < 0:
         return {
             "code": "{}_too_small".format(duration_key),
             "message": "{} duration cannot be negative.".format(get_duration_type(duration_key)),

--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -5,6 +5,8 @@
 import logging
 import json
 import os
+
+from os import path
 from toolz.functoolz import pipe, partial, flip
 
 from django.db import models
@@ -528,6 +530,8 @@ class SendResultsToClientStep(Step):
             ]
             if duration is not None
         ]
+
+        action_list = filter(lambda (label, (mnt_pt, mailbox_file)): path.exists("/var/spool/iml/mailbox/{}".format(mailbox_file)), action_list)
 
         file_location = pipe(
             action_list,

--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -531,7 +531,7 @@ class SendResultsToClientStep(Step):
             if duration is not None
         ]
 
-        action_list = filter(lambda (label, (mnt_pt, mailbox_file)): path.exists("{}/{}".format(MAILBOX_PATH, mailbox_file)), action_list)
+        action_list = filter(lambda (_, xs): path.exists("{}/{}".format(MAILBOX_PATH, xs[1])), action_list)
 
         file_location = pipe(
             action_list,

--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -8,7 +8,7 @@ import os
 
 from os import path
 from toolz.functoolz import pipe, partial, flip
-
+from settings import MAILBOX_PATH
 from django.db import models
 
 from chroma_core.lib.cache import ObjectCache
@@ -531,7 +531,7 @@ class SendResultsToClientStep(Step):
             if duration is not None
         ]
 
-        action_list = filter(lambda (label, (mnt_pt, mailbox_file)): path.exists("/var/spool/iml/mailbox/{}".format(mailbox_file)), action_list)
+        action_list = filter(lambda (label, (mnt_pt, mailbox_file)): path.exists("{}/{}".format(MAILBOX_PATH, mailbox_file)), action_list)
 
         file_location = pipe(
             action_list,


### PR DESCRIPTION
they don't exist

Fixes #1137.

- Make sure values are not None before checking if they are negative in
validation
- Filter out action items if the mailbox file does not exist

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>