### PR TITLE
Revert to rust stable

### DIFF
--- a/ci/azure-5.0-release-pipeline.yml
+++ b/ci/azure-5.0-release-pipeline.yml
@@ -19,7 +19,7 @@ jobs:
       spec: rust-iml.spec
       release: true
       branchref: refs/tags/v0.1.2rust-r5.1
-      image: imlteam/copr-rust
+      image: imlteam/copr-rust:stable
 
   # Wasm-Components Continuous Release to Prod Copr
   - template: template/azure-release.yml

--- a/ci/azure-5.0-release-pipeline.yml
+++ b/ci/azure-5.0-release-pipeline.yml
@@ -19,7 +19,7 @@ jobs:
       spec: rust-iml.spec
       release: true
       branchref: refs/tags/v0.1.2rust-r5.1
-      image: imlteam/copr-rust:beta
+      image: imlteam/copr-rust
 
   # Wasm-Components Continuous Release to Prod Copr
   - template: template/azure-release.yml

--- a/ci/azure-test-pipeline.yml
+++ b/ci/azure-test-pipeline.yml
@@ -34,7 +34,7 @@ jobs:
       name: test_rpm_build
       displayName: Test rpm building
       spec: rust-iml.spec
-      image: imlteam/copr-rust
+      image: imlteam/copr-rust:stable
 
   # Check formatting
   - template: template/azure-rustfmt.yml

--- a/ci/azure-test-pipeline.yml
+++ b/ci/azure-test-pipeline.yml
@@ -34,7 +34,7 @@ jobs:
       name: test_rpm_build
       displayName: Test rpm building
       spec: rust-iml.spec
-      image: imlteam/copr-rust:beta
+      image: imlteam/copr-rust
 
   # Check formatting
   - template: template/azure-rustfmt.yml

--- a/ci/template/azure-clippy.yml
+++ b/ci/template/azure-clippy.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - template: azure-install-rust.yml
         parameters:
-          rust_version: beta
+          rust_version: stable
       - script: |
           rustup component add clippy
         displayName: Install clippy

--- a/ci/template/azure-rustfmt.yml
+++ b/ci/template/azure-rustfmt.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - template: azure-install-rust.yml
         parameters:
-          rust_version: beta
+          rust_version: stable
       - script: |
           rustup component add rustfmt
         displayName: Install rustfmt

--- a/ci/template/azure-test-stable.yml
+++ b/ci/template/azure-test-stable.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - template: azure-install-rust.yml
         parameters:
-          rust_version: beta
+          rust_version: stable
 
       - template: azure-install-lustre.yml
         parameters:


### PR DESCRIPTION
With the new release of rust we can now compile all rust code using
`stable` instead of `beta`. Update all azure templates to use stable.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>