### PR TITLE
GH-1157 - Show legend for file-size and space distribution charts

### DIFF
--- a/grafana/dashboards/stratagem-dashboard-1.json
+++ b/grafana/dashboards/stratagem-dashboard-1.json
@@ -20,7 +20,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1566309516649,
+  "iteration": 1566404748526,
   "links": [],
   "panels": [
     {
@@ -42,11 +42,14 @@
         "alignAsTable": false,
         "avg": false,
         "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
-        "show": false,
-        "total": false,
-        "values": false
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -298,9 +301,10 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
-        "total": false,
-        "values": false
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,

--- a/grafana/dashboards/stratagem-dashboard-1.json
+++ b/grafana/dashboards/stratagem-dashboard-1.json
@@ -42,8 +42,6 @@
         "alignAsTable": false,
         "avg": false,
         "current": false,
-        "hideEmpty": false,
-        "hideZero": false,
         "max": false,
         "min": false,
         "rightSide": false,


### PR DESCRIPTION
There may be cases where the variance between buckets is so large that the bars are basically invisible. By adding a legend we can see the values in these cases.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>