### PR TITLE
Skip removal of bundle_name index

### DIFF
--- a/chroma_core/south_migrations/0044_auto__del_bundle__del_unique_bundle_bundle_name__add_repo__add_unique_.py
+++ b/chroma_core/south_migrations/0044_auto__del_bundle__del_unique_bundle_bundle_name__add_repo__add_unique_.py
@@ -11,9 +11,6 @@ class Migration(SchemaMigration):
         # Removing unique constraint on 'ServerProfilePackage', fields ['bundle', 'server_profile', 'package_name']
         db.delete_unique(u'chroma_core_serverprofilepackage', ['bundle_id', 'server_profile_id', 'package_name'])
 
-        # Removing unique constraint on 'Bundle', fields ['bundle_name']
-        db.delete_unique(u'chroma_core_bundle', ['bundle_name'])
-
         # Deleting model 'Bundle'
         db.delete_table(u'chroma_core_bundle')
 


### PR DESCRIPTION
It will be dropped with the table.

Fixes #1087.