### PR TITLE
Gh 1285 (#1308)

### DIFF
--- a/iml-wasm-components/iml-fs/src/fs_detail_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_detail_page.rs
@@ -65,6 +65,15 @@ impl Default for FsDetail {
     }
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PolledMetric {
+    bytes_free: Option<f64>,
+    bytes_total: Option<f64>,
+    client_count: Option<f64>,
+    files_free: Option<f64>,
+    files_total: Option<f64>,
+}
+
 #[derive(Default)]
 struct Model {
     pub destroyed: bool,
@@ -131,6 +140,7 @@ enum Msg {
     CloseMountModal,
     Destroy,
     Filesystem(Option<Filesystem>),
+    UpdateMetrics(HashMap<String, PolledMetric>),
     FsDetailDropdown(dad::IdMsg<Filesystem>),
     FsDetailPopoverState(AlertIndicatorPopoverState),
     FsDetailPopoverLockState(LockIndicatorState),
@@ -231,6 +241,20 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             };
 
             model.fs = fs;
+        }
+        Msg::UpdateMetrics(polled_metrics) => {
+            if let Some(fs) = &mut model.fs {
+                let metric_data = polled_metrics.get(&fs.id.to_string());
+                if let Some(metric_data) = metric_data {
+                    fs.bytes_free = metric_data.bytes_free;
+                    fs.bytes_total = metric_data.bytes_total;
+                    fs.files_free = metric_data.files_free;
+                    fs.files_total = metric_data.files_total;
+
+                    let mdts_length = fs.mdts.len() as f64;
+                    fs.client_count = metric_data.client_count.map(move |x| x / mdts_length);
+                }
+            }
         }
         Msg::Locks(locks) => {
             if let Some(fs) = &model.fs {
@@ -685,6 +709,10 @@ impl FsDetailPageCallbacks {
     }
     pub fn command_modal_closed(&self) {
         self.app.update(Msg::CloseCommandModal);
+    }
+    pub fn set_polled_metrics(&self, polled_metrics: JsValue) {
+        let polled_metrics: HashMap<String, PolledMetric> = polled_metrics.into_serde().unwrap();
+        self.app.update(Msg::UpdateMetrics(polled_metrics));
     }
 }
 

--- a/iml-wasm-components/iml-fs/src/fs_page.rs
+++ b/iml-wasm-components/iml-fs/src/fs_page.rs
@@ -48,6 +48,15 @@ struct Model {
     pub locks: Locks,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PolledMetric {
+    bytes_free: Option<f64>,
+    bytes_total: Option<f64>,
+    client_count: Option<f64>,
+    files_free: Option<f64>,
+    files_total: Option<f64>,
+}
+
 impl Model {
     fn has_fs(&self) -> bool {
         !self.rows.is_empty()
@@ -64,6 +73,7 @@ enum Msg {
     Destroy,
     WindowClick,
     Filesystems(HashMap<u32, Filesystem>),
+    UpdateMetrics(HashMap<String, PolledMetric>),
     FsRowPopoverState(AlertIndicatorPopoverState),
     FsRowLockIndicatorState(LockIndicatorState),
     Targets(HashMap<u32, Target<TargetConfParam>>),
@@ -133,6 +143,35 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
                 let mut r = model.rows.get_mut(&x).unwrap();
 
                 r.fs = filesystems.remove(&x).unwrap();
+            }
+        }
+        Msg::UpdateMetrics(polled_metrics) => {
+            let fs_ids = polled_metrics
+                .keys()
+                .cloned()
+                .into_iter()
+                .map(|x| {
+                    x.parse::<u32>()
+                        .expect(&format!("Filesystem id, {}, should be a number.", x))
+                })
+                .collect::<HashSet<u32>>();
+
+            for fs_id in fs_ids {
+                let metric_data = polled_metrics.get(&fs_id.to_string()).expect(&format!(
+                    "Couldn't retrieve metric data for fs_id {}",
+                    fs_id
+                ));
+                let r = model.rows.get_mut(&fs_id);
+
+                if let Some(row) = r {
+                    row.fs.bytes_free = metric_data.bytes_free;
+                    row.fs.bytes_total = metric_data.bytes_total;
+                    row.fs.files_free = metric_data.files_free;
+                    row.fs.files_total = metric_data.files_total;
+
+                    let mdts_length = row.fs.mdts.len() as f64;
+                    row.fs.client_count = metric_data.client_count.map(move |x| x / mdts_length);
+                }
             }
         }
         Msg::Targets(targets) => {
@@ -299,6 +338,10 @@ impl FsPageCallbacks {
     pub fn set_locks(&self, locks: JsValue) {
         let locks: Locks = locks.into_serde().unwrap();
         self.app.update(Msg::SetLocks(locks));
+    }
+    pub fn set_polled_metrics(&self, polled_metrics: JsValue) {
+        let polled_metrics: HashMap<String, PolledMetric> = polled_metrics.into_serde().unwrap();
+        self.app.update(Msg::UpdateMetrics(polled_metrics));
     }
 }
 


### PR DESCRIPTION
* GH-1285 Update Wasm Components with metric data as it is polled

Certain metric properties of the filesystems are not updated live in
iml-warp-drive and thus must be polled and set every x seconds. This
data will be passed to wasm-components where it will be updated on both
the filesystem and filesystem detail page.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>

* - temporarily move the PolledMetric type into both fs_detail_page and
fs_page until it is in wire-types (if we decide to go that route).

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>

* - client count should take into account the number of mdt's

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>

* - Rust beta updated to 1.40 and uses new format rules. Updating to
account for this.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>

* formatting

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>