### PR TITLE
Centrally define base packages

### DIFF
--- a/chroma_agent_comms/views.py
+++ b/chroma_agent_comms/views.py
@@ -388,8 +388,8 @@ def setup(request, key):
     crypto = Crypto()
     cert_str = open(crypto.AUTHORITY_CERT_FILE).read()
 
-    repo_packages = "python2-iml-agent rust-iml-agent"
     server_profile = ServerProfile.objects.get(name=request.REQUEST["profile_name"])
+    repo_packages = " ".join(server_profile.base_packages)
 
     repos = server_profile.repo_contents
 

--- a/chroma_core/models/host.py
+++ b/chroma_core/models/host.py
@@ -1523,7 +1523,7 @@ class UpdateJob(Job):
             (UpdateYumFileStep, {"host": self.host, "filename": REPO_FILENAME, "file_contents": repo_file_contents}),
             (
                 UpdatePackagesStep,
-                {"host": self.host, "enablerepos": [], "packages": ["python2-iml-agent", "rust-iml-agent"]},
+                {"host": self.host, "enablerepos": [], "packages": list(self.host.server_profile.base_packages)},
             ),
             (RemovePackagesStep, {"host": self.host, "packages": ["lustre-all-dkms"]}),
             (

--- a/chroma_core/models/server_profile.py
+++ b/chroma_core/models/server_profile.py
@@ -39,6 +39,14 @@ class ServerProfile(models.Model):
             yield package["package_name"]
 
     @property
+    def base_packages(self):
+        """
+        Obtaining an iterable list of the base packages always installed on a host
+        """
+        for package in ["python2-iml-agent", "rust-iml-agent"]:
+            yield package
+
+    @property
     def repos(self):
         """
         Convenience for obtaining an iterable of repo names from the ServerProfilePackage model


### PR DESCRIPTION
Define "base" packages in a single location (ServerProfile)
base packages are packages that are ALWAYS installed on a host.

Fixes #1264 

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>