### PR TITLE
Set ZFS params for EFS testing

### DIFF
--- a/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -72,6 +72,10 @@ class TestBlockDeviceZfs(TestBlockDevice):
         return [
             "flock -x /var/lock/lustre_installer_lock -c 'rpm -q zfs || (yum -y install kernel-devel-[0-9]\*_lustre lustre-zfs > /tmp/zfs_installer.stdout)'",
             "modprobe zfs",
+            "echo 100 > /sys/module/zfs/parameters/zfs_multihost_history",
+            "echo 60 > /sys/module/zfs/parameters/zfs_multihost_fail_intervals",
+            "echo options zfs zfs_multihost_history=100 > /etc/modprobe.d/iml_zfs_module_parameters.conf",
+            "echo options zfs zfs_multihost_fail_intervals=60 >> /etc/modprobe.d/iml_zfs_module_parameters.conf",
         ]
 
     @property


### PR DESCRIPTION
so pools won't enter a suspended state.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>