### PR TITLE
GH-1246 - Stop services during setup before restarting rabbitmq

### DIFF
--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -829,6 +829,7 @@ proxy=_none_
         self._setup_ntp(ntp_server)
         self._setup_crypto()
 
+        self._stop_services()
         self._setup_rabbitmq_service()
 
         self._setup_rabbitmq_credentials()


### PR DESCRIPTION
Fixes #1246.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>