### PR TITLE
Add PolledMetric type to wire-types

### DIFF
--- a/iml-wire-types/wire-types.rs
+++ b/iml-wire-types/wire-types.rs
@@ -1740,3 +1740,12 @@ pub struct ComponentState<T: Default> {
     pub info: String,
     pub state: T,
 }
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PolledMetric {
+    bytes_free: Option<f64>,
+    bytes_total: Option<f64>,
+    client_count: Option<f64>,
+    files_free: Option<f64>,
+    files_total: Option<f64>,
+}


### PR DESCRIPTION
The PolledMetric type represents polled metric data that will be handled
in the wasm-components filesystem and filesystem detail pages.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>