### PR TITLE
Add font-awesome componet

### DIFF
--- a/iml-gui/crate/src/components/font_awesome.rs
+++ b/iml-gui/crate/src/components/font_awesome.rs
@@ -1,0 +1,14 @@
+use crate::{generated::css_classes::C, Model, Msg};
+use seed::{dom_types::Attrs, prelude::*, *};
+
+pub fn font_awesome<T>(more_attrs: Attrs, icon_name: &str) -> Node<T> {
+    let mut attrs = class![C.fill_current];
+    attrs.merge(more_attrs);
+
+    svg![
+        attrs,
+        r#use![attrs! {
+            At::Href => format!("sprites/solid.svg#{}", icon_name),
+        }]
+    ]
+}

--- a/iml-gui/crate/src/components/mod.rs
+++ b/iml-gui/crate/src/components/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod font_awesome;
+
+pub(crate) use font_awesome::font_awesome;


### PR DESCRIPTION
Add a new fn that can render a given font-awesome icon.

This fn will use the svg sprite sheet for rendering rather then CSS.

In addition, any attributes (classes, styles, etc...) can be passed in
as a param.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>