### PR TITLE
Use copr-lustre to build

### DIFF
--- a/ci/azure-test-pipeline.yml
+++ b/ci/azure-test-pipeline.yml
@@ -34,7 +34,7 @@ jobs:
       name: test_rpm_build
       displayName: Test rpm building
       spec: rust-iml.spec
-      image: imlteam/copr
+      image: imlteam/copr-lustre
 
   # Check formatting
   - template: template/azure-rustfmt.yml


### PR DESCRIPTION
So tests can pass until 2.12.3 is available.