### PR TITLE
Remove error_for_status call from POST

### DIFF
--- a/iml-manager-cli/src/api_utils.rs
+++ b/iml-manager-cli/src/api_utils.rs
@@ -36,7 +36,7 @@ pub struct SendCmd<T> {
 pub async fn create_command<T: serde::Serialize>(
     cmd_body: SendCmd<T>,
 ) -> Result<Command, ImlManagerCliError> {
-    let resp = post(Command::endpoint_name(), cmd_body).await?;
+    let resp = post(Command::endpoint_name(), cmd_body).await?.error_for_status()?;
 
     let cmd = resp.json().await?;
 

--- a/iml-manager-cli/src/api_utils.rs
+++ b/iml-manager-cli/src/api_utils.rs
@@ -36,7 +36,9 @@ pub struct SendCmd<T> {
 pub async fn create_command<T: serde::Serialize>(
     cmd_body: SendCmd<T>,
 ) -> Result<Command, ImlManagerCliError> {
-    let resp = post(Command::endpoint_name(), cmd_body).await?.error_for_status()?;
+    let resp = post(Command::endpoint_name(), cmd_body)
+        .await?
+        .error_for_status()?;
 
     let cmd = resp.json().await?;
 

--- a/iml-manager-cli/src/server.rs
+++ b/iml-manager-cli/src/server.rs
@@ -241,6 +241,7 @@ pub async fn server_cli(command: ServerCommand) -> Result<(), ImlManagerCliError
 
             let Objects { objects } = post("test_host", Objects { objects })
                 .await?
+                .error_for_status()?
                 .json()
                 .await
                 .map_err(iml_manager_client::ImlManagerClientError::Reqwest)?;

--- a/iml-manager-cli/src/stratagem.rs
+++ b/iml-manager-cli/src/stratagem.rs
@@ -152,6 +152,8 @@ pub async fn stratagem_cli(command: StratagemCommand) -> Result<(), ImlManagerCl
         StratagemCommand::Scan(data) => {
             let r = post("run_stratagem", data).await?;
 
+            tracing::debug!("resp {:?}", r);
+
             let CmdWrapper { command } = handle_cmd_resp(r).await?;
 
             let stop_spinner = start_spinner(&command.message);

--- a/iml-manager-client/src/lib.rs
+++ b/iml-manager-client/src/lib.rs
@@ -129,6 +129,8 @@ pub async fn get<T: DeserializeOwned + Debug>(
 }
 
 /// Performs a POST to the given API path
+/// This call will *not* treat unsuccessful status codes
+/// as an error.
 pub async fn post(
     client: Client,
     path: &str,
@@ -140,8 +142,7 @@ pub async fn post(
         .post(uri)
         .json(&body)
         .send()
-        .await?
-        .error_for_status()?;
+        .await?;
 
     tracing::debug!("Resp: {:?}", resp);
 

--- a/iml-manager-client/src/lib.rs
+++ b/iml-manager-client/src/lib.rs
@@ -138,11 +138,7 @@ pub async fn post(
 ) -> Result<Response, ImlManagerClientError> {
     let uri = create_api_url(path)?;
 
-    let resp = client
-        .post(uri)
-        .json(&body)
-        .send()
-        .await?;
+    let resp = client.post(uri).json(&body).send().await?;
 
     tracing::debug!("Resp: {:?}", resp);
 


### PR DESCRIPTION
We are using `error_for_status` to cooerce any unsuccessful status codes
into an `Err`.

However, using this method discards the response body, which may have
useful information in terms of the actual issue with the request /
response.

As a start, this patch will remove `error_for_status` from the top-level
post call to let downstream consumers deal with the error directly.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>