### PR TITLE
Implement popover

### DIFF
--- a/iml-gui/crate/LICENSE
+++ b/iml-gui/crate/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 DDN
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/iml-gui/crate/src/components/arrow.rs
+++ b/iml-gui/crate/src/components/arrow.rs
@@ -1,0 +1,48 @@
+use crate::{components::Placement, generated::css_classes::C};
+use seed::{prelude::*, *};
+
+pub(crate) fn arrow<T>(direction: &Placement, color: &str) -> Node<T> {
+    let arrow_top_styles = style! {
+        St::Top => percent(100),
+        St::Left => percent(50),
+        St::MarginLeft => px(-5),
+        St::BorderWidth => "5px 5px 0",
+        St::BorderTopColor => color
+    };
+
+    let arrow_right_styles = style! {
+        St::Top => percent(50),
+        St::Right => percent(100),
+        St::MarginTop => px(-5),
+        St::BorderWidth => "5px 5px 5px 0",
+        St::BorderRightColor => color
+    };
+
+    let arrow_bottom_styles = style! {
+        St::Top => 0,
+        St::Left => percent(50),
+        St::MarginLeft => px(-5),
+        St::BorderWidth => "0 5px 5px",
+        St::BorderBottomColor => color
+    };
+
+    let arrow_left_styles = style! {
+        St::Top => percent(50),
+        St::Left => percent(100),
+        St::MarginTop => px(-5),
+        St::BorderWidth => "5px 0 5px 5px",
+        St::BorderLeftColor => color
+    };
+
+    let arrow_style = match direction {
+        Placement::Left => arrow_left_styles,
+        Placement::Right => arrow_right_styles,
+        Placement::Top => arrow_top_styles,
+        Placement::Bottom => arrow_bottom_styles,
+    };
+
+    div![
+        class![C.w_0, C.h_0, C.border_solid, C.border_transparent, C.absolute],
+        arrow_style,
+    ]
+}

--- a/iml-gui/crate/src/components/mod.rs
+++ b/iml-gui/crate/src/components/mod.rs
@@ -1,7 +1,30 @@
+pub(crate) mod arrow;
 pub(crate) mod font_awesome;
+pub(crate) mod popover;
 pub(crate) mod tooltip;
 
+pub(crate) use arrow::arrow;
 pub(crate) use font_awesome::font_awesome;
+pub(crate) use popover::{popover, popover_content, popover_title};
 pub(crate) use tooltip::{
-    color_tooltip, error_tooltip, tooltip, tooltip_container, TooltipPlacement,
+    color_tooltip, error_tooltip, tooltip, tooltip_container,
 };
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Placement {
+    Left,
+    Right,
+    Top,
+    Bottom,
+}
+
+impl From<&Placement> for &str {
+    fn from(p: &Placement) -> Self {
+        match p {
+            Placement::Left => "left",
+            Placement::Right => "right",
+            Placement::Top => "top",
+            Placement::Bottom => "bottom",
+        }
+    }
+}

--- a/iml-gui/crate/src/components/popover.rs
+++ b/iml-gui/crate/src/components/popover.rs
@@ -1,0 +1,72 @@
+use crate::{
+    components::{arrow, Placement},
+    generated::css_classes::C,
+};
+use seed::{prelude::*, *};
+
+pub fn popover_title<T>(content: &str) -> Node<T> {
+    div![
+        class![C.bg_gray_200, C.py_1, C.px_3],
+        h4![class![C.font_normal, C.text_lg], content]
+    ]
+}
+
+pub fn popover_content<T>(content: impl View<T>) -> Node<T> {
+    div![class![C.py_2, C.px_3, C.w_64], content.els()]
+}
+
+pub(crate) fn popover<T>(
+    content: impl View<T>,
+    placement: Placement,
+    visible: bool,
+) -> Node<T> {
+    let color = "#e2e8f0";
+
+    let popover_top_styles = style! {
+        St::Transform => "translate(50%, -100%)",
+        St::Top => 0,
+        St::Right => percent(50),
+        St::MarginTop => px(-3),
+    };
+
+    let popover_right_styles = style! {
+        St::Transform => "translateY(50%)",
+        St::Left => percent(100),
+        St::Bottom => percent(50),
+        St::MarginLeft => px(5),
+    };
+
+    let popover_bottom_styles = style! {
+        St::Transform => "translateX(50%)",
+        St::Top => percent(100),
+        St::Right => percent(50),
+        St::MarginTop => px(3),
+        St::PaddingTop => px(5)
+    };
+
+    let popover_left_styles = style! {
+        St::Transform => "translate(-100%,50%)",
+        St::Bottom => percent(50),
+        St::MarginRight => px(5),
+    };
+
+    let popover_style = match placement {
+        Placement::Left => popover_left_styles,
+        Placement::Right => popover_right_styles,
+        Placement::Top => popover_top_styles,
+        Placement::Bottom => popover_bottom_styles,
+    };
+
+    div![
+        class![
+            C.absolute,
+            C.pointer_events_none,
+            C.z_10,
+            C.hidden => !visible,
+            C.block => visible
+        ],
+        popover_style,
+        arrow(&placement, &color),
+        div![class![C.rounded, C.shadow, C.bg_white,], content.els(),]
+    ]
+}

--- a/iml-gui/crate/src/components/tooltip.rs
+++ b/iml-gui/crate/src/components/tooltip.rs
@@ -1,24 +1,8 @@
-use crate::generated::css_classes::C;
+use crate::{
+    components::{arrow, Placement},
+    generated::css_classes::C,
+};
 use seed::{dom_types::Attrs, prelude::*, *};
-
-#[derive(Debug, Clone, Copy)]
-pub enum TooltipPlacement {
-    Left,
-    Right,
-    Top,
-    Bottom,
-}
-
-impl From<&TooltipPlacement> for &str {
-    fn from(p: &TooltipPlacement) -> Self {
-        match p {
-            TooltipPlacement::Left => "left",
-            TooltipPlacement::Right => "right",
-            TooltipPlacement::Top => "top",
-            TooltipPlacement::Bottom => "bottom",
-        }
-    }
-}
 
 /// Call this fn within the element wrapping the tooltip
 /// It will add the needed styles so the tooltip will render
@@ -28,43 +12,11 @@ pub fn tooltip_container() -> Attrs {
 }
 
 /// Render a tooltip with vaild CSS color string.
-pub fn color_tooltip<T>(
+pub(crate) fn color_tooltip<T>(
     content: &str,
-    direction: TooltipPlacement,
+    placement: &Placement,
     color: &str,
 ) -> Node<T> {
-    let arrow_top_styles = style! {
-        St::Top => percent(100),
-        St::Left => percent(50),
-        St::MarginLeft => px(-5),
-        St::BorderWidth => "5px 5px 0",
-        St::BorderTopColor => color
-    };
-
-    let arrow_right_styles = style! {
-        St::Top => percent(50),
-        St::Left => 0,
-        St::MarginTop => px(-5),
-        St::BorderWidth => "5px 5px 5px 0",
-        St::BorderRightColor => color
-    };
-
-    let arrow_bottom_styles = style! {
-        St::Top => 0,
-        St::Left => percent(50),
-        St::MarginLeft => px(-5),
-        St::BorderWidth => "0 5px 5px",
-        St::BorderBottomColor => color
-    };
-
-    let arrow_left_styles = style! {
-        St::Top => percent(50),
-        St::Right => 0,
-        St::MarginTop => px(-5),
-        St::BorderWidth => "5px 0 5px 5px",
-        St::BorderLeftColor => color
-    };
-
     let tooltip_top_styles = style! {
         St::Transform => "translate(50%, -100%)",
         St::Top => 0,
@@ -76,8 +28,7 @@ pub fn color_tooltip<T>(
         St::Transform => "translateY(50%)",
         St::Left => percent(100),
         St::Bottom => percent(50),
-        St::MarginLeft => px(3),
-        St::PaddingLeft => px(5)
+        St::MarginLeft => px(8),
     };
 
     let tooltip_bottom_styles = style! {
@@ -91,17 +42,14 @@ pub fn color_tooltip<T>(
     let tooltip_left_styles = style! {
         St::Bottom => percent(50),
         St::Transform => "translate(-100%,50%)",
-        St::MarginRight => px(3),
-        St::PaddingRight => px(5)
+        St::MarginRight => px(8),
     };
 
-    let (arrow_style, tooltip_style) = match direction {
-        TooltipPlacement::Left => (arrow_left_styles, tooltip_left_styles),
-        TooltipPlacement::Right => (arrow_right_styles, tooltip_right_styles),
-        TooltipPlacement::Top => (arrow_top_styles, tooltip_top_styles),
-        TooltipPlacement::Bottom => {
-            (arrow_bottom_styles, tooltip_bottom_styles)
-        }
+    let tooltip_style = match placement {
+        Placement::Left => tooltip_left_styles,
+        Placement::Right => tooltip_right_styles,
+        Placement::Top => tooltip_top_styles,
+        Placement::Bottom => tooltip_bottom_styles,
     };
 
     div![
@@ -111,13 +59,10 @@ pub fn color_tooltip<T>(
             C.hidden,
             C.group_hover__block,
             C.pointer_events_none,
-            C.z_10
+            C.z_20
         ],
         tooltip_style,
-        div![
-            class![C.w_0, C.h_0, C.border_solid, C.absolute, C.opacity_90,],
-            arrow_style,
-        ],
+        arrow(&placement, &color),
         div![
             class![
                 C.text_center,
@@ -139,11 +84,14 @@ pub fn color_tooltip<T>(
 }
 
 /// Render a tooltip.
-pub fn tooltip<T>(content: &str, direction: TooltipPlacement) -> Node<T> {
+pub(crate) fn tooltip<T>(content: &str, direction: &Placement) -> Node<T> {
     color_tooltip(content, direction, "black")
 }
 
 /// Render a tooltip with a red error color.
-pub fn error_tooltip<T>(content: &str, direction: TooltipPlacement) -> Node<T> {
+pub(crate) fn error_tooltip<T>(
+    content: &str,
+    direction: &Placement,
+) -> Node<T> {
     color_tooltip(content, direction, "red")
 }


### PR DESCRIPTION
Implement a popover component in seed.

In addition, split out the arrow on the tooltip and popover which uses
common code to it's own file.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>