### PR TITLE
[WIP] IML-1178  remove stratagem scans from MDS nodes after transfer

### DIFF
--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -394,7 +394,7 @@ class StreamFidlistStep(Step):
         unique_id = args["uuid"]
         fs_name = args["fs_name"]
 
-        _, stratagem_result, mailbox_files = scan_result
+        parent_dir, stratagem_result, mailbox_files = scan_result
 
         # Send stratagem_results to time series database
         influx_entries = parse_stratagem_results_to_influx(temp_stratagem_measurement, fs_name, stratagem_result)
@@ -403,7 +403,7 @@ class StreamFidlistStep(Step):
         record_stratagem_point("\n".join(influx_entries))
 
         mailbox_files = map(lambda xs: (xs[0], "{}-{}".format(unique_id, xs[1])), mailbox_files)
-        result = self.invoke_rust_agent_expect_result(host, "stream_fidlists_stratagem", mailbox_files)
+        result = self.invoke_rust_agent_expect_result(host, "stream_fidlists_stratagem", (parent_dir, mailbox_files))
 
         return result
 
@@ -543,7 +543,7 @@ class SendResultsToClientStep(Step):
             if duration is not None
         ]
 
-        action_list = filter(lambda (_, xs): path.exists("{}/{}".format(MAILBOX_PATH, xs[1])), action_list)
+        action_list = filter(lambda action: path.exists("{}/{}".format(MAILBOX_PATH, action[1][1])), action_list)
 
         file_location = pipe(
             action_list,

--- a/iml-agent/src/action_plugins/stratagem/server.rs
+++ b/iml-agent/src/action_plugins/stratagem/server.rs
@@ -363,12 +363,6 @@ pub fn trigger_scan(
 /// Streams output for all given mailbox files
 ///
 /// This fn will stream all files in parallel and return once they have all finished.
-///
-/// Issues:
-/// * mailbox_files - actually directories
-/// * Parent dir and files - should be one contract (or struct in Rust terms).
-///     This directory used only for listed files and should not used anyone else.
-/// * Used one tuple param (instead two params) to meet mk_callback() reqs.
 pub fn stream_fidlists(
     (parent_dir, mailbox_files): (String, MailboxFiles),
 ) -> impl Future<Item = (), Error = ImlAgentError> {

--- a/iml-agent/src/action_plugins/stratagem/server.rs
+++ b/iml-agent/src/action_plugins/stratagem/server.rs
@@ -4,9 +4,8 @@
 
 use crate::{agent_error::ImlAgentError, cmd::cmd_output_success, http_comms::mailbox_client};
 use futures::{future, stream, Future, IntoFuture, Stream as _};
-use iml_fs::{read_file_to_end, stream_dir_lines, write_tempfile};
+use iml_fs::{read_file_to_end, remove_dir_all, stream_dir_lines, write_tempfile};
 use std::{convert::Into, path::PathBuf};
-use tokio::fs::remove_dir;
 use uuid::Uuid;
 
 /// The device that is scanned for matching rules.
@@ -379,7 +378,7 @@ pub fn stream_fidlists(
     });
 
     future::join_all(mailbox_files)
-        .and_then(|_| remove_dir(parent_dir).from_err())
+        .and_then(|_| remove_dir_all(parent_dir).from_err())
         .map(drop)
 }
 

--- a/iml-fs/src/lib.rs
+++ b/iml-fs/src/lib.rs
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+mod remove_dir_all;
+
+pub use crate::remove_dir_all::{remove_dir_all, RemoveDirAllFuture};
+
 use bytes::IntoBuf;
 use futures::{future::poll_fn, stream, Future, Stream};
 use std::{

--- a/iml-fs/src/remove_dir_all.rs
+++ b/iml-fs/src/remove_dir_all.rs
@@ -1,0 +1,79 @@
+use futures::{
+    Async,
+    Poll,
+    future::Future,
+};
+use std::{
+    fs,
+    future::Future as stdFuture,
+    io,
+    path::Path,
+    pin::Pin,
+    task::{Context, Poll as StdPoll},
+};
+use tokio_threadpool::blocking;
+
+
+/// tokio-fs.remove_dir_all
+
+/// Removes a directory at this path, after removing all its contents. Use carefully!
+///
+/// This is an async version of [`std::fs::remove_dir_all`][std]
+///
+/// [std]: https://doc.rust-lang.org/std/fs/fn.remove_dir_all.html
+pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> RemoveDirAllFuture<P> {
+    RemoveDirAllFuture::new(path)
+}
+
+/// Future returned by `remove_dir_all`.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct RemoveDirAllFuture<P>
+where
+    P: AsRef<Path>,
+{
+    path: P,
+}
+
+impl<P> RemoveDirAllFuture<P>
+where
+    P: AsRef<Path>,
+{
+    fn new(path: P) -> RemoveDirAllFuture<P> {
+        RemoveDirAllFuture { path }
+    }
+}
+
+///our future FeaturesFuture
+impl<P> Future for RemoveDirAllFuture<P>
+where
+    P: AsRef<Path>,
+{
+    type Item = ();
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        blocking_io(|| fs::remove_dir_all(&self.path))
+    }
+}
+
+/// tokio-fs.lib
+fn blocking_io<F, T>(f: F) -> Poll<T, io::Error>
+where
+    F: FnOnce() -> io::Result<T>,
+{
+    match tokio_threadpool::blocking(f) {
+        Ok(Async::Ready(Ok(v))) => Ok(v.into()),
+        Ok(Async::Ready(Err(err))) => Err(err),
+        Ok(Async::NotReady) => Ok(Async::NotReady),
+        Err(_) => Err(blocking_err()),
+    }
+}
+
+fn blocking_err() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Other,
+        "`blocking` annotated I/O must be called \
+         from the context of the Tokio runtime.",
+    )
+}

--- a/iml-fs/src/remove_dir_all.rs
+++ b/iml-fs/src/remove_dir_all.rs
@@ -1,16 +1,6 @@
-use futures::{
-    Async,
-    Poll,
-    future::Future,
-};
-use std::{
-    fs,
-    io,
-    path::Path,
-    pin::Pin,
-};
+use futures::{future::Future, Async, Poll};
+use std::{fs, io, path::Path, pin::Pin};
 use tokio_threadpool::blocking;
-
 
 /// tokio-fs.remove_dir_all
 

--- a/iml-fs/src/remove_dir_all.rs
+++ b/iml-fs/src/remove_dir_all.rs
@@ -5,11 +5,9 @@ use futures::{
 };
 use std::{
     fs,
-    future::Future as stdFuture,
     io,
     path::Path,
     pin::Pin,
-    task::{Context, Poll as StdPoll},
 };
 use tokio_threadpool::blocking;
 

--- a/iml-fs/src/remove_dir_all_tokio.rs
+++ b/iml-fs/src/remove_dir_all_tokio.rs
@@ -1,7 +1,6 @@
 use futures::{
     Async,
     Poll as FeaturePoll,
-    future::Future as FeaturesFuture,
 };
 use std::{
     fs,

--- a/iml-fs/src/remove_dir_all_tokio.rs
+++ b/iml-fs/src/remove_dir_all_tokio.rs
@@ -1,0 +1,76 @@
+use futures::{
+    Async,
+    Poll as FeaturePoll,
+    future::Future as FeaturesFuture,
+};
+use std::{
+    fs,
+    future::Future,
+    io,
+    path::Path,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio_threadpool::blocking;
+
+
+/// tokio-fs.remove_dir_all
+
+/// Removes a directory at this path, after removing all its contents. Use carefully!
+///
+/// This is an async version of [`std::fs::remove_dir_all`][std]
+///
+/// [std]: https://doc.rust-lang.org/std/fs/fn.remove_dir_all.html
+pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> RemoveDirAllFuture<P> {
+    RemoveDirAllFuture::new(path)
+}
+
+/// Future returned by `remove_dir_all`.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct RemoveDirAllFuture<P>
+where
+    P: AsRef<Path>,
+{
+    path: P,
+}
+
+impl<P> RemoveDirAllFuture<P>
+where
+    P: AsRef<Path>,
+{
+    fn new(path: P) -> RemoveDirAllFuture<P> {
+        RemoveDirAllFuture { path }
+    }
+}
+
+impl<P> Future for RemoveDirAllFuture<P>
+where
+    P: AsRef<Path>,
+{
+    type Output = io::Result<()>;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        blocking_io(|| fs::remove_dir_all(&self.path))
+    }
+}
+
+/// tokio-fs.lib
+fn blocking_io<F, T>(f: F) -> Poll<io::Result<T>>
+where
+    F: FnOnce() -> io::Result<T>,
+{
+    match tokio_threadpool::blocking(f) {
+        FeaturePoll::Ok(Async::Ready(v)) => Poll::Ready(v),
+        FeaturePoll::Ok(Async::NotReady) => Poll::Pending,
+        FeaturePoll::Err(_) => Poll::Ready(io::Result::Err(blocking_err())),
+    }
+}
+
+fn blocking_err() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Other,
+        "`blocking` annotated I/O must be called \
+         from the context of the Tokio runtime.",
+    )
+}


### PR DESCRIPTION
https://github.com/whamcloud/integrated-manager-for-lustre/issues/1178

Removing each directory after mail send.

[ ] choose solution
1 collaps sync
2 create global counter for last transmission