### PR TITLE
Create util crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "iml-util"
+version = "0.1.0"
+
+[[package]]
 name = "iml-warp-drive"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ members = [
     'iml-manager-cli',
     'iml-manager-client',
     'iml-fs',
+    'iml-util',
     'iml-postgres'
 ]

--- a/iml-util/Cargo.toml
+++ b/iml-util/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "iml-util"
+description = "IML Util Library"
+license = "MIT"
+version = "0.1.0"
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+
+[lib]
+path = "util.rs"

--- a/iml-util/util.rs
+++ b/iml-util/util.rs
@@ -6,15 +6,12 @@ pub trait Flatten<T> {
     fn flatten(self) -> Option<T>;
 }
 
+/// Implement flatten for the `Option` type.
+/// See https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten
+/// for more information.
 impl<T> Flatten<T> for Option<Option<T>> {
     fn flatten(self) -> Option<T> {
         self.unwrap_or(None)
-    }
-}
-
-impl<T> Flatten<T> for Option<Option<Option<T>>> {
-    fn flatten(self) -> Option<T> {
-        self.unwrap_or(None).unwrap_or(None)
     }
 }
 
@@ -23,26 +20,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_option_of_Some() {
+    fn test_option_of_some() {
         let x = Some(Some(7));
         assert_eq!(x.flatten(), Some(7));
     }
 
     #[test]
-    fn test_option_of_None() {
-        let x = Some(Some(None));
+    fn test_option_of_none() {
+        let x: Option<Option<i32>> = Some(None);
         assert_eq!(x.flatten(), None);
     }
 
     #[test]
     fn test_option_of_option_of_some() {
         let x = Some(Some(Some(7)));
-        assert_eq!(x.flatten(), Some(7));
+        assert_eq!(x.flatten().flatten(), Some(7));
     }
 
     #[test]
-    fn test_option_of_option_of_None() {
-        let x = Some(Some(None));
-        assert_eq!(x.flatten(), None);
+    fn test_option_of_option_of_none() {
+        let x: Option<Option<Option<u32>>> = Some(Some(None));
+        assert_eq!(x.flatten().flatten(), None);
     }
 }

--- a/iml-util/util.rs
+++ b/iml-util/util.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+pub trait Flatten<T> {
+    fn flatten(self) -> Option<T>;
+}
+
+impl<T> Flatten<T> for Option<Option<T>> {
+    fn flatten(self) -> Option<T> {
+        self.unwrap_or(None)
+    }
+}
+
+impl<T> Flatten<T> for Option<Option<Option<T>>> {
+    fn flatten(self) -> Option<T> {
+        self.unwrap_or(None).unwrap_or(None)
+    }
+}

--- a/iml-util/util.rs
+++ b/iml-util/util.rs
@@ -17,3 +17,32 @@ impl<T> Flatten<T> for Option<Option<Option<T>>> {
         self.unwrap_or(None).unwrap_or(None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_option_of_Some() {
+        let x = Some(Some(7));
+        assert_eq!(x.flatten(), Some(7));
+    }
+
+    #[test]
+    fn test_option_of_None() {
+        let x = Some(Some(None));
+        assert_eq!(x.flatten(), None);
+    }
+
+    #[test]
+    fn test_option_of_option_of_some() {
+        let x = Some(Some(Some(7)));
+        assert_eq!(x.flatten(), Some(7));
+    }
+
+    #[test]
+    fn test_option_of_option_of_None() {
+        let x = Some(Some(None));
+        assert_eq!(x.flatten(), None);
+    }
+}


### PR DESCRIPTION
This crate will provide a place to add traits and other useful features.
This can come in handy when a feature is only enabled for nightly rust,
     for example. Implementing a trait here in the utils crate provides
     the ability to use features we may not otherwise have access to.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>