### PR TITLE
Revert to rust stable

### DIFF
--- a/.github/actions/copr-rust/action.yml
+++ b/.github/actions/copr-rust/action.yml
@@ -2,4 +2,4 @@ name: copr rust
 description: build in the copr-rust image
 runs:
   using: "docker"
-  image: "docker://imlteam/copr-rust:beta"
+  image: "docker://imlteam/copr-rust"

--- a/.github/actions/copr-rust/action.yml
+++ b/.github/actions/copr-rust/action.yml
@@ -2,4 +2,4 @@ name: copr rust
 description: build in the copr-rust image
 runs:
   using: "docker"
-  image: "docker://imlteam/copr-rust"
+  image: "docker://imlteam/copr-rust:stable"

--- a/.github/workflows/devel-release.yml
+++ b/.github/workflows/devel-release.yml
@@ -20,7 +20,7 @@ jobs:
           PACKAGE: rust-iml
           SPEC: rust-iml.spec
           WORKSPACE: ${{ github.workspace }}
-          RUSTUP_TOOLCHAIN: beta-x86_64-unknown-linux-gnu
+          RUSTUP_TOOLCHAIN: stable-x86_64-unknown-linux-gnu
           KEY: ${{ secrets.key }}
           IV: ${{ secrets.iv }}
   push_iml_wasm:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -20,7 +20,7 @@ jobs:
           PACKAGE: rust-iml
           SPEC: rust-iml.spec
           WORKSPACE: ${{ github.workspace }}
-          RUSTUP_TOOLCHAIN: beta-x86_64-unknown-linux-gnu
+          RUSTUP_TOOLCHAIN: stable-x86_64-unknown-linux-gnu
           KEY: ${{ secrets.key }}
           IV: ${{ secrets.iv }}
   push_iml_wasm:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: beta
+          toolchain: stable
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: beta
+          toolchain: stable
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: beta
+          toolchain: stable
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - beta
+          - stable
     services:
       rabbitmq:
         image: rabbitmq:3.6
@@ -91,4 +91,4 @@ jobs:
           SPEC: rust-iml.spec
           LOCAL_ONLY: true
           WORKSPACE: ${{ github.workspace }}
-          RUSTUP_TOOLCHAIN: beta-x86_64-unknown-linux-gnu
+          RUSTUP_TOOLCHAIN: stable-x86_64-unknown-linux-gnu

--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - beta
+          - stable
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: beta
+          toolchain: stable
           override: true
       - run: rustup component add clippy
 
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: beta
+          toolchain: stable
           override: true
       - run: rustup component add rustfmt
 
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - beta
+          - stable
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1


### PR DESCRIPTION
With the new release of rust we can now compile all rust code using
stable instead of beta. Update all azure templates to use stable.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>