### PR TITLE
Stratagem GUI should be hidden if not available

### DIFF
--- a/chroma_api/target.py
+++ b/chroma_api/target.py
@@ -275,7 +275,6 @@ class TargetResource(MetricResource, ConfParamResource):
             "failover_server_name",
             "volume_name",
             "primary_server_name",
-            "active_host_name",
             "filesystems",
             "name",
             "uuid",

--- a/iml-wasm-components/iml-fs/src/fs_detail_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_detail_page.rs
@@ -87,28 +87,26 @@ struct Model {
 
 impl Model {
     fn stratagem_ready(&self) -> bool {
-        if !self.mdts.is_empty() && !self.hosts.is_empty() && self.fs.is_some() {
-            let filtered_hosts: Vec<&Host> = self
-                .hosts
-                .values()
-                .filter(|x| {
-                    self.mdts.iter().any(|mdt| {
-                        if let Some(active_host) = mdt.clone().active_host {
-                            active_host == x.resource_uri
-                        } else {
-                            false
-                        }
-                    })
-                })
-                .collect();
+        if self.mdts.is_empty() || self.hosts.is_empty() || self.fs.is_none() {
+            return false;
+        }
 
-            if filtered_hosts.len() > 0 {
-                filtered_hosts
-                    .iter()
-                    .all(|x| x.server_profile.name == "stratagem_server")
-            } else {
-                false
-            }
+        let active_hosts: Vec<_> = self
+            .mdts
+            .iter()
+            .filter_map(|x| x.active_host.as_ref())
+            .collect();
+
+        let filtered_hosts: Vec<&Host> = self
+            .hosts
+            .values()
+            .filter(|x| active_hosts.contains(&&x.resource_uri))
+            .collect();
+
+        if filtered_hosts.len() > 0 {
+            filtered_hosts
+                .iter()
+                .all(|x| x.server_profile.name == "stratagem_server")
         } else {
             false
         }

--- a/iml-wasm-components/iml-fs/src/fs_detail_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_detail_page.rs
@@ -94,13 +94,7 @@ impl Model {
         let server_resources: Vec<_> = self
             .mdts
             .iter()
-            .map(move |x| {
-                vec![x.failover_servers.clone(), vec![x.primary_server.clone()]]
-                    .into_iter()
-                    .flatten()
-                    .collect::<Vec<String>>()
-            })
-            .flatten()
+            .flat_map(|x| x.failover_servers.as_ref().chain(vec![&x.primary_server]))
             .collect();
 
         let filtered_hosts: Vec<&Host> = self

--- a/iml-wasm-components/iml-fs/src/fs_detail_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_detail_page.rs
@@ -94,7 +94,11 @@ impl Model {
         let server_resources: Vec<_> = self
             .mdts
             .iter()
-            .flat_map(|x| x.failover_servers.as_ref().chain(vec![&x.primary_server]))
+            .flat_map(|x| {
+                x.failover_servers
+                    .iter()
+                    .chain(std::iter::once(&x.primary_server))
+            })
             .collect();
 
         let filtered_hosts: Vec<&Host> = self

--- a/iml-wasm-components/iml-fs/src/fs_detail_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_detail_page.rs
@@ -294,6 +294,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             model.osts = osts;
 
             model.stratagem_ready = model.stratagem_ready();
+            model.scan_now.disabled = !model.can_scan_stratagem();
         }
         Msg::OstPaging(msg) => update_paging(msg, &mut model.ost_paging),
         Msg::MdtPaging(msg) => update_paging(msg, &mut model.mdt_paging),
@@ -301,6 +302,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             model.hosts = hosts;
 
             model.stratagem_ready = model.stratagem_ready();
+            model.scan_now.disabled = !model.can_scan_stratagem();
         }
         Msg::Alerts(alerts) => {
             model.alerts = alerts;
@@ -352,6 +354,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         }
         Msg::StratagemInit(msg) => {
             model.stratagem_ready = model.stratagem_ready();
+            model.scan_now.disabled = !model.can_scan_stratagem();
 
             orders.send_msg(Msg::StratagemComponent(msg));
         }


### PR DESCRIPTION
Fixes #1160.

Stratagem info: "Scan Filesystem Now", "Top inode Users", "File Size Distribution", ... is all shown in filesystem detail page, but there's no stratagem profiles or components installed on servers.

To Reproduce
Steps to reproduce the behavior:
1. Create filesystem in managed mode.
2. See Stratagem components

Expected behavior
No stratagem components

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>