### PR TITLE
Add systemd drop-in to override grafana ExecStart

### DIFF
--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -322,13 +322,6 @@ class ServiceConfig(CommandLine):
         self.try_shell(["influx", "-execute", "CREATE DATABASE {}".format(settings.INFLUXDB_STRATAGEM_SCAN_DB)])
 
     def _setup_grafana(self):
-        cfg_file = "/etc/sysconfig/grafana-server"
-        if os.path.exists("%s.dist" % cfg_file):
-            return
-        shutil.copy2(cfg_file, "%s.dist" % cfg_file)
-        with open(cfg_file, "a") as fn:
-            fn.write("CONF_FILE=/etc/grafana/grafana-iml.ini")
-
         # grafana needs daemon-reload before enable and start
         ServiceControlEL7.daemon_reload()
         service = ServiceControl.create("grafana-server")

--- a/grafana/dropin-iml.conf
+++ b/grafana/dropin-iml.conf
@@ -1,0 +1,10 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/grafana-server                                                  \
+                            --config=/etc/grafana/grafana-iml.ini                   \
+                            --pidfile=${PID_FILE_DIR}/grafana-server.pid            \
+                            --packaging=rpm                                         \
+                            cfg:default.paths.logs=${LOG_DIR}                       \
+                            cfg:default.paths.data=${DATA_DIR}                      \
+                            cfg:default.paths.plugins=${PLUGINS_DIR}                \
+                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -215,6 +215,8 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/grafana/provisioning/dashboards
 cp -r grafana $RPM_BUILD_ROOT%{manager_root}
 mv $RPM_BUILD_ROOT%{manager_root}/grafana/grafana-iml.ini $RPM_BUILD_ROOT%{_sysconfdir}/grafana/
 mv $RPM_BUILD_ROOT%{manager_root}/grafana/dashboards/iml-dashboards.yaml $RPM_BUILD_ROOT%{_sysconfdir}/grafana/provisioning/dashboards
+mkdir -p $RPM_BUILD_ROOT%{_unitdir}/grafana-server.service.d/
+mv $RPM_BUILD_ROOT%{manager_root}/grafana/dropin-iml.conf $RPM_BUILD_ROOT%{_unitdir}/grafana-server.service.d/90-iml.conf
 cp iml-manager-redirect.conf $RPM_BUILD_ROOT%{_sysconfdir}/nginx/default.d/iml-manager-redirect.conf
 cp rabbitmq-env.conf $RPM_BUILD_ROOT%{_sysconfdir}/rabbitmq/rabbitmq-env.conf
 cp chroma-host-discover-init.sh $RPM_BUILD_ROOT%{_sysconfdir}/init.d/chroma-host-discover
@@ -333,6 +335,7 @@ fi
 %{_sysconfdir}/nginx/default.d/iml-manager-redirect.conf
 %{_sysconfdir}/rabbitmq/rabbitmq-env.conf
 %{_sysconfdir}/grafana/grafana-iml.ini
+%{_unitdir}/grafana-server.service.d/90-iml.conf
 %attr(0755,root,root)%{_sysconfdir}/init.d/chroma-host-discover
 %attr(0755,root,root)%{_mandir}/man1/chroma-config.1.gz
 %attr(0644,root,root)%{_sysconfdir}/logrotate.d/chroma-manager


### PR DESCRIPTION
This replaces the use of /etc/sysconfig/grafana to setup grafana config file, to ensure that when grafana is upgraded, we maintain the same config.

Fixes #1156 

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>