### PR TITLE
Wait for gunicorn

### DIFF
--- a/iml-gunicorn.service
+++ b/iml-gunicorn.service
@@ -5,7 +5,7 @@ Before=nginx.service
 
 
 [Service]
-Type=simple
+Type=notify
 WorkingDirectory=/usr/share/chroma-manager
 ExecStart=/bin/gunicorn wsgi:application -c ./wsgi.py
 Restart=on-failure

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -63,6 +63,7 @@ Requires:       rabbitmq-server >= 3.3.5-34
 Requires:       Django >= 1.11, Django < 1.12
 Requires:       policycoreutils-python
 Requires:       system-config-firewall-base
+Requires:       systemd-python
 Requires:       nginx >= 1:1.12.2
 Requires:       nodejs >= 1:6.16.0
 Requires(post): selinux-policy-targeted

--- a/wsgi.py
+++ b/wsgi.py
@@ -113,7 +113,7 @@ def when_ready(server):
     try:
         from systemd.daemon import notify
 
-        notify('READY=1')
+        notify("READY=1")
     except ImportError:
         pass
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -109,6 +109,15 @@ def get_app():
     return get_wsgi_application()
 
 
+def when_ready(server):
+    try:
+        from systemd.daemon import notify
+
+        notify('READY=1')
+    except ImportError:
+        pass
+
+
 def post_fork(server, worker):
     from chroma_core.services.log import log_set_filename, log_enable_stdout
 


### PR DESCRIPTION
When (re)starting gunicorn, there are cases where the service is marked
as ready before it can accept connections. This leads to 502 errors.

Update the gunicorn service to use systemd notications to tell when it's
ready for requests.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>