### PR TITLE
Fixup python cli

### DIFF
--- a/chroma_api/authentication.py
+++ b/chroma_api/authentication.py
@@ -46,7 +46,11 @@ class CsrfAuthentication(Authentication):
             return True
 
         request_csrf_token = request.META.get("HTTP_X_CSRFTOKEN", "")
-        csrf_token = request.META["CSRF_COOKIE"]
+
+        csrf_token = request.META.get("CSRF_COOKIE")
+
+        if csrf_token is None:
+            return False
 
         if not constant_time_compare(csrf_token, request_csrf_token):
             return False

--- a/chroma_cli/api.py
+++ b/chroma_cli/api.py
@@ -78,8 +78,7 @@ class ChromaSessionClient(object):
             raise RuntimeError("No session (status: %s, text: %s)" % (r.status_code, r.content))
 
         self.session.headers["X-CSRFToken"] = r.cookies["csrftoken"]
-        self.session.cookies["csrftoken"] = r.cookies["csrftoken"]
-        self.session.cookies["sessionid"] = r.cookies["sessionid"]
+        self.session.cookies.set("csrftoken", r.cookies["csrftoken"])
 
     def login(self, **credentials):
         if not self.is_authenticated:
@@ -87,9 +86,12 @@ class ChromaSessionClient(object):
                 self.start_session()
 
             r = self.post(self.session_uri, data=json.dumps(credentials))
+
             if not 200 <= r.status_code < 300:
                 raise AuthenticationFailure()
             else:
+                self.session.headers["X-CSRFToken"] = r.cookies["csrftoken"]
+                self.session.cookies.set("sessionid", r.cookies["sessionid"])
                 self.is_authenticated = True
 
         return self.is_authenticated


### PR DESCRIPTION
The python manager cli currently is expecting a sessionid
for a non-logged in user.

In more recent versions of Django, a sessionid is not provided
until a user has logged in.

In addition, we should update the csrftoken header after logging in to
match the csrftoken value passed back.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>