### PR TITLE
Add local action plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
  "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -889,7 +889,7 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "headers-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -901,7 +901,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -954,7 +954,7 @@ version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -980,7 +980,7 @@ dependencies = [
  "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1055,7 +1055,7 @@ dependencies = [
  "elementtree 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exitcode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-fs 0.1.0",
  "iml-util 0.1.0",
  "iml-wire-types 0.2.0",
@@ -1203,7 +1203,7 @@ name = "iml-request-retry"
 version = "0.1.0"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2268,7 +2268,7 @@ dependencies = [
  "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.4.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3049,7 +3049,7 @@ dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3224,7 +3224,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3250,7 +3250,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3557,7 +3557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum hostlist-parser 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba5876b7518700be47dd82784fb53e614deafbb39eeead8b66f194537788e90f"
-"checksum http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e06e336150b178206af098a055e3621e8336027e2b4d126bda0bc64824baaf"
+"checksum http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "2790658cddc82e82b08e25176c431d7015a0adeb1718498715cbd20138a0bf68"
 "checksum http-body 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f3aef6f3de2bd8585f5b366f3f550b5774500b4764d00cf00f903c95749eec3"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"

--- a/chroma_core/services/job_scheduler/agent_rpc.py
+++ b/chroma_core/services/job_scheduler/agent_rpc.py
@@ -377,6 +377,25 @@ class AgentCancellation(Exception):
     pass
 
 
+class LocalActionException(Exception):
+    def __init__(self, action, params, backtrace, subprocesses=[]):
+        self.action = action
+        self.params = params
+        self.backtrace = backtrace
+        self.subprocesses = subprocesses
+
+    def __str__(self):
+        return """LocalActionException
+Action: %s
+Arguments: %s
+Exception: %s
+""" % (
+            self.action,
+            self.params,
+            self.backtrace,
+        )
+
+
 class AgentException(Exception):
     def __init__(self, fqdn, action, params, backtrace, subprocesses=[]):
         self.fqdn = fqdn

--- a/iml-services/iml-action-runner/src/error.rs
+++ b/iml-services/iml-action-runner/src/error.rs
@@ -4,8 +4,24 @@
 
 use futures::channel::oneshot;
 use iml_wire_types::Fqdn;
+use std::fmt;
 use tokio::timer;
 use warp::reject;
+
+#[derive(Debug)]
+pub struct RequiredError(pub String);
+
+impl fmt::Display for RequiredError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl std::error::Error for RequiredError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
 
 /// Encapsulates any errors that may happen while working with the `ActionRunner` service
 #[derive(Debug)]
@@ -14,6 +30,7 @@ pub enum ActionRunnerError {
     TokioTimerError(timer::Error),
     ImlRabbitError(iml_rabbit::ImlRabbitError),
     OneShotCanceledError(oneshot::Canceled),
+    RequiredError(RequiredError),
 }
 
 impl reject::Reject for ActionRunnerError {}
@@ -27,6 +44,7 @@ impl std::fmt::Display for ActionRunnerError {
             ActionRunnerError::TokioTimerError(ref err) => write!(f, "{}", err),
             ActionRunnerError::ImlRabbitError(ref err) => write!(f, "{}", err),
             ActionRunnerError::OneShotCanceledError(ref err) => write!(f, "{}", err),
+            ActionRunnerError::RequiredError(ref err) => write!(f, "{}", err),
         }
     }
 }
@@ -38,6 +56,7 @@ impl std::error::Error for ActionRunnerError {
             ActionRunnerError::TokioTimerError(ref err) => Some(err),
             ActionRunnerError::ImlRabbitError(ref err) => Some(err),
             ActionRunnerError::OneShotCanceledError(ref err) => Some(err),
+            ActionRunnerError::RequiredError(ref err) => Some(err),
         }
     }
 }
@@ -57,5 +76,11 @@ impl From<iml_rabbit::ImlRabbitError> for ActionRunnerError {
 impl From<oneshot::Canceled> for ActionRunnerError {
     fn from(err: oneshot::Canceled) -> Self {
         ActionRunnerError::OneShotCanceledError(err)
+    }
+}
+
+impl From<RequiredError> for ActionRunnerError {
+    fn from(err: RequiredError) -> Self {
+        ActionRunnerError::RequiredError(err)
     }
 }

--- a/iml-services/iml-action-runner/src/lib.rs
+++ b/iml-services/iml-action-runner/src/lib.rs
@@ -4,5 +4,26 @@
 
 pub mod data;
 pub mod error;
+pub mod local_actions;
 pub mod receiver;
 pub mod sender;
+
+use futures::{channel::oneshot, lock::Mutex};
+use iml_wire_types::{Action, Fqdn, Id};
+use std::{collections::HashMap, sync::Arc};
+
+pub type Shared<T> = Arc<Mutex<T>>;
+pub type Sessions = HashMap<Fqdn, Id>;
+pub type Sender = oneshot::Sender<Result<serde_json::Value, String>>;
+
+/// Actions can be run either locally or remotely.
+/// Besides the node these are run on, the interface should
+/// be the same.
+///
+/// This should probably be collapsed into a single struct over an enum at some point.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ActionType {
+    Remote((Fqdn, Action)),
+    Local(Action),
+}

--- a/iml-services/iml-action-runner/src/local_actions.rs
+++ b/iml-services/iml-action-runner/src/local_actions.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{
+    data::{await_next_session, get_session},
+    error::{self, ActionRunnerError},
+    Sender, Sessions, Shared,
+};
+use futures::{channel::oneshot, Future, FutureExt, TryFutureExt};
+use iml_wire_types::{Action, ActionId, ToJsonValue};
+use serde_json::value::Value;
+use std::{collections::HashMap, fmt::Display, sync::Arc};
+
+pub type LocalActionsInFlight = HashMap<ActionId, Sender>;
+pub type SharedLocalActionsInFlight = Shared<LocalActionsInFlight>;
+
+/// Adds an action id to the in-flight list.
+/// A tx handle is stored internally, and the rx side is returned.
+///
+/// The rx will resolve once the plugin has completed or is cancelled.
+async fn add_in_flight(
+    in_flight: SharedLocalActionsInFlight,
+    id: ActionId,
+) -> oneshot::Receiver<Result<Value, String>> {
+    let (tx, rx) = oneshot::channel();
+
+    let mut in_flight = in_flight.lock().await;
+
+    in_flight.insert(id.clone(), tx);
+
+    rx
+}
+
+/// Removes an action id from the in-flight list.
+///
+/// Returns the tx handle which can then be used to cancel the action if needed.
+async fn remove_in_flight(
+    in_flight: SharedLocalActionsInFlight,
+    id: &ActionId,
+) -> Option<oneshot::Sender<Result<Value, String>>> {
+    let mut in_flight = in_flight.lock().await;
+
+    in_flight.remove(id).or_else(|| {
+        tracing::info!(
+            "Local action {:?} not found, perhaps it was already cancelled.",
+            id
+        );
+
+        None
+    })
+}
+
+/// Spawn the plugin within a new task.
+///
+/// When the plugin completes or is cancelled, it will notify the rx
+/// handle associated with the action id.
+pub fn spawn_plugin(
+    fut: impl Future<Output = Result<Value, String>> + Send + 'static,
+    in_flight: SharedLocalActionsInFlight,
+    id: ActionId,
+) {
+    tokio::spawn(fut.then(move |result| {
+        async move {
+            let _ = remove_in_flight(in_flight, &id)
+                .await
+                .map(|tx| tx.send(result));
+        }
+    }));
+}
+
+/// Wraps a `FnOnce` so it will be called with a deserialized value and return a serialized value.
+///
+/// This is subetly different from a usual action plugin in that it's meant to be used with closures.
+async fn wrap_plugin<T, R, E: Display, Fut>(
+    v: Value,
+    f: impl FnOnce(T) -> Fut,
+) -> Result<Value, String>
+where
+    T: serde::de::DeserializeOwned + Send,
+    R: serde::Serialize + Send,
+    Fut: Future<Output = Result<R, E>> + Send,
+{
+    let x = serde_json::from_value(v).map_err(|e| format!("{}", e))?;
+
+    let x = f(x).await.map_err(|e| format!("{}", e))?;
+
+    x.to_json_value()
+}
+
+/// Try to locate and start or cancel a local action.
+pub async fn handle_local_action(
+    action: Action,
+    in_flight: SharedLocalActionsInFlight,
+    sessions: Shared<Sessions>,
+) -> Result<Result<serde_json::value::Value, String>, ActionRunnerError> {
+    match action {
+        Action::ActionCancel { id } => {
+            let _ = remove_in_flight(in_flight, &id)
+                .await
+                .map(|tx| tx.send(Ok(serde_json::Value::Null)));
+
+            Ok(Ok(serde_json::Value::Null))
+        }
+        Action::ActionStart { id, action, args } => {
+            if action == "get_session".into() {
+                let rx = add_in_flight(Arc::clone(&in_flight), id.clone()).await;
+
+                let fut = wrap_plugin(args, move |fqdn| get_session(fqdn, sessions));
+
+                spawn_plugin(fut, in_flight, id);
+
+                rx.err_into().await
+            } else if action == "await_next_session".into() {
+                let rx = add_in_flight(Arc::clone(&in_flight), id.clone()).await;
+
+                let fut = wrap_plugin(args, move |(fqdn, last_session, wait_secs)| {
+                    await_next_session(fqdn, last_session, wait_secs, sessions)
+                });
+
+                spawn_plugin(fut, in_flight, id);
+
+                rx.await.map_err(ActionRunnerError::OneShotCanceledError)
+            } else {
+                Err(ActionRunnerError::RequiredError(error::RequiredError(
+                    format!("Could not find action {} in local registry", action),
+                )))
+            }
+        }
+    }
+}

--- a/iml-services/iml-action-runner/src/main.rs
+++ b/iml-services/iml-action-runner/src/main.rs
@@ -4,9 +4,11 @@
 
 use futures::{lock::Mutex, prelude::*};
 use iml_action_runner::{
-    data::{SessionToRpcs, Sessions, Shared},
+    data::SessionToRpcs,
+    local_actions::SharedLocalActionsInFlight,
     receiver::handle_agent_data,
     sender::{create_client_filter, sender},
+    Sessions, Shared,
 };
 use iml_service_queue::service_queue::consume_service_queue;
 use iml_util::tokio_utils::get_tcp_or_unix_listener;
@@ -28,6 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let sessions: Shared<Sessions> = Arc::new(Mutex::new(HashMap::new()));
     let rpcs: Shared<SessionToRpcs> = Arc::new(Mutex::new(HashMap::new()));
+    let local_actions: SharedLocalActionsInFlight = Arc::new(Mutex::new(HashMap::new()));
 
     let log = warp::log("iml_action_runner::sender");
 
@@ -39,6 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         AGENT_TX_RUST,
         Arc::clone(&sessions),
         Arc::clone(&rpcs),
+        Arc::clone(&local_actions),
         client_filter,
     )
     .map(|x| warp::reply::json(&x))

--- a/iml-services/iml-action-runner/src/receiver.rs
+++ b/iml-services/iml-action-runner/src/receiver.rs
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::data::{create_data_message, remove_action_in_flight, SessionToRpcs, Sessions, Shared};
+use crate::{
+    data::{create_data_message, remove_action_in_flight, SessionToRpcs},
+    Sessions, Shared,
+};
 use iml_rabbit::{send_message, Client};
 use iml_wire_types::{ActionResult, Fqdn, PluginMessage};
 

--- a/iml-services/iml-action-runner/src/sender.rs
+++ b/iml-services/iml-action-runner/src/sender.rs
@@ -5,13 +5,15 @@
 use crate::{
     data::{
         await_session, create_data_message, has_action_in_flight, insert_action_in_flight,
-        remove_action_in_flight, ActionInFlight, SessionToRpcs, Sessions, Shared,
+        remove_action_in_flight, ActionInFlight, SessionToRpcs,
     },
     error::ActionRunnerError,
+    local_actions::{handle_local_action, SharedLocalActionsInFlight},
+    ActionType, Sessions, Shared,
 };
 use futures::{channel::oneshot, Future, TryFutureExt};
 use iml_rabbit::{connect_to_rabbit, get_cloned_conns, send_message, Client};
-use iml_wire_types::{Action, ActionId, Fqdn, Id, ManagerMessage};
+use iml_wire_types::{Action, ActionId, Id, ManagerMessage};
 use std::{sync::Arc, time::Duration};
 use warp::{self, Filter};
 
@@ -84,60 +86,74 @@ pub fn sender(
     queue_name: impl Into<String>,
     sessions: Shared<Sessions>,
     session_to_rpcs: Shared<SessionToRpcs>,
+    local_actions: SharedLocalActionsInFlight,
     client_filter: impl Filter<Extract = (Client,), Error = warp::Rejection> + Clone + Send,
 ) -> impl Filter<Extract = (Result<serde_json::Value, String>,), Error = warp::Rejection> + Clone {
     let queue_name = queue_name.into();
 
     let sessions_filter = warp::any().map(move || Arc::clone(&sessions));
     let session_to_rpcs_filter = warp::any().map(move || Arc::clone(&session_to_rpcs));
+    let local_actions_filter = warp::any().map(move || Arc::clone(&local_actions));
     let queue_name_filter = warp::any().map(move || queue_name.clone());
 
     let deps = sessions_filter
         .and(session_to_rpcs_filter)
+        .and(local_actions_filter)
         .and(client_filter)
         .and(queue_name_filter);
 
     warp::post().and(deps).and(warp::body::json()).and_then(
         move |shared_sessions: Shared<Sessions>,
               shared_session_to_rpcs: Shared<SessionToRpcs>,
+              local_actions: SharedLocalActionsInFlight,
               client: Client,
               queue_name: String,
-              (fqdn, action): (Fqdn, Action)| {
+              action_type: ActionType| {
             async move {
-                let session_id: Id =
-                    await_session(fqdn.clone(), shared_sessions, Duration::from_secs(30)).await?;
+                match action_type {
+                    ActionType::Local(action) => {
+                        tracing::debug!("Sending {:?}", action);
 
-                tracing::debug!("Sending {:?} to {}", action, fqdn);
-
-                let msg = create_data_message(session_id.clone(), fqdn, action.clone());
-
-                match action {
-                    Action::ActionCancel { id } => {
-                        cancel_running_action(
-                            client.clone(),
-                            msg,
-                            queue_name,
-                            session_id,
-                            id,
-                            shared_session_to_rpcs,
-                        )
-                        .await
+                        handle_local_action(action, local_actions, shared_sessions).await
                     }
-                    action => {
-                        let (tx, rx) = oneshot::channel();
+                    ActionType::Remote((fqdn, action)) => {
+                        let session_id: Id =
+                            await_session(fqdn.clone(), shared_sessions, Duration::from_secs(30))
+                                .await?;
 
-                        send_message(client.clone(), "", queue_name, msg).await?;
+                        tracing::debug!("Sending {:?} to {}", action, fqdn);
 
-                        let action_id: ActionId = action.get_id().clone();
-                        let af = ActionInFlight::new(action, tx);
+                        let msg = create_data_message(session_id.clone(), fqdn, action.clone());
 
-                        {
-                            let mut lock = shared_session_to_rpcs.lock().await;
+                        match action {
+                            Action::ActionCancel { id } => {
+                                cancel_running_action(
+                                    client.clone(),
+                                    msg,
+                                    queue_name,
+                                    session_id,
+                                    id,
+                                    shared_session_to_rpcs,
+                                )
+                                .await
+                            }
+                            action => {
+                                let (tx, rx) = oneshot::channel();
 
-                            insert_action_in_flight(session_id, action_id, af, &mut lock);
+                                send_message(client.clone(), "", queue_name, msg).await?;
+
+                                let action_id: ActionId = action.get_id().clone();
+                                let af = ActionInFlight::new(action, tx);
+
+                                {
+                                    let mut lock = shared_session_to_rpcs.lock().await;
+
+                                    insert_action_in_flight(session_id, action_id, af, &mut lock);
+                                }
+
+                                rx.await.map_err(|e| e.into())
+                            }
                         }
-
-                        rx.await.map_err(|e| e.into())
                     }
                 }
             }

--- a/iml-services/iml-action-runner/tests/action_runner_tests.rs
+++ b/iml-services/iml-action-runner/tests/action_runner_tests.rs
@@ -4,12 +4,11 @@
 
 use futures::{channel::oneshot, lock::Mutex, StreamExt, TryFutureExt, TryStreamExt};
 use iml_action_runner::{
-    data::{
-        has_action_in_flight, remove_action_in_flight, ActionInFlight, SessionToRpcs, Sessions,
-        Shared,
-    },
+    data::{has_action_in_flight, remove_action_in_flight, ActionInFlight, SessionToRpcs},
     error::ActionRunnerError,
+    local_actions::SharedLocalActionsInFlight,
     sender::sender,
+    ActionType, Sessions, Shared,
 };
 use iml_agent_comms::messaging::consume_agent_tx_queue;
 use iml_rabbit::ConnectionProperties;
@@ -31,11 +30,16 @@ async fn create_test_connection() -> Result<iml_rabbit::Client, iml_rabbit::ImlR
     iml_rabbit::connect("amqp://127.0.0.1:5672//", ConnectionProperties::default()).await
 }
 
-fn create_shared_state() -> (Shared<Sessions>, Shared<SessionToRpcs>) {
+fn create_shared_state() -> (
+    Shared<Sessions>,
+    Shared<SessionToRpcs>,
+    SharedLocalActionsInFlight,
+) {
     let sessions: Shared<Sessions> = Arc::new(Mutex::new(HashMap::new()));
     let session_to_rpcs: Shared<SessionToRpcs> = Arc::new(Mutex::new(HashMap::new()));
+    let local_actions: SharedLocalActionsInFlight = Arc::new(Mutex::new(HashMap::new()));
 
-    (sessions, session_to_rpcs)
+    (sessions, session_to_rpcs, local_actions)
 }
 
 fn create_client_filter(
@@ -45,13 +49,14 @@ fn create_client_filter(
 
 #[tokio::test]
 async fn test_sender_only_accepts_post() -> Result<(), Box<dyn std::error::Error>> {
-    let (sessions, session_to_rpcs) = create_shared_state();
+    let (sessions, session_to_rpcs, local_actions) = create_shared_state();
     let client_filter = create_client_filter();
 
     let filter = sender(
         "foo",
         Arc::clone(&sessions),
         Arc::clone(&session_to_rpcs),
+        Arc::clone(&local_actions),
         client_filter,
     )
     .map(|x| warp::reply::json(&x));
@@ -67,13 +72,14 @@ async fn test_data_sent_to_active_session() -> Result<(), Box<dyn std::error::Er
     let queue_name = create_random_string();
     let queue_name2 = queue_name.clone();
 
-    let (sessions, session_to_rpcs) = create_shared_state();
+    let (sessions, session_to_rpcs, local_actions) = create_shared_state();
     let client_filter = create_client_filter();
 
     let filter = sender(
         queue_name,
         Arc::clone(&sessions),
         Arc::clone(&session_to_rpcs),
+        Arc::clone(&local_actions),
         client_filter,
     )
     .map(|x| warp::reply::json(&x));
@@ -84,11 +90,14 @@ async fn test_data_sent_to_active_session() -> Result<(), Box<dyn std::error::Er
 
     sessions.lock().await.insert(fqdn.clone(), id.clone());
 
-    let action = Action::ActionStart {
-        action: ActionName("erase".to_string()),
-        args: serde_json::Value::Array(vec![]),
-        id: action_id.clone(),
-    };
+    let action = ActionType::Remote((
+        fqdn,
+        Action::ActionStart {
+            action: ActionName("erase".to_string()),
+            args: serde_json::Value::Array(vec![]),
+            id: action_id.clone(),
+        },
+    ));
 
     tokio::spawn(
         async move {
@@ -125,7 +134,7 @@ async fn test_data_sent_to_active_session() -> Result<(), Box<dyn std::error::Er
 
     let res = warp::test::request()
         .method("POST")
-        .json(&(fqdn, action))
+        .json(&action)
         .reply(&filter)
         .await;
 
@@ -146,13 +155,14 @@ async fn test_cancel_sent_to_active_session() -> Result<(), Box<dyn std::error::
     let queue_name = create_random_string();
     let queue_name2 = queue_name.clone();
 
-    let (sessions, session_to_rpcs) = create_shared_state();
+    let (sessions, session_to_rpcs, local_actions) = create_shared_state();
     let client_filter = create_client_filter();
 
     let filter = sender(
         queue_name,
         Arc::clone(&sessions),
         Arc::clone(&session_to_rpcs),
+        Arc::clone(&local_actions),
         client_filter,
     )
     .map(|x| warp::reply::json(&x));
@@ -177,9 +187,12 @@ async fn test_cancel_sent_to_active_session() -> Result<(), Box<dyn std::error::
     rpcs.insert(action_id.clone(), action_in_flight);
     session_to_rpcs.lock().await.insert(id.clone(), rpcs);
 
-    let cancel_action = Action::ActionCancel {
-        id: action_id.clone(),
-    };
+    let cancel_action = ActionType::Remote((
+        fqdn,
+        Action::ActionCancel {
+            id: action_id.clone(),
+        },
+    ));
 
     tokio::spawn(
         async move {
@@ -199,7 +212,7 @@ async fn test_cancel_sent_to_active_session() -> Result<(), Box<dyn std::error::
 
     let res = warp::test::request()
         .method("POST")
-        .json(&(fqdn, cancel_action))
+        .json(&cancel_action)
         .reply(&filter)
         .await;
 

--- a/tests/unit/chroma_core/lib/test_util.py
+++ b/tests/unit/chroma_core/lib/test_util.py
@@ -13,7 +13,7 @@ class TestInvokeRustAgent(unittest.TestCase):
 
         post.assert_called_once_with(
             "http+unix://%2Fvar%2Frun%2Fiml-action-runner.sock/",
-            json=("mds1.local", {"action": "ls", "args": {}, "type": "ACTION_START", "id": "1-2-3-4"}),
+            json={"REMOTE": ("mds1.local", {"action": "ls", "args": {}, "type": "ACTION_START", "id": "1-2-3-4"})},
         )
 
     def test_get_data(self, post, _):


### PR DESCRIPTION
This patch adds a way to run any sort of Rust code as part of a step
within the manager.

From the Python side, two new methods are exposed that can be called
within a step:

`invoke_rust_local_action` and `invoke_rust_local_action_expect_result`.

They work basically the same as their remote counterparts:

`invoke_rust_agent` and `invoke_rust_agent_expect_result`

Except they run the plugins on the manager and don't require a fqdn to
route the call to.

The first two plugins deal with getting the current session and waiting
for a new session, but future plugins can basically be anything.

COPR Module Manager: managerforlustre/rust-local-plugins

Signed-off-by: Joe Grund <jgrund@whamcloud.io>