### PR TITLE
Lock patchless profile to el7.6

### DIFF
--- a/base_managed_patchless.profile
+++ b/base_managed_patchless.profile
@@ -24,7 +24,7 @@
   "validation": [
     {
       "description": "The profile is designed for version 7 of EL",
-      "test": "distro_version < 8 and distro_version >= 7"
+      "test": "distro_version < 7.7 and distro_version > 7.5"
     }
   ]
 }


### PR DESCRIPTION
Since we reference 7.6 in zfs repo, we shouldn't try to install
on any other rev-level

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>