### PR TITLE
Avoid passing host

### DIFF
--- a/chroma_core/models/lnet_configuration.py
+++ b/chroma_core/models/lnet_configuration.py
@@ -379,7 +379,7 @@ class StartLNetJob(LNetStateChangeJob):
 
     def get_steps(self):
         host_id = self.lnet_configuration.host.id
-        fqdn = self.lnet_configuration.fqdn
+        fqdn = self.lnet_configuration.host.fqdn
 
         return self.lnet_configuration.filter_steps(
             [(StartLNetStep, {"fqdn": fqdn}), (GetLNetStateStep, {"host_id": host_id, "fqdn": fqdn}),]

--- a/chroma_core/models/ntp.py
+++ b/chroma_core/models/ntp.py
@@ -45,7 +45,7 @@ class ConfigureNTPStep(Step):
         else:
             ntp_server = socket.getfqdn()
 
-        self.invoke_agent_expect_result(kwargs["fqdn"].host, "configure_ntp", {"ntp_server": ntp_server})
+        self.invoke_agent_expect_result(kwargs["fqdn"], "configure_ntp", {"ntp_server": ntp_server})
 
 
 class ConfigureNTPJob(StateChangeJob):

--- a/chroma_core/models/ntp.py
+++ b/chroma_core/models/ntp.py
@@ -45,7 +45,7 @@ class ConfigureNTPStep(Step):
         else:
             ntp_server = socket.getfqdn()
 
-        self.invoke_agent_expect_result(kwargs["ntp_configuration"].host, "configure_ntp", {"ntp_server": ntp_server})
+        self.invoke_agent_expect_result(kwargs["fqdn"].host, "configure_ntp", {"ntp_server": ntp_server})
 
 
 class ConfigureNTPJob(StateChangeJob):
@@ -66,10 +66,10 @@ class ConfigureNTPJob(StateChangeJob):
         return help_text["configure_ntp"]
 
     def description(self):
-        return "Configure NTP on %s" % self.ntp_configuration.host
+        return "Configure NTP on {}".format(self.ntp_configuration.host)
 
     def get_steps(self):
-        return [(ConfigureNTPStep, {"ntp_configuration": self.ntp_configuration})]
+        return [(ConfigureNTPStep, {"fqdn": self.ntp_configuration.host.fqdn})]
 
     def get_deps(self):
         """
@@ -89,7 +89,7 @@ class UnconfigureNTPStep(Step):
     idempotent = True
 
     def run(self, kwargs):
-        self.invoke_agent_expect_result(kwargs["ntp_configuration"].host, "unconfigure_ntp")
+        self.invoke_agent_expect_result(kwargs["fqdn"], "unconfigure_ntp")
 
 
 class UnconfigureNTPJob(StateChangeJob):
@@ -110,7 +110,7 @@ class UnconfigureNTPJob(StateChangeJob):
         return help_text["unconfigure_ntp"]
 
     def description(self):
-        return "Unconfigure Ntp on %s" % self.ntp_configuration.host
+        return "Unconfigure Ntp on {}".format(self.ntp_configuration.host)
 
     def get_steps(self):
-        return [(UnconfigureNTPStep, {"ntp_configuration": self.ntp_configuration})]
+        return [(UnconfigureNTPStep, {"fqdn": self.ntp_configuration.host.fqdn})]

--- a/tests/unit/chroma_core/jobs/test_jobs.py
+++ b/tests/unit/chroma_core/jobs/test_jobs.py
@@ -50,7 +50,7 @@ class TestJobs(IMLUnitTestCase):
 
         assert type(args) is dict, "args list must be dict :%s" % type(args)
 
-        args = InvokeAgentInvoke(host.fqdn, invoke, args, None, None)
+        args = InvokeAgentInvoke(host, invoke, args, None, None)
 
         self._invokes_history.append(args)
 


### PR DESCRIPTION
When configuring servers, I sometimes see a trace like:

```
  File "/usr/share/chroma-manager/chroma_core/services/job_scheduler/job_scheduler.py", line 282, in run
    self._run()
  File "/usr/share/chroma-manager/chroma_core/services/job_scheduler/job_scheduler.py", line 306, in _run
    self.job.id, step_klass=klass, args=clean_args, step_index=step_index, step_count=len(self.steps)
  File "/usr/share/chroma-manager/chroma_core/services/job_scheduler/job_scheduler.py", line 209, in getter
    self.put(deepcopy((name, args, kwargs)))
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 237, in _deepcopy_tuple
    y.append(deepcopy(a, memo))
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 257, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 257, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python2.7/copy.py", line 190, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python2.7/copy.py", line 334, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 257, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python2.7/copy.py", line 190, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python2.7/copy.py", line 334, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 257, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python2.7/copy.py", line 190, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python2.7/copy.py", line 334, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python2.7/copy.py", line 163, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python2.7/copy.py", line 256, in _deepcopy_dict
    for key, value in x.iteritems():
RuntimeError: dictionary changed size during iteration
```

I suspect this may be due to passing host model instances to LNet steps instead of passing relevant properties directly.

This patch updates the LnetSteps to take the needed host properties instead of the entire host model.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>