### PR TITLE
Update rust version for iml-warp-drive

### DIFF
--- a/docker/iml-warp-drive.dockerfile
+++ b/docker/iml-warp-drive.dockerfile
@@ -1,12 +1,12 @@
-FROM rust:1.38 as builder
+FROM rust:1.39 as builder
 WORKDIR /build
 COPY . .
 RUN cargo build -p iml-warp-drive --release
 
-FROM rust:1.38
+FROM rust:1.39
 COPY --from=builder /build/target/release/iml-warp-drive /usr/local/bin
 RUN apt-get update \
-    && apt install -y postgresql-client
+  && apt install -y postgresql-client
 
 COPY docker/wait-for-dependencies.sh /usr/local/bin/
 ENTRYPOINT [ "wait-for-dependencies.sh" ]


### PR DESCRIPTION
- Update version from 1.38 to 1.39.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>