### PR TITLE
Stratagem duration values need to load using the maximuim unit that doesn't have a remainder.

### DIFF
--- a/iml-wasm-components/iml-duration-picker/duration-picker.rs
+++ b/iml-wasm-components/iml-duration-picker/duration-picker.rs
@@ -84,6 +84,17 @@ pub fn update(msg: Msg, model: &mut Model) {
     }
 }
 
+pub fn calculate_value_and_unit(model: &mut Model, ms: u64) {
+    let interval_opt = convert_ms_to_max_unit(ms);
+    if let Some((unit, val)) = interval_opt {
+        model.value = Some(val);
+        model.unit = unit;
+    } else {
+        model.value = None;
+        model.unit = Unit::Days;
+    }
+}
+
 pub fn convert_ms_to_unit(unit: Unit, val: u64) -> u64 {
     match unit {
         Unit::Days => val / 24 / 60 / 60 / 1000,
@@ -91,6 +102,54 @@ pub fn convert_ms_to_unit(unit: Unit, val: u64) -> u64 {
         Unit::Minutes => val / 60 / 1000,
         Unit::Seconds => val / 1000,
     }
+}
+
+fn get_unit_value(unit: Unit, val: u64) -> f64 {
+    let val = val as f64;
+    match unit {
+        Unit::Days => val / 24.0 / 60.0 / 60.0 / 1000.0,
+        Unit::Hours => val / 60.0 / 60.0 / 1000.0,
+        Unit::Minutes => val / 60.0 / 1000.0,
+        Unit::Seconds => val / 1000.0,
+    }
+}
+
+pub fn convert_ms_to_max_unit(val: u64) -> Option<(Unit, u64)> {
+    let days = get_unit_value(Unit::Days, val);
+    let mut result = if days.fract() == 0.0 {
+        Some((Unit::Days, days as u64))
+    } else {
+        None
+    };
+
+    if result == None {
+        let hours = get_unit_value(Unit::Hours, val);
+        result = if hours.fract() == 0.0 {
+            Some((Unit::Hours, hours as u64))
+        } else {
+            None
+        };
+    }
+
+    if result == None {
+        let minutes = get_unit_value(Unit::Minutes, val);
+        result = if minutes.fract() == 0.0 {
+            Some((Unit::Minutes, minutes as u64))
+        } else {
+            None
+        };
+    }
+
+    if result == None {
+        let seconds = get_unit_value(Unit::Seconds, val);
+        result = if seconds.fract() == 0.0 {
+            Some((Unit::Seconds, seconds as u64))
+        } else {
+            None
+        };
+    }
+
+    result
 }
 
 pub fn duration_picker(model: &Model, mut input: Node<Msg>) -> Vec<Node<Msg>> {

--- a/iml-wasm-components/iml-stratagem/src/lib.rs
+++ b/iml-wasm-components/iml-stratagem/src/lib.rs
@@ -65,24 +65,16 @@ pub struct Model {
 
 impl Default for Model {
     fn default() -> Self {
-        let exclude_units = vec![
-            iml_duration_picker::Unit::Minutes,
-            iml_duration_picker::Unit::Seconds,
-        ];
-
         Model {
             id: None,
             fs_id: 1,
             run_config: iml_duration_picker::Model {
-                exclude_units: exclude_units.clone(),
                 ..Default::default()
             },
             report_config: iml_duration_picker::Model {
-                exclude_units: exclude_units.clone(),
                 ..Default::default()
             },
             purge_config: iml_duration_picker::Model {
-                exclude_units,
                 ..Default::default()
             },
             inode_table: inode_table::Model::default(),
@@ -201,20 +193,14 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             Some(c) => {
                 model.id = Some(c.id);
 
-                model.run_config.value = Some(iml_duration_picker::convert_ms_to_unit(
-                    iml_duration_picker::Unit::Days,
-                    c.interval,
-                ));
+                iml_duration_picker::calculate_value_and_unit(&mut model.run_config, c.interval);
 
                 match c.report_duration {
                     None => {
                         model.report_config.value = None;
                     }
                     Some(x) => {
-                        model.report_config.value = Some(iml_duration_picker::convert_ms_to_unit(
-                            iml_duration_picker::Unit::Days,
-                            x,
-                        ))
+                        iml_duration_picker::calculate_value_and_unit(&mut model.report_config, x);
                     }
                 }
 
@@ -223,10 +209,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
                         model.purge_config.value = None;
                     }
                     Some(x) => {
-                        model.purge_config.value = Some(iml_duration_picker::convert_ms_to_unit(
-                            iml_duration_picker::Unit::Days,
-                            x,
-                        ))
+                        iml_duration_picker::calculate_value_and_unit(&mut model.purge_config, x);
                     }
                 }
 


### PR DESCRIPTION
Fixes #1146.

- Refreshing now loads the value and maintains the unit.
- Enable minutes and seconds as an option in the duration picker

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>