### PR TITLE
Add tokio_utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,11 @@ dependencies = [
 [[package]]
 name = "iml-util"
 version = "0.1.0"
+dependencies = [
+ "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "iml-warp-drive"

--- a/iml-util/Cargo.toml
+++ b/iml-util/Cargo.toml
@@ -6,5 +6,10 @@ version = "0.1.0"
 authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
+[dependencies]
+futures-preview = "0.3.0-alpha.19"
+tokio = "0.2.0-alpha.6"
+tracing = "0.1"
+
 [lib]
 path = "util.rs"

--- a/iml-util/util.rs
+++ b/iml-util/util.rs
@@ -56,6 +56,76 @@ impl<A, B, C, D, E> Pick<A, B> for (A, B, C, D, E) {
     }
 }
 
+pub mod tokio_utils {
+    use futures::{future::Either, Stream, TryStreamExt};
+    use std::{
+        convert::TryFrom,
+        env, io,
+        os::unix::{io::FromRawFd, net::UnixListener as NetUnixListener},
+        pin::Pin,
+    };
+    use tokio::{
+        io::{AsyncRead, AsyncWrite},
+        net::{TcpListener, UnixListener},
+    };
+
+    pub trait Socket: AsyncRead + AsyncWrite + Send + 'static + Unpin {}
+    impl<T: AsyncRead + AsyncWrite + Send + 'static + Unpin> Socket for T {}
+
+    /// Given an environment variable that resolves to a port,
+    /// Return a stream containing `TcpStream`s that have been erased to
+    /// `AsyncRead` + `AsyncWrite` traits. This is useful when you won't know which stream
+    /// to choose at runtime
+    pub async fn get_tcp_stream(
+        port: String,
+    ) -> Result<impl Stream<Item = Result<Pin<Box<dyn Socket>>, io::Error>>, io::Error> {
+        let addr = format!("127.0.0.1:{}", port);
+
+        tracing::debug!("Listening over tcp port {}", port);
+
+        let s = TcpListener::bind(&addr)
+            .await?
+            .incoming()
+            .map_ok(|x| -> Pin<Box<dyn Socket>> { Box::pin(x) });
+
+        Ok(s)
+    }
+
+    /// Returns a stream containing `UnixStream`s that have been erased to
+    /// `AsyncRead` + `AsyncWrite` traits. This is useful when you won't know which stream
+    /// to choose at runtime
+    pub fn get_unix_stream(
+    ) -> Result<impl Stream<Item = Result<Pin<Box<dyn Socket>>, io::Error>>, io::Error> {
+        let addr = unsafe { NetUnixListener::from_raw_fd(3) };
+
+        tracing::debug!("Listening over unix domain socket");
+
+        let s = UnixListener::try_from(addr)?
+            .incoming()
+            .map_ok(|x| -> Pin<Box<dyn Socket>> { Box::pin(x) });
+
+        Ok(s)
+    }
+
+    /// Given an environment variable that resolves to a port,
+    /// Return a stream containing items that have been erased to
+    /// `AsyncRead` + `AsyncWrite` traits. This is useful when you won't know which stream
+    /// to choose at runtime.
+    ///
+    /// If the `port_var` resolves to a port, `TcpStream` will be used internally.
+    /// Otherwise a `UnixStream` will be used.
+    pub async fn get_tcp_or_unix_listener(
+        port_var: &str,
+    ) -> Result<impl Stream<Item = Result<Pin<Box<dyn Socket>>, io::Error>>, io::Error> {
+        let s = match env::var(port_var) {
+            Ok(port) => Either::Left(get_tcp_stream(port).await?),
+            Err(_) => Either::Right(get_unix_stream()?),
+        };
+
+        Ok(s)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Add a new module, tokio_utils to the iml-util crate.

Within it, add three new fns to deal with incoming socket streams of
different types.

We should use these fns when we don't know which type of stream we will
be using at runtime.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>