### PR TITLE
Use serial try-restart of pacemaker

### DIFF
--- a/tests/integration/core/chroma_integration_testcase.py
+++ b/tests/integration/core/chroma_integration_testcase.py
@@ -287,6 +287,7 @@ class ChromaIntegrationTestCase(ApiTestCaseWithTestReset):
                 ],
                 x["fqdn"],
                 "Set pacemaker debug for test",
+                expected_return_code=None,  # Not all nodes will have pacemaker (e.g. client)
             )
 
         for host in new_hosts:

--- a/tests/integration/core/chroma_integration_testcase.py
+++ b/tests/integration/core/chroma_integration_testcase.py
@@ -279,15 +279,11 @@ class ChromaIntegrationTestCase(ApiTestCaseWithTestReset):
         self.assertEqual(len(new_hosts), len(addresses), new_hosts)
 
         # Setup pacemaker debugging
-        self.execute_simultaneous_commands(
-            [
+        for x in new_hosts:
+            self.execute_commands([
                 "grep -q ^PCMK_debug /etc/sysconfig/pacemaker || echo PCMK_debug=crmd,pengine,stonith-ng >> /etc/sysconfig/pacemaker",
                 "systemctl try-restart pacemaker",
-            ],
-            [x["fqdn"] for x in new_hosts],
-            "Set pacemaker debug for test",
-            expected_return_code=None,
-        )
+            ], x["fqdn"], "Set pacemaker debug for test")
 
         for host in new_hosts:
             profile = self.get_current_host_profile(host)

--- a/tests/integration/core/chroma_integration_testcase.py
+++ b/tests/integration/core/chroma_integration_testcase.py
@@ -280,10 +280,14 @@ class ChromaIntegrationTestCase(ApiTestCaseWithTestReset):
 
         # Setup pacemaker debugging
         for x in new_hosts:
-            self.execute_commands([
-                "grep -q ^PCMK_debug /etc/sysconfig/pacemaker || echo PCMK_debug=crmd,pengine,stonith-ng >> /etc/sysconfig/pacemaker",
-                "systemctl try-restart pacemaker",
-            ], x["fqdn"], "Set pacemaker debug for test")
+            self.execute_commands(
+                [
+                    "grep -q ^PCMK_debug /etc/sysconfig/pacemaker || echo PCMK_debug=crmd,pengine,stonith-ng >> /etc/sysconfig/pacemaker",
+                    "systemctl try-restart pacemaker",
+                ],
+                x["fqdn"],
+                "Set pacemaker debug for test",
+            )
 
         for host in new_hosts:
             profile = self.get_current_host_profile(host)


### PR DESCRIPTION
Adding debug to pacemaker and restarting after host addition is done in
parallel, which may be causing issues.

Instead use a serial restart for each node and check that the return
code is 0.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>