### PR TITLE
GH-1248 Add package-upgrade check

### DIFF
--- a/tests/integration/core/remote_operations.py
+++ b/tests/integration/core/remote_operations.py
@@ -1031,7 +1031,9 @@ class RealRemoteOperations(RemoteOperations):
         self._ssh_address(server["address"], "yum -y upgrade --exclude=python2-iml*")
 
     def yum_check_update(self, server):
-        self._ssh_address(server["address"], "yum check-update | xargs -n3 | column -t | awk '{print$2}'")
+        logger.debug("Checking for updates")
+        result = self._ssh_address(server["address"], "yum check-update | xargs -n3 | column -t | awk '{print$2}'")
+        logger.debug("yum_check_update results: {}".format(result))
 
     def default_boot_kernel_path(self, server):
         r = self._ssh_address(server["address"], "grubby --default-kernel")

--- a/tests/integration/core/remote_operations.py
+++ b/tests/integration/core/remote_operations.py
@@ -1031,8 +1031,13 @@ class RealRemoteOperations(RemoteOperations):
         self._ssh_address(server["address"], "yum -y upgrade --exclude=python2-iml*")
 
     def yum_check_update(self, server):
-        available_updates = self._ssh_address(server["address"], "yum check-update | xargs -n3 | column -t | awk '{print$1}'")
-        available_updates =  filter(lambda x: x != "Loaded" and x != "Loading" and x != "from" and x != "*", available_updates.stdout.split("\n"))
+        available_updates = self._ssh_address(
+            server["address"], "yum check-update | xargs -n3 | column -t | awk '{print$1}'"
+        )
+        available_updates = filter(
+            lambda x: x != "Loaded" and x != "Loading" and x != "from" and x != "*",
+            available_updates.stdout.split("\n"),
+        )
         logger.debug("yum_check_update results: {}".format(available_updates))
         return available_updates
 

--- a/tests/integration/core/remote_operations.py
+++ b/tests/integration/core/remote_operations.py
@@ -1027,6 +1027,12 @@ class RealRemoteOperations(RemoteOperations):
     def yum_update(self, server):
         self._ssh_address(server["address"], "yum -y update")
 
+    def yum_upgrade_exclude_python2_iml(self, server):
+        self._ssh_address(server["address"], "yum -y upgrade --exclude=python2-iml*")
+
+    def yum_check_update(self, server):
+        self._ssh_address(server["address"], "yum check-update | xargs -n3 | column -t | awk '{print$2}'")
+
     def default_boot_kernel_path(self, server):
         r = self._ssh_address(server["address"], "grubby --default-kernel")
         stdout = r.stdout.rstrip()

--- a/tests/integration/core/remote_operations.py
+++ b/tests/integration/core/remote_operations.py
@@ -1031,9 +1031,10 @@ class RealRemoteOperations(RemoteOperations):
         self._ssh_address(server["address"], "yum -y upgrade --exclude=python2-iml*")
 
     def yum_check_update(self, server):
-        logger.debug("Checking for updates")
-        result = self._ssh_address(server["address"], "yum check-update | xargs -n3 | column -t | awk '{print$2}'")
-        logger.debug("yum_check_update results: {}".format(result))
+        available_updates = self._ssh_address(server["address"], "yum check-update | xargs -n3 | column -t | awk '{print$1}'")
+        available_updates =  filter(lambda x: x != "Loaded" and x != "Loading" and x != "from" and x != "*", available_updates.stdout.split("\n"))
+        logger.debug("yum_check_update results: {}".format(available_updates))
+        return available_updates
 
     def default_boot_kernel_path(self, server):
         r = self._ssh_address(server["address"], "grubby --default-kernel")

--- a/tests/integration/installation_and_upgrade/test_update_with_yum.py
+++ b/tests/integration/installation_and_upgrade/test_update_with_yum.py
@@ -70,9 +70,9 @@ class TestYumUpdate(TestInstallationAndUpgrade):
         for server in self.config_servers:
             kernel = self.remote_operations.default_boot_kernel_path(server)
             self.assertGreaterEqual(kernel.find("_lustre"), 7)
-            print "About to check for updates on {}".format(server)
             available_updates = self.remote_operations.yum_check_update(server)
-            print "Available updates: {}".format(available_updates)
+            available_updates = filter(lambda x: "iml-" in x, available_updates)
+            self.assertEqual(len(available_updates), 0)
 
         # Update corosync on the storage servers
         # N.B. This will also start the FS

--- a/tests/integration/installation_and_upgrade/test_update_with_yum.py
+++ b/tests/integration/installation_and_upgrade/test_update_with_yum.py
@@ -71,7 +71,7 @@ class TestYumUpdate(TestInstallationAndUpgrade):
             kernel = self.remote_operations.default_boot_kernel_path(server)
             self.assertGreaterEqual(kernel.find("_lustre"), 7)
             print "About to check for updates on {}".format(server)
-            available_updates = yum_check_update(server)
+            available_updates = self.remote_operations.yum_check_update(server)
             print "Available updates: {}".format(available_updates)
 
         # Update corosync on the storage servers

--- a/tests/integration/installation_and_upgrade/test_update_with_yum.py
+++ b/tests/integration/installation_and_upgrade/test_update_with_yum.py
@@ -12,9 +12,6 @@ from tests.integration.installation_and_upgrade.test_installation_and_upgrade im
 class TestYumUpdate(TestInstallationAndUpgrade):
     def test_yum_update(self):
         """ Test for lustre kernel is set to boot after yum update"""
-
-        from remote_pdb import RemotePdb
-        RemotePdb('127.0.0.1', 4444).set_trace()
         self.assertGreaterEqual(len(config["lustre_servers"]), 4)
 
         # get a list of hosts
@@ -73,6 +70,7 @@ class TestYumUpdate(TestInstallationAndUpgrade):
         for server in self.config_servers:
             kernel = self.remote_operations.default_boot_kernel_path(server)
             self.assertGreaterEqual(kernel.find("_lustre"), 7)
+            print "About to check for updates on {}".format(server)
             available_updates = yum_check_update(server)
             print "Available updates: {}".format(available_updates)
 


### PR DESCRIPTION
Add travis CI test that parses the Requires from the IML spec and ensures there are no newer versions available than what is pinned. Haven't done too much research but you should be able to use rpmspec to read the spec file.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>