### PR TITLE
Update seed crate from 0.4.0 to 0.4.1

### DIFF
--- a/iml-wasm-components/Cargo.lock
+++ b/iml-wasm-components/Cargo.lock
@@ -51,7 +51,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "bootstrap-components"
 version = "0.1.0"
 dependencies = [
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ dependencies = [
  "iml-wire-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -234,7 +234,7 @@ dependencies = [
  "iml-utils 0.1.0",
  "iml-wire-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -247,7 +247,7 @@ dependencies = [
  "iml-utils 0.1.0",
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -258,7 +258,7 @@ version = "0.1.0"
 dependencies = [
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -285,7 +285,7 @@ dependencies = [
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -297,7 +297,7 @@ name = "iml-grafana-chart"
 version = "0.1.0"
 dependencies = [
  "iml-environment 0.1.0",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -311,7 +311,7 @@ dependencies = [
  "iml-utils 0.1.0",
  "iml-wire-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -320,14 +320,14 @@ version = "0.1.0"
 dependencies = [
  "bootstrap-components 0.1.0",
  "iml-utils 0.1.0",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "iml-pie-chart"
 version = "0.1.0"
 dependencies = [
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -336,7 +336,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -359,7 +359,7 @@ dependencies = [
  "iml-utils 0.1.0",
  "iml-wire-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -374,7 +374,7 @@ dependencies = [
  "bootstrap-components 0.1.0",
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -383,7 +383,7 @@ name = "iml-tooltip"
 version = "0.1.0"
 dependencies = [
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -395,7 +395,7 @@ dependencies = [
  "iml-wire-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -417,7 +417,7 @@ dependencies = [
  "iml-wire-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -722,7 +722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "seed"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1126,7 +1126,7 @@ dependencies = [
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-"checksum seed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7dd46ad45809a5a08c7ec2b3ed9f6a077d4e4b7b62878f6e58c8957db60b75c"
+"checksum seed 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e301f6934f124e16fc9ddc7a1cc605e47153d44ab8bc6ff69ddd4fe69cfa57e1"
 "checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
 "checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"

--- a/iml-wasm-components/bootstrap-components/Cargo.toml
+++ b/iml-wasm-components/bootstrap-components/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 
 [lib]
 path = "bootstrap.rs"

--- a/iml-wasm-components/iml-action-dropdown/Cargo.toml
+++ b/iml-wasm-components/iml-action-dropdown/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 serde = { version = "1", features = ['derive'] }
 serde_json = "1.0"
 futures = "0.1"

--- a/iml-wasm-components/iml-action-dropdown/src/action_dropdown.rs
+++ b/iml-wasm-components/iml-action-dropdown/src/action_dropdown.rs
@@ -26,15 +26,15 @@ pub fn dropdown<T>(
 ) -> Node<T> {
     let open_class = if open { "open" } else { "" };
 
-    let btn: Node<_> = button![
+    let mut btn: Node<_> = button![
         class!["btn", "dropdown-toggle"],
         btn_name,
         i![class!["fa", "fa-fw", "fa-caret-down", "icon-caret-down"]]
     ];
 
-    let btn = btn_classes
-        .into_iter()
-        .fold(btn, |btn, &x| btn.add_class(x));
+    for &c in btn_classes {
+        btn.add_class(c);
+    }
 
     div![
         class!["btn-group", "dropdown", open_class],

--- a/iml-wasm-components/iml-action-dropdown/src/deferred_action_dropdown.rs
+++ b/iml-wasm-components/iml-action-dropdown/src/deferred_action_dropdown.rs
@@ -227,10 +227,11 @@ pub fn render_with_action<'a, T: 'static + ActionRecord>(
     model: &Model,
     actions: ActionMap<'a, T>,
 ) -> Node<IdMsg<T>> {
+    let mut el;
     if model.destroyed {
-        seed::empty()
+        el = seed::empty();
     } else if model.first_fetch_activated {
-        div![
+        el = div![
             class!["action-dropdown"],
             button![
                 attrs! {At::Disabled => true},
@@ -238,14 +239,14 @@ pub fn render_with_action<'a, T: 'static + ActionRecord>(
                 "Waiting",
                 i![class!["fa", "fa-spinner", "fa-fw", "fa-spin"]]
             ]
-        ]
+        ];
     } else if !model.activated {
-        action_dropdown(model.watching.is_open(), model.is_locked, vec![span![]])
-            .add_listener(simple_ev(Ev::MouseMove, IdMsg(id, Msg::StartFetch)))
+        el = action_dropdown(model.watching.is_open(), model.is_locked, vec![span![]]);
+        el.add_listener(simple_ev(Ev::MouseMove, IdMsg(id, Msg::StartFetch)));
     } else {
         let record_els = get_record_els(id, actions, &model.flag, &model.tooltip);
-
-        action_dropdown(model.watching.is_open(), model.is_locked, record_els)
-            .add_listener(simple_ev(Ev::Click, IdMsg(id, Msg::WatchChange)))
+        el = action_dropdown(model.watching.is_open(), model.is_locked, record_els);
+        el.add_listener(simple_ev(Ev::Click, IdMsg(id, Msg::WatchChange)));
     }
+    el
 }

--- a/iml-wasm-components/iml-action-dropdown/src/hsm_action_dropdown.rs
+++ b/iml-wasm-components/iml-action-dropdown/src/hsm_action_dropdown.rs
@@ -129,6 +129,7 @@ pub fn view(model: &Model) -> Node<Msg> {
         Msg::ActionClicked,
     );
 
-    action_dropdown(model.watching.is_open(), model.is_locked, record_els)
-        .add_listener(simple_ev(Ev::Click, Msg::WatchChange))
+    let mut el = action_dropdown(model.watching.is_open(), model.is_locked, record_els);
+    el.add_listener(simple_ev(Ev::Click, Msg::WatchChange));
+    el
 }

--- a/iml-wasm-components/iml-alert-indicator/Cargo.toml
+++ b/iml-wasm-components/iml-alert-indicator/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 log = "0.4"
 bootstrap-components = { path = "../bootstrap-components", version = "0.1" }
 iml-tooltip = { path = "../iml-tooltip", version = "0.1" }

--- a/iml-wasm-components/iml-alert-indicator/src/lib.rs
+++ b/iml-wasm-components/iml-alert-indicator/src/lib.rs
@@ -44,14 +44,12 @@ pub fn alert_indicator(
             if alerts.is_empty() {
                 vec![i![class!["fa", "fa-check-circle"]]]
             } else {
-                let i = i![class!["fa", "activate-popover", "fa-exclamation-circle"]];
+                let mut i = i![class!["fa", "activate-popover", "fa-exclamation-circle"]];
 
-                let i = if !open {
+                if !open {
                     i.add_listener(mouse_ev(Ev::Click, move |_| {
                         AlertIndicatorPopoverState((id, WatchState::Watching))
-                    }))
-                } else {
-                    i
+                    }));
                 };
 
                 vec![

--- a/iml-wasm-components/iml-duration-picker/Cargo.toml
+++ b/iml-wasm-components/iml-duration-picker/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 path = "duration-picker.rs"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 log = "0.4"
 web-sys = { version = "0.3", features = ["Event", "EventTarget", "Element", "HtmlInputElement", "ValidityState"]}
 iml-tooltip = { path = "../iml-tooltip", version = "0.1" }

--- a/iml-wasm-components/iml-duration-picker/duration-picker.rs
+++ b/iml-wasm-components/iml-duration-picker/duration-picker.rs
@@ -163,7 +163,7 @@ pub fn duration_picker(model: &Model, mut input: Node<Msg>) -> Vec<Node<Msg>> {
         )
         .collect();
 
-    input = input
+    input
         .add_class("form-control")
         .add_attrs(attrs! {
             At::Type => "number",
@@ -171,15 +171,14 @@ pub fn duration_picker(model: &Model, mut input: Node<Msg>) -> Vec<Node<Msg>> {
             At::Max => MAX_SAFE_INTEGER
         })
         .add_listener(raw_ev(Ev::Input, Msg::InputChange));
-
     if let Some(x) = model.value {
-        input = input.add_attr(At::Value.as_str(), x);
+        input.add_attr(At::Value.as_str(), x);
     } else {
-        input = input.add_attr(At::Value.as_str(), "");
+        input.add_attr(At::Value.as_str(), "");
     }
 
     if model.disabled {
-        input = input.add_attr(At::Disabled.as_str(), true);
+        input.add_attr(At::Disabled.as_str(), true);
     }
 
     let validation_message = &model.validation_message;
@@ -209,21 +208,17 @@ pub fn duration_picker(model: &Model, mut input: Node<Msg>) -> Vec<Node<Msg>> {
 
     let open = model.watching.is_open();
 
-    let btn = bs_dropdown::btn(model.unit.to_string()).add_attrs(attrs);
+    let mut btn = bs_dropdown::btn(model.unit.to_string());
+    btn.add_attrs(attrs);
 
-    let mut dropdown = bs_dropdown::wrapper(
-        class![bs_input::INPUT_GROUP_BTN],
-        open,
-        vec![
-            btn,
-            bs_dropdown::menu(items).add_class(bs_dropdown::DROPDOWN_MENU_RIGHT),
-        ],
-    );
+    let mut menu = bs_dropdown::menu(items);
+    menu.add_class(bs_dropdown::DROPDOWN_MENU_RIGHT);
 
-    dropdown = if !open && !model.disabled {
-        dropdown.add_listener(mouse_ev(Ev::Click, move |_| Msg::WatchChange))
-    } else {
-        dropdown
+    let mut dropdown =
+        bs_dropdown::wrapper(class![bs_input::INPUT_GROUP_BTN], open, vec![btn, menu]);
+
+    if !open && !model.disabled {
+        dropdown.add_listener(mouse_ev(Ev::Click, move |_| Msg::WatchChange));
     };
 
     vec![input, el, dropdown]

--- a/iml-wasm-components/iml-environment/Cargo.toml
+++ b/iml-wasm-components/iml-environment/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"]}
 web-sys = { version = "0.3", features = ["HtmlDocument"] }
 regex = "1"

--- a/iml-wasm-components/iml-fs/Cargo.toml
+++ b/iml-wasm-components/iml-fs/Cargo.toml
@@ -20,7 +20,7 @@ iml-utils = { path = "../iml-utils", version = "0.1" }
 iml-wire-types = "0.2"
 iml-stratagem = { path = "../iml-stratagem", version = "0.1" }
 log = "0.4"
-seed = "=0.4.0"
+seed = "=0.4.1"
 natord = "1.0.9"
 serde = { version = "1", features = ['derive'] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"]}

--- a/iml-wasm-components/iml-fs/src/fs_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_page.rs
@@ -193,8 +193,21 @@ fn fs_rows(model: &Model) -> Vec<Node<Msg>> {
         .values()
         .map(|x| {
             let fs = &x.fs;
-
             let mgt = model.get_mgt(&fs);
+            let mut lck = lock_indicator(
+                fs.id,
+                x.lock_indicator.is_open(),
+                fs.composite_id(),
+                &model.locks,
+            );
+            lck.add_style("margin-right", px(5));
+
+            let alr = alert_indicator(
+                &model.alerts,
+                fs.id,
+                &fs.resource_uri,
+                x.alert_indicator.is_open(),
+            );
 
             tr![
                 td![ui_link(
@@ -202,21 +215,8 @@ fn fs_rows(model: &Model) -> Vec<Node<Msg>> {
                     &fs.name
                 )],
                 td![
-                    lock_indicator(
-                        fs.id,
-                        x.lock_indicator.is_open(),
-                        fs.composite_id(),
-                        &model.locks
-                    )
-                    .add_style("margin-right", px(5))
-                    .map_message(Msg::FsRowLockIndicatorState),
-                    alert_indicator(
-                        &model.alerts,
-                        fs.id,
-                        &fs.resource_uri,
-                        x.alert_indicator.is_open()
-                    )
-                    .map_message(Msg::FsRowPopoverState)
+                    lck.map_message(Msg::FsRowLockIndicatorState),
+                    alr.map_message(Msg::FsRowPopoverState)
                 ],
                 td![mgt_link(mgt)],
                 td![fs.mdts.len().to_string()],

--- a/iml-wasm-components/iml-fs/src/lib.rs
+++ b/iml-wasm-components/iml-fs/src/lib.rs
@@ -43,16 +43,19 @@ fn usage<T>(
     formatter: fn(f64, Option<usize>) -> String,
 ) -> Node<T> {
     div![match (used, total) {
-        (Some(used), Some(total)) => div![
-            pie_chart(used, total, "#aec7e8", "#1f77b4")
-                .add_style("width", px(18))
+        (Some(used), Some(total)) => {
+            let mut pc = pie_chart(used, total, "#aec7e8", "#1f77b4");
+            pc.add_style("width", px(18))
                 .add_style("height", px(18))
                 .add_style("vertical-align", "bottom")
-                .add_style("margin-right", px(3)),
-            formatter(used, Some(1)),
-            " / ",
-            formatter(total, Some(1)),
-        ],
+                .add_style("margin-right", px(3));
+            div![
+                pc,
+                formatter(used, Some(1)),
+                " / ",
+                formatter(total, Some(1)),
+            ]
+        }
         _ => Node::new_text("Calculating..."),
     }]
 }

--- a/iml-wasm-components/iml-grafana-chart/Cargo.toml
+++ b/iml-wasm-components/iml-grafana-chart/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 serde = { version = "1", features = ['derive'] }
 serde_urlencoded = "0.6.1"
 iml-environment = { path = "../iml-environment", version = "0.1" }

--- a/iml-wasm-components/iml-lock-indicator/Cargo.toml
+++ b/iml-wasm-components/iml-lock-indicator/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 log = "0.4"
 iml-tooltip = { path = "../iml-tooltip", version = "0.1" }
 iml-wire-types = "0.2"

--- a/iml-wasm-components/iml-lock-indicator/lock-indicator.rs
+++ b/iml-wasm-components/iml-lock-indicator/lock-indicator.rs
@@ -59,14 +59,12 @@ pub fn lock_indicator(
 ) -> Node<LockIndicatorState> {
     match get_locks(composite_id, &locks) {
         Some((write_locks, read_locks)) => {
-            let i = i![class!["fa", "fa-lock"]];
+            let mut i = i![class!["fa", "fa-lock"]];
 
-            let i = if !open {
+            if !open {
                 i.add_listener(mouse_ev(Ev::Click, move |_| {
                     LockIndicatorState(id, WatchState::Watching)
-                }))
-            } else {
-                i
+                }));
             };
 
             span![

--- a/iml-wasm-components/iml-paging/Cargo.toml
+++ b/iml-wasm-components/iml-paging/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 bootstrap-components = { path = "../bootstrap-components", version = "0.1" }
 iml-utils = { path = "../iml-utils", version = "0.1" }
-seed = "=0.4.0"
+seed = "=0.4.1"
 
 
 [lib]

--- a/iml-wasm-components/iml-paging/paging.rs
+++ b/iml-wasm-components/iml-paging/paging.rs
@@ -60,18 +60,19 @@ pub enum PagingMsg {
 }
 
 pub fn page_selection(open: bool, rows: usize) -> Node<PagingMsg> {
-    let btn = bs_button::btn(
+    let mut btn = bs_button::btn(
         class![bs_dropdown::DROPDOWN_TOGGLE, bs_button::EXTRASMALL],
         vec![
             Node::new_text(rows.to_string()),
             i![class!["fa", "fa-fw", "fa-caret-up", "icon-caret-up"]],
         ],
-    )
-    .add_listener(mouse_ev(Ev::Click, |_| {
+    );
+
+    btn.add_listener(mouse_ev(Ev::Click, |_| {
         PagingMsg::Dropdown(WatchState::Watching)
     }));
 
-    bs_dropdown::wrapper(
+    let mut drdw = bs_dropdown::wrapper(
         class!["dropup"],
         open,
         vec![
@@ -88,8 +89,9 @@ pub fn page_selection(open: bool, rows: usize) -> Node<PagingMsg> {
                     .collect(),
             ),
         ],
-    )
-    .add_style("display", "inline-block")
+    );
+    drdw.add_style("display", "inline-block");
+    drdw
 }
 
 pub fn update_paging(msg: PagingMsg, p: &mut Paging) {

--- a/iml-wasm-components/iml-pie-chart/Cargo.toml
+++ b/iml-wasm-components/iml-pie-chart/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"

--- a/iml-wasm-components/iml-sleep/Cargo.toml
+++ b/iml-wasm-components/iml-sleep/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 futures = "0.1"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"]}
 

--- a/iml-wasm-components/iml-stratagem/Cargo.toml
+++ b/iml-wasm-components/iml-stratagem/Cargo.toml
@@ -20,7 +20,7 @@ iml-utils = { path = "../iml-utils", version = "0.1" }
 iml-wire-types = "0.2"
 iml-grafana-chart = { path = "../iml-grafana-chart", version = "0.1" }
 log = "0.4"
-seed = "=0.4.0"
+seed = "=0.4.1"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"]}
 web-sys = "0.3"
 chrono = "0.4.9"

--- a/iml-wasm-components/iml-stratagem/src/delete_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/delete_stratagem_button.rs
@@ -23,14 +23,16 @@ pub fn delete_stratagem<T: serde::de::DeserializeOwned + 'static>(
 }
 
 pub fn view(is_valid: bool, disabled: bool) -> Node<Command> {
-    let btn = bs_button::btn(
+    let mut btn = bs_button::btn(
         class![bs_button::BTN_DANGER, "delete-button"],
         vec![Node::new_text("Delete"), i![class!["fas fa-times-circle"]]],
     );
 
     if is_valid && !disabled {
-        btn.add_listener(simple_ev(Ev::Click, Command::Delete))
+        btn.add_listener(simple_ev(Ev::Click, Command::Delete));
     } else {
-        btn.add_attr(At::Disabled.as_str(), "disabled")
+        btn.add_attr(At::Disabled.as_str(), "disabled");
     }
+
+    btn
 }

--- a/iml-wasm-components/iml-stratagem/src/enable_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/enable_stratagem_button.rs
@@ -22,7 +22,7 @@ pub fn enable_stratagem<T: serde::de::DeserializeOwned + 'static>(
 }
 
 pub fn view(is_valid: bool, disabled: bool) -> Node<Command> {
-    let btn = bs_button::btn(
+    let mut btn = bs_button::btn(
         class![bs_button::BTN_PRIMARY],
         vec![
             Node::new_text("Enable Scan Interval"),
@@ -31,8 +31,10 @@ pub fn view(is_valid: bool, disabled: bool) -> Node<Command> {
     );
 
     if is_valid && !disabled {
-        btn.add_listener(simple_ev(Ev::Click, Command::Enable))
+        btn.add_listener(simple_ev(Ev::Click, Command::Enable));
     } else {
-        btn.add_attr(At::Disabled.as_str(), "disabled")
+        btn.add_attr(At::Disabled.as_str(), "disabled");
     }
+
+    btn
 }

--- a/iml-wasm-components/iml-stratagem/src/inode_table.rs
+++ b/iml-wasm-components/iml-stratagem/src/inode_table.rs
@@ -180,10 +180,11 @@ fn get_inode_elements<T>(inodes: &Vec<INodeCount>) -> Vec<Node<T>> {
 }
 
 fn detail_panel<T>(children: Vec<Node<T>>) -> Node<T> {
-    div!(children)
-        .add_style("display", "grid")
+    let mut div = div!(children);
+    div.add_style("display", "grid")
         .add_style("grid-template-columns", "50% 50%")
-        .add_style("grid-row-gap", px(20))
+        .add_style("grid-row-gap", px(20));
+    div
 }
 
 fn get_date_time(timestamp: i64) -> String {

--- a/iml-wasm-components/iml-stratagem/src/lib.rs
+++ b/iml-wasm-components/iml-stratagem/src/lib.rs
@@ -263,10 +263,11 @@ fn detail_header<T>(header: &str) -> Node<T> {
 }
 
 fn detail_panel<T>(children: Vec<Node<T>>) -> Node<T> {
-    well(children)
-        .add_style("display", "grid")
+    let mut el = well(children);
+    el.add_style("display", "grid")
         .add_style("grid-template-columns", "repeat(11, 1fr) minmax(90px, 1fr)")
-        .add_style("grid-row-gap", px(20))
+        .add_style("grid-row-gap", px(20));
+    el
 }
 
 fn detail_label<T>(content: &str) -> Node<T> {
@@ -317,29 +318,27 @@ pub fn view(model: &Model) -> Node<Msg> {
     ];
 
     if model.id.is_some() {
-        configuration_component.push(
-            update_stratagem_button::view(model.config_valid(), model.disabled || model.is_locked)
-                .add_style("grid-column", "1 /span 12")
-                .map_message(Msg::SendCommand),
-        );
+        let mut upd_btn =
+            update_stratagem_button::view(model.config_valid(), model.disabled || model.is_locked);
+        upd_btn.add_style("grid-column", "1 /span 12");
+        configuration_component.push(upd_btn.map_message(Msg::SendCommand));
 
-        configuration_component.push(
-            delete_stratagem_button::view(model.config_valid(), model.disabled || model.is_locked)
-                .add_style("grid-column", "1 /span 12")
-                .map_message(Msg::SendCommand),
-        );
+        let mut del_btn =
+            delete_stratagem_button::view(model.config_valid(), model.disabled || model.is_locked);
+        del_btn.add_style("grid-column", "1 /span 12");
+        configuration_component.push(del_btn.map_message(Msg::SendCommand));
     } else {
-        configuration_component.push(
-            enable_stratagem_button::view(model.config_valid(), model.disabled || model.is_locked)
-                .add_style("grid-column", "1 /span 12")
-                .map_message(Msg::SendCommand),
-        )
+        let mut enb_btn =
+            enable_stratagem_button::view(model.config_valid(), model.disabled || model.is_locked);
+        enb_btn.add_style("grid-column", "1 /span 12");
+        configuration_component.push(enb_btn.map_message(Msg::SendCommand));
     }
 
+    let mut in_tbl = inode_table::view(&model.inode_table);
+    in_tbl.add_style("margin-bottom", px(20));
+
     div![
-        inode_table::view(&model.inode_table)
-            .add_style("margin-bottom", px(20))
-            .map_message(Msg::InodeTable),
+        in_tbl.map_message(Msg::InodeTable),
         h4![class!["section-header"], "File Size Distribution"],
         p![
             class!["text-muted"],

--- a/iml-wasm-components/iml-stratagem/src/scan_now.rs
+++ b/iml-wasm-components/iml-stratagem/src/scan_now.rs
@@ -116,13 +116,14 @@ pub fn view(fs_id: u32, model: &Model) -> Vec<Node<Msg>> {
             Node::new_text("Scan Filesystem Now"),
             i![class!["far", "fa-chart-bar"]],
         ],
-    )
-    .add_style("margin-left", px(15));
+    );
+
+    scan_now_button.add_style("margin-left", px(15));
 
     if !model.disabled && !model.is_locked {
-        scan_now_button = scan_now_button.add_listener(simple_ev(Ev::Click, Msg::OpenModal));
+        scan_now_button.add_listener(simple_ev(Ev::Click, Msg::OpenModal));
     } else {
-        scan_now_button = scan_now_button.add_attr(At::Disabled.as_str(), "disabled");
+        scan_now_button.add_attr(At::Disabled.as_str(), "disabled");
     }
 
     let mut xs = vec![scan_now_button];
@@ -144,12 +145,22 @@ fn scan_modal(fs_id: u32, model: &Model) -> Vec<Node<Msg>> {
         } else {
             Node::new_text("Scan Now")
         }],
-    )
-    .add_listener(mouse_ev(Ev::Click, move |_| Msg::ScanStratagem(fs_id)));
+    );
+
+    scan_button.add_listener(mouse_ev(Ev::Click, move |_| Msg::ScanStratagem(fs_id)));
 
     if model.disabled || model.is_locked {
-        scan_button = scan_button.add_attr("disabled", true);
+        scan_button.add_attr("disabled", true);
     }
+
+    let mut close_button = bs_button::btn(
+        class![bs_button::BTN_DEFAULT],
+        vec![
+            Node::new_text("Close"),
+            i![class!["far", "fa-times-circle"]],
+        ],
+    );
+    close_button.add_listener(simple_ev(Ev::Click, Msg::CloseModal));
 
     vec![
         bs_modal::backdrop(),
@@ -184,17 +195,7 @@ fn scan_modal(fs_id: u32, model: &Model) -> Vec<Node<Msg>> {
                     ],
                 ],
             ]]),
-            bs_modal::footer(vec![
-                scan_button,
-                bs_button::btn(
-                    class![bs_button::BTN_DEFAULT],
-                    vec![
-                        Node::new_text("Close"),
-                        i![class!["far", "fa-times-circle"]],
-                    ],
-                )
-                .add_listener(simple_ev(Ev::Click, Msg::CloseModal)),
-            ]),
+            bs_modal::footer(vec![scan_button, close_button]),
         ]),
     ]
 }

--- a/iml-wasm-components/iml-stratagem/src/update_stratagem_button.rs
+++ b/iml-wasm-components/iml-stratagem/src/update_stratagem_button.rs
@@ -24,14 +24,16 @@ pub fn update_stratagem<T: serde::de::DeserializeOwned + 'static>(
 }
 
 pub fn view(is_valid: bool, disabled: bool) -> Node<Command> {
-    let btn = bs_button::btn(
+    let mut btn = bs_button::btn(
         class![bs_button::BTN_SUCCESS, "update-button"],
         vec![Node::new_text("Update"), i![class!["fas fa-check"]]],
     );
 
     if is_valid && !disabled {
-        btn.add_listener(simple_ev(Ev::Click, Command::Update))
+        btn.add_listener(simple_ev(Ev::Click, Command::Update));
     } else {
-        btn.add_attr(At::Disabled.as_str(), "disabled")
+        btn.add_attr(At::Disabled.as_str(), "disabled");
     }
+
+    btn
 }

--- a/iml-wasm-components/iml-toggle/Cargo.toml
+++ b/iml-wasm-components/iml-toggle/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 log = "0.4"
 bootstrap-components = { path = "../bootstrap-components", version = "0.1" }
 

--- a/iml-wasm-components/iml-toggle/toggle.rs
+++ b/iml-wasm-components/iml-toggle/toggle.rs
@@ -15,7 +15,7 @@ pub fn toggle(active: bool) -> Node<Active> {
         cfg.merge(class!["active"]);
     }
 
-    bs_button::btn(
+    let mut btn = bs_button::btn(
         cfg,
         if active {
             vec![i![class!["fa", "fa-check"]], Node::new_text("Enabled")]
@@ -25,6 +25,7 @@ pub fn toggle(active: bool) -> Node<Active> {
                 Node::new_text("Disabled"),
             ]
         },
-    )
-    .add_listener(mouse_ev(Ev::Click, move |_| Active(!active)))
+    );
+    btn.add_listener(mouse_ev(Ev::Click, move |_| Active(!active)));
+    btn
 }

--- a/iml-wasm-components/iml-tooltip/Cargo.toml
+++ b/iml-wasm-components/iml-tooltip/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 serde = { version = "1", features = ['derive'] }
 
 [dev-dependencies]

--- a/iml-wasm-components/iml-utils/Cargo.toml
+++ b/iml-wasm-components/iml-utils/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1", features = ['derive'] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"]}
 web-sys = { version = "0.3", features = ["CustomEvent", "CustomEventInit", "Event", "EventTarget"]}
 serde_json = "1.0"
-seed = "=0.4.0"
+seed = "=0.4.1"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.2"

--- a/iml-wasm-components/iml-utils/src/lib.rs
+++ b/iml-wasm-components/iml-utils/src/lib.rs
@@ -35,17 +35,15 @@ impl IntoSerdeOpt for JsValue {
 }
 
 pub trait AddAttrs {
-    fn add_attrs(self, attrs: Attrs) -> Self;
+    fn add_attrs(&mut self, attrs: Attrs) -> &mut Self;
 }
 
 impl<T> AddAttrs for Node<T> {
-    fn add_attrs(self, attrs: Attrs) -> Self {
-        if let Node::Element(mut el) = self {
+    fn add_attrs(&mut self, attrs: Attrs) -> &mut Self {
+        if let Node::Element(el) = self {
             el.attrs.merge(attrs);
-            Node::Element(el)
-        } else {
-            self
         }
+        self
     }
 }
 

--- a/iml-wasm-components/iml-wasm/Cargo.toml
+++ b/iml-wasm-components/iml-wasm/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 name = "package"
 
 [dependencies]
-seed = "=0.4.0"
+seed = "=0.4.1"
 serde = { version = "1", features = ['derive'] }
 serde_json = "1.0"
 futures = "0.1"


### PR DESCRIPTION
Some functions in "seed", like add_class(), now accept and return mutable
reference.

P. S.
Seed's commit => [Make chainable methods on El and Node more convenient](https://github.com/David-OConnor/seed/commit/095422b4c08a88574c224d827c1801500f09de3c). It says "more convenient", maybe we should make deeper refactoring?

P. P. S. At least now we don't need to do `foo = foo.add_style(...)` for example.

Closes https://github.com/whamcloud/integrated-manager-for-lustre/issues/1302.