### PR TITLE
Find latest kernel that supports listed modules

### DIFF
--- a/iml-agent/src/action_plugins/check_kernel.rs
+++ b/iml-agent/src/action_plugins/check_kernel.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{agent_error::ImlAgentError, cmd::cmd_output, cmd::cmd_output_success};
+use futures::{
+    compat::Future01CompatExt,
+    future::{FutureExt, TryFutureExt},
+};
+use futures01::Future;
+use std::cmp::Ordering;
+
+#[derive(Debug, PartialEq, Eq)]
+enum VerPart {
+    Int(u32),
+    Str(String),
+}
+
+impl Ord for VerPart {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (VerPart::Int(s), VerPart::Int(o)) => s.cmp(o),
+            (VerPart::Int(_), VerPart::Str(_)) => Ordering::Greater,
+            (VerPart::Str(_), VerPart::Int(_)) => Ordering::Less,
+            (VerPart::Str(s), VerPart::Str(o)) => s.cmp(o),
+        }
+    }
+}
+
+impl PartialOrd for VerPart {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl From<String> for VerPart {
+    fn from(part: String) -> Self {
+        match part.parse::<u32>() {
+            Ok(n) => VerPart::Int(n),
+            Err(_) => VerPart::Str(part),
+        }
+    }
+}
+
+impl From<&str> for VerPart {
+    fn from(part: &str) -> Self {
+        match part.parse::<u32>() {
+            Ok(n) => VerPart::Int(n),
+            Err(_) => VerPart::Str(part.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Eq)]
+struct Version {
+    version: String,
+    v: Vec<VerPart>,
+    r: Vec<VerPart>,
+}
+
+impl From<&str> for Version {
+    fn from(version: &str) -> Self {
+        let vr: Vec<&str> = version.splitn(2, '-').collect();
+        Version {
+            version: version.to_string(),
+            v: if vr.len() > 0 {
+                vr[0].split('.').map(|s| VerPart::from(s)).collect()
+            } else {
+                vec![]
+            },
+            r: if vr.len() > 1 {
+                vr[1].split('.').map(|s| VerPart::from(s)).collect()
+            } else {
+                vec![]
+            },
+        }
+    }
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.v.cmp(&other.v).then(self.r.cmp(&other.r))
+    }
+}
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Version {
+    fn eq(&self, other: &Self) -> bool {
+        self.version == other.version
+    }
+}
+
+async fn check_kver_module(module: &str, kver: &str) -> Result<bool, ImlAgentError> {
+    let output = cmd_output("modinfo", &["-n", "-k", kver, module])
+        .compat()
+        .await?;
+
+    Ok(output.status.success())
+}
+
+pub async fn get_kernel_async(modules: Vec<String>) -> Result<String, ImlAgentError> {
+    let output = cmd_output_success("rpm", &["-q", "--qf", "%{V}-%{R}.%{ARCH}\n", "kernel"])
+        .compat()
+        .await?;
+
+    let mut newest = Version::from("");
+
+    for kver in std::str::from_utf8(output.stdout.as_slice())?.lines() {
+        let mut okay = true;
+        for module in modules.iter() {
+            if !check_kver_module(&module, kver).await? {
+                okay = false;
+                break;
+            }
+        }
+        if okay {
+            newest = newest.max(Version::from(kver));
+        }
+    }
+    Ok(newest.version)
+}
+
+pub fn get_kernel(modules: Vec<String>) -> impl Future<Item = String, Error = ImlAgentError> {
+    get_kernel_async(modules).boxed().compat()
+}

--- a/iml-agent/src/action_plugins/check_kernel.rs
+++ b/iml-agent/src/action_plugins/check_kernel.rs
@@ -90,15 +90,14 @@ impl PartialEq for Version {
 }
 
 async fn check_kver_module(module: &str, kver: &str) -> Result<bool, ImlAgentError> {
-    let output = cmd_output("modinfo", vec!["-n", "-k", kver, module])
-        .await?;
+    let output = cmd_output("modinfo", vec!["-n", "-k", kver, module]).await?;
 
     Ok(output.status.success())
 }
 
 pub async fn get_kernel(modules: Vec<String>) -> Result<String, ImlAgentError> {
-    let output = cmd_output_success("rpm", vec!["-q", "--qf", "%{V}-%{R}.%{ARCH}\n", "kernel"])
-        .await?;
+    let output =
+        cmd_output_success("rpm", vec!["-q", "--qf", "%{V}-%{R}.%{ARCH}\n", "kernel"]).await?;
 
     let mut newest = Version::from("");
 

--- a/iml-agent/src/action_plugins/check_kernel.rs
+++ b/iml-agent/src/action_plugins/check_kernel.rs
@@ -110,6 +110,10 @@ pub async fn get_kernel_async(modules: Vec<String>) -> Result<String, ImlAgentEr
     let mut newest = Version::from("");
 
     for kver in std::str::from_utf8(output.stdout.as_slice())?.lines() {
+        let contender = Version::from(kver);
+        if contender <= newest {
+            continue;
+        }
         let mut okay = true;
         for module in modules.iter() {
             if !check_kver_module(&module, kver).await? {
@@ -118,7 +122,7 @@ pub async fn get_kernel_async(modules: Vec<String>) -> Result<String, ImlAgentEr
             }
         }
         if okay {
-            newest = newest.max(Version::from(kver));
+            newest = contender;
         }
     }
     Ok(newest.version)

--- a/iml-agent/src/action_plugins/mod.rs
+++ b/iml-agent/src/action_plugins/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod action_plugin;
 pub mod check_ha;
+pub mod check_kernel;
 pub mod check_stonith;
 pub mod stratagem;
 pub use action_plugin::{create_registry, Actions};

--- a/iml-agent/src/cli.rs
+++ b/iml-agent/src/cli.rs
@@ -332,7 +332,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             Err(e) => println!("{:?}", e),
         },
-        App::GetKernel { modules } => match check_kernel::get_kernel(modules).wait() {
+        App::GetKernel { modules } => match check_kernel::get_kernel(modules).await {
             Ok(s) => println!("{}", s),
             Err(e) => println!("{:?}", e),
         },

--- a/iml-agent/src/cli.rs
+++ b/iml-agent/src/cli.rs
@@ -6,7 +6,7 @@ use iml_agent::action_plugins::stratagem::{
     action_purge, action_warning,
     server::{generate_cooked_config, trigger_scan, Counter, StratagemCounters},
 };
-use iml_agent::action_plugins::{check_ha, check_stonith};
+use iml_agent::action_plugins::{check_ha, check_kernel, check_stonith};
 use prettytable::{cell, row, Table};
 use spinners::{Spinner, Spinners};
 use std::{
@@ -124,6 +124,10 @@ pub enum App {
 
     #[structopt(name = "check_stonith")]
     CheckStonith,
+
+    #[structopt(name = "get_kernel")]
+    /// Get latest kernel which supports listed modules
+    GetKernel { modules: Vec<String> },
 }
 
 fn input_to_iter(input: Option<String>, fidlist: Vec<String>) -> Box<dyn Iterator<Item = String>> {
@@ -326,6 +330,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     cs.info
                 );
             }
+            Err(e) => println!("{:?}", e),
+        },
+        App::GetKernel { modules } => match check_kernel::get_kernel(modules).wait() {
+            Ok(s) => println!("{}", s),
             Err(e) => println!("{:?}", e),
         },
     };


### PR DESCRIPTION
Will iterate all installed kernels (found via rpm -q),
and check for listed modules, and will return kernel, that
supports ALL modules.

Fixes Issue #1293

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>