### PR TITLE
Support both unix socket and TCP communication in the action runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "iml-manager-env 0.1.0",
  "iml-rabbit 0.1.0",
  "iml-service-queue 0.1.0",
+ "iml-util 0.1.0",
  "iml-wire-types 0.2.0",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/iml-services/iml-action-runner/Cargo.toml
+++ b/iml-services/iml-action-runner/Cargo.toml
@@ -15,6 +15,7 @@ iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
 iml-rabbit = { path = "../../iml-rabbit", version = "0.1.0" }
 iml-manager-env = { path = "../../iml-manager-env", version = "0.1.0" }
 iml-service-queue = { path = "../iml-service-queue", version = "0.1.0" }
+iml-util = { path = "../../iml-util", version = "0.1.0" }
 tokio-runtime-shutdown = { path = "../../tokio-runtime-shutdown", version = "0.1.0" }
 tracing = "0.1"
 tracing-subscriber = "0.1"

--- a/iml-services/iml-action-runner/src/main.rs
+++ b/iml-services/iml-action-runner/src/main.rs
@@ -9,11 +9,8 @@ use iml_action_runner::{
     sender::{create_client_filter, sender},
 };
 use iml_service_queue::service_queue::consume_service_queue;
-use std::{
-    collections::HashMap,
-    sync::Arc,
-};
 use iml_util::tokio_utils::get_tcp_or_unix_listener;
+use std::{collections::HashMap, sync::Arc};
 use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::{self, Filter as _};
 

--- a/iml-services/iml-action-runner/src/main.rs
+++ b/iml-services/iml-action-runner/src/main.rs
@@ -11,12 +11,9 @@ use iml_action_runner::{
 use iml_service_queue::service_queue::consume_service_queue;
 use std::{
     collections::HashMap,
-    convert::TryFrom,
-    env,
-    os::unix::{io::FromRawFd, net::UnixListener as NetUnixListener},
     sync::Arc,
 };
-use tokio::net::{TcpListener, UnixListener};
+use iml_util::tokio_utils::get_tcp_or_unix_listener;
 use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::{self, Filter as _};
 
@@ -50,29 +47,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .map(|x| warp::reply::json(&x))
     .with(log);
 
-    match env::var("LISTEN_PID") {
-        Ok(_) => {
-            let addr = unsafe { NetUnixListener::from_raw_fd(3) };
-            let listener = UnixListener::try_from(addr)?
-                .incoming()
-                .inspect_ok(|_| tracing::debug!("Client connected"));
-
-            tracing::debug!("Listening over socket");
-            tokio::spawn(warp::serve(routes).serve_incoming(listener));
-        }
-        Err(_) => {
-            let port = env::var("ACTION_RUNNER_PORT").expect("ACTION_RUNNER_PORT not defined!");
-
-            tracing::debug!("Listening over tcp port {}", port);
-            let addr = format!("127.0.0.1:{}", port);
-            let listener = TcpListener::bind(&addr)
-                .await?
-                .incoming()
-                .inspect_ok(|_| tracing::debug!("Client connected"));
-
-            tokio::spawn(warp::serve(routes).serve_incoming(listener));
-        }
-    };
+    let listener = get_tcp_or_unix_listener("ACTION_RUNNER_PORT").await?;
+    tokio::spawn(warp::serve(routes).serve_incoming(listener));
 
     let client = iml_rabbit::connect_to_rabbit().await?;
 


### PR DESCRIPTION
The action runner is currently configured to run strictly on a unix
domain socket. This will prevent the docker service from running
correctly. If the proces is being run in systemd then the LISTEN_PID
environment variable will be set and the war server can be spawned with
the unix socket. If the LISTEN_PID environment variable is not defined
it will instead launch the warp server over http (used in docker).

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>