### PR TITLE
Stratagem buttons should be disabled based on write locks

### DIFF
--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -449,6 +449,15 @@ class RunStratagemJob(Job):
     def description(self):
         return self.long_description(self)
 
+    def create_locks(self):
+        from chroma_core.models import ManagedFilesystem;
+        locks = super(RunStratagemJob, self).create_locks()
+
+        fs = ManagedFilesystem.objects.get(name=self.fs_name)
+        locks.append(StateLock(job=self, locked_item=fs, write=True))
+
+        return locks
+
     def get_steps(self):
 
         if self.filesystem_type.lower() == "zfs":

--- a/chroma_core/services/job_scheduler/job_scheduler.py
+++ b/chroma_core/services/job_scheduler/job_scheduler.py
@@ -1823,7 +1823,7 @@ class JobScheduler(object):
                     "uuid": unique_id,
                     "report_duration": stratagem_data.get("report_duration"),
                     "purge_duration": stratagem_data.get("purge_duration"),
-                    "fs_name": filesystem.name,
+                    "filesystem": filesystem,
                 },
             },
             mdts,
@@ -1843,7 +1843,7 @@ class JobScheduler(object):
         if not client_mount_exists:
             self._create_client_mount(client_host, filesystem, mountpoint)
 
-        client_mount = LustreClientMount.objects.get(host_id=client_host.id)
+        client_mount = LustreClientMount.objects.get(host_id=client_host.id, filesystem_id=fs_id)
         client_mount.state = "unmounted"
         client_mount.mountpoint = mountpoint
         client_mount.filesystem_id = filesystem.id

--- a/chroma_core/south_migrations/0046_auto__add_sendstratagemresultstoclientjob__add_stratagemconfiguration_.py
+++ b/chroma_core/south_migrations/0046_auto__add_sendstratagemresultstoclientjob__add_stratagemconfiguration_.py
@@ -58,6 +58,7 @@ class Migration(SchemaMigration):
         # Adding model 'RunStratagemJob'
         db.create_table(u'chroma_core_runstratagemjob', (
             (u'job_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['chroma_core.Job'], unique=True, primary_key=True)),
+            ('filesystem', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['chroma_core.ManagedFilesystem'])),
             ('mdt_id', self.gf('django.db.models.fields.IntegerField')()),
             ('uuid', self.gf('django.db.models.fields.CharField')(default='', max_length=64)),
             ('report_duration', self.gf('django.db.models.fields.BigIntegerField')(null=True)),
@@ -67,7 +68,6 @@ class Migration(SchemaMigration):
             ('filesystem_type', self.gf('django.db.models.fields.CharField')(default='', max_length=32)),
             ('target_mount_point', self.gf('django.db.models.fields.CharField')(default='', max_length=512)),
             ('device_path', self.gf('django.db.models.fields.CharField')(default='', max_length=512)),
-            ('fs_name', self.gf('django.db.models.fields.CharField')(max_length=8, null=False)),
         ))
         db.send_create_signal('chroma_core', ['RunStratagemJob'])
 
@@ -987,10 +987,10 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'RegistrationToken'},
             'cancelled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'credits': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
-            'expiry': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 8, 19, 0, 0)'}),
+            'expiry': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2019, 8, 22, 0, 0)'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.ServerProfile']", 'null': 'True'}),
-            'secret': ('django.db.models.fields.CharField', [], {'default': "'AFA8115F007D7E448973481FFBD898F8'", 'max_length': '32'})
+            'secret': ('django.db.models.fields.CharField', [], {'default': "'6FB2C0E9A2242EF4CABBF91D6CC1BFE7'", 'max_length': '32'})
         },
         'chroma_core.removeconfiguredtargetjob': {
             'Meta': {'ordering': "['id']", 'object_name': 'RemoveConfiguredTargetJob'},
@@ -1060,9 +1060,9 @@ class Migration(SchemaMigration):
         'chroma_core.runstratagemjob': {
             'Meta': {'ordering': "['id']", 'object_name': 'RunStratagemJob', '_ormbases': ['chroma_core.Job']},
             'device_path': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '512'}),
+            'filesystem': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['chroma_core.ManagedFilesystem']"}),
             'filesystem_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '32'}),
             'fqdn': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255'}),
-            'fs_name': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'False'}),
             u'job_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['chroma_core.Job']", 'unique': 'True', 'primary_key': 'True'}),
             'mdt_id': ('django.db.models.fields.IntegerField', [], {}),
             'purge_duration': ('django.db.models.fields.BigIntegerField', [], {'null': 'True'}),

--- a/iml-wasm-components/iml-fs/src/fs_detail_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_detail_page.rs
@@ -200,7 +200,10 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         }
         Msg::Locks(locks) => {
             if let Some(fs) = &model.fs {
-                model.fs_detail.dropdown.is_locked = has_lock(&locks, fs);
+                let has_fs_locks = has_lock(&locks, fs);
+                model.fs_detail.dropdown.is_locked = has_fs_locks;
+                model.stratagem.is_locked = has_fs_locks;
+                model.scan_now.is_locked = has_fs_locks;
             }
 
             model.locks = locks;

--- a/iml-wasm-components/iml-fs/src/fs_detail_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_detail_page.rs
@@ -12,7 +12,9 @@ use iml_lock_indicator::{lock_indicator, LockIndicatorState};
 use iml_paging::{paging, update_paging, Paging, PagingMsg};
 use iml_utils::{IntoSerdeOpt as _, Locks, WatchState};
 use iml_wire_types::{Alert, Filesystem, Host, Target, TargetConfParam, ToCompositeId};
-use seed::{class, div, dom_types::Attrs, h4, h5, i, prelude::*, style, tbody, td, th, thead, tr};
+use seed::{
+    class, div, dom_types::Attrs, h4, h5, i, prelude::*, span, style, tbody, td, th, thead, tr,
+};
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
@@ -44,6 +46,7 @@ struct TableRow {
 struct FsDetail {
     pub dropdown: dad::Model,
     pub alert_indicator: WatchState,
+    pub lock_indicator: WatchState,
 }
 
 impl Default for FsDetail {
@@ -57,6 +60,7 @@ impl Default for FsDetail {
                 },
                 ..Default::default()
             },
+            lock_indicator: Default::default(),
         }
     }
 }
@@ -106,6 +110,7 @@ enum Msg {
     Filesystem(Option<Filesystem>),
     FsDetailDropdown(dad::IdMsg<Filesystem>),
     FsDetailPopoverState(AlertIndicatorPopoverState),
+    FsDetailPopoverLockState(LockIndicatorState),
     FsRowDropdown(dad::IdMsg<Target<TargetConfParam>>),
     FsRowIndicatorState(AlertIndicatorPopoverState),
     FsRowLockIndicatorState(LockIndicatorState),
@@ -131,6 +136,10 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         Msg::WindowClick => {
             if model.fs_detail.alert_indicator.should_update() {
                 model.fs_detail.alert_indicator.update();
+            }
+
+            if model.fs_detail.lock_indicator.should_update() {
+                model.fs_detail.lock_indicator.update();
             }
 
             if model.fs_detail.dropdown.watching.should_update() {
@@ -272,6 +281,9 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         Msg::FsDetailPopoverState(AlertIndicatorPopoverState((_, state))) => {
             model.fs_detail.alert_indicator = state;
         }
+        Msg::FsDetailPopoverLockState(LockIndicatorState(_, state)) => {
+            model.fs_detail.lock_indicator = state;
+        }
         Msg::FsRowIndicatorState(AlertIndicatorPopoverState((id, state))) => {
             if let Some(row) = model.table_rows.get_mut(&id) {
                 row.alert_indicator = state;
@@ -363,6 +375,7 @@ fn filesystem(
     alerts: &[Alert],
     fs_detail: &FsDetail,
     mgt_el: Node<Msg>,
+    locks: &Locks,
 ) -> Node<Msg> {
     detail_panel(vec![
         detail_header(&format!("{} Details", fs.name)),
@@ -387,13 +400,23 @@ fn filesystem(
         detail_label("Mounted Clients"),
         div![client_count(fs.client_count)],
         detail_label("Alerts"),
-        div![alert_indicator(
-            &alerts,
-            0,
-            &fs.resource_uri,
-            fs_detail.alert_indicator.is_open()
-        )
-        .map_message(Msg::FsDetailPopoverState)],
+        div![
+            span![lock_indicator(
+                fs.id,
+                fs_detail.lock_indicator.is_open(),
+                fs.composite_id(),
+                &locks
+            )
+            .add_style("padding-right", px(10))]
+            .map_message(Msg::FsDetailPopoverLockState),
+            span![alert_indicator(
+                &alerts,
+                0,
+                &fs.resource_uri,
+                fs_detail.alert_indicator.is_open()
+            )]
+            .map_message(Msg::FsDetailPopoverState),
+        ],
         div![
             class!["full-width"],
             style! { "grid-column" => "1 / span 2" },
@@ -524,6 +547,7 @@ fn view(model: &Model) -> Node<Msg> {
                 &model.alerts,
                 &model.fs_detail,
                 mgt_link(model.mgt.first()),
+                &model.locks,
             ),
             mnt_info_btn,
             if model.stratagem_ready {

--- a/iml-wasm-components/iml-stratagem/src/lib.rs
+++ b/iml-wasm-components/iml-stratagem/src/lib.rs
@@ -64,6 +64,7 @@ pub struct Model {
     pub purge_config: iml_duration_picker::Model,
     pub inode_table: inode_table::Model,
     pub disabled: bool,
+    pub is_locked: bool,
 }
 
 pub fn max_value_validation(ms: u64, unit: iml_duration_picker::Unit) -> Option<String> {
@@ -328,19 +329,19 @@ pub fn view(model: &Model) -> Node<Msg> {
 
     if model.id.is_some() {
         configuration_component.push(
-            update_stratagem_button::view(model.config_valid(), model.disabled)
+            update_stratagem_button::view(model.config_valid(), model.disabled || model.is_locked)
                 .add_style("grid-column", "1 /span 12")
                 .map_message(Msg::SendCommand),
         );
 
         configuration_component.push(
-            delete_stratagem_button::view(model.config_valid(), model.disabled)
+            delete_stratagem_button::view(model.config_valid(), model.disabled || model.is_locked)
                 .add_style("grid-column", "1 /span 12")
                 .map_message(Msg::SendCommand),
         );
     } else {
         configuration_component.push(
-            enable_stratagem_button::view(model.config_valid(), model.disabled)
+            enable_stratagem_button::view(model.config_valid(), model.disabled || model.is_locked)
                 .add_style("grid-column", "1 /span 12")
                 .map_message(Msg::SendCommand),
         )

--- a/iml-wasm-components/iml-stratagem/src/scan_now.rs
+++ b/iml-wasm-components/iml-stratagem/src/scan_now.rs
@@ -22,6 +22,7 @@ pub struct Model {
     pub data: Option<StratagemScan>,
     pub open: bool,
     pub disabled: bool,
+    pub is_locked: bool,
     pub report_config: iml_duration_picker::Model,
     pub purge_config: iml_duration_picker::Model,
 }
@@ -118,7 +119,7 @@ pub fn view(fs_id: u32, model: &Model) -> Vec<Node<Msg>> {
     )
     .add_style("margin-left", px(15));
 
-    if !model.disabled {
+    if !model.disabled && !model.is_locked {
         scan_now_button = scan_now_button.add_listener(simple_ev(Ev::Click, Msg::OpenModal));
     } else {
         scan_now_button = scan_now_button.add_attr(At::Disabled.as_str(), "disabled");
@@ -138,13 +139,15 @@ fn scan_modal(fs_id: u32, model: &Model) -> Vec<Node<Msg>> {
         class![bs_button::BTN_SUCCESS],
         vec![Node::new_text(if model.disabled {
             "Scanning..."
+        } else if model.is_locked {
+            "Locked 🔒"
         } else {
             "Scan Now"
         })],
     )
     .add_listener(mouse_ev(Ev::Click, move |_| Msg::ScanStratagem(fs_id)));
 
-    if model.disabled {
+    if model.disabled || model.is_locked {
         scan_button = scan_button.add_attr("disabled", true);
     }
 


### PR DESCRIPTION
Fixes #1152.

The buttons for stratagem should be disabled based on any write lock associated with the stratagem configuration, or the fs.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>