### PR TITLE
Enable detail routing

### DIFF
--- a/iml-gui/crate/src/page/home.rs
+++ b/iml-gui/crate/src/page/home.rs
@@ -1,4 +1,4 @@
-use crate::{generated::css_classes::C, Model, Msg, Page};
+use crate::{generated::css_classes::C, Model, Msg, Route};
 use seed::{prelude::*, *};
 
 pub fn view(model: &Model) -> impl View<Msg> {

--- a/iml-gui/crate/src/page/partial/header.rs
+++ b/iml-gui/crate/src/page/partial/header.rs
@@ -1,7 +1,7 @@
 use crate::{
     components::{activity_indicator, font_awesome},
     generated::css_classes::C,
-    Model, Msg, Page,
+    Model, Msg, Route,
     Visibility::*,
 };
 use seed::{prelude::*, *};
@@ -43,41 +43,41 @@ fn nav_manage_dropdown(open: bool) -> Node<Msg> {
         ul![
             li![a![
                 &cls,
-                Page::Server.to_string(),
+                Route::Server.to_string(),
                 attrs! {
-                    At::Href => Page::Server.to_href(),
+                    At::Href => Route::Server.to_href(),
                 },
             ]],
             li![
-                a![&cls, Page::PowerControl.to_string()],
+                a![&cls, Route::PowerControl.to_string()],
                 attrs! {
-                    At::Href => Page::PowerControl.to_href(),
+                    At::Href => Route::PowerControl.to_href(),
                 },
             ],
             li![
-                a![&cls, Page::Filesystem.to_string()],
+                a![&cls, Route::Filesystem.to_string()],
                 attrs! {
-                    At::Href => Page::Filesystem.to_href(),
+                    At::Href => Route::Filesystem.to_href(),
                 },
             ],
             li![a![&cls, "HSM"]],
             li![a![&cls, "Storage"]],
             li![
-                a![&cls, Page::User.to_string()],
+                a![&cls, Route::User.to_string()],
                 attrs! {
-                    At::Href => Page::User.to_href(),
+                    At::Href => Route::User.to_href(),
                 },
             ],
             li![
-                a![&cls, Page::Volume.to_string()],
+                a![&cls, Route::Volume.to_string()],
                 attrs! {
-                    At::Href => Page::Volume.to_href(),
+                    At::Href => Route::Volume.to_href(),
                 },
             ],
             li![
-                a![&cls, Page::Mgt.to_string()],
+                a![&cls, Route::Mgt.to_string()],
                 attrs! {
-                    At::Href => Page::Mgt.to_href(),
+                    At::Href => Route::Mgt.to_href(),
                 },
             ]
         ]
@@ -106,15 +106,15 @@ fn main_menu_items(model: &Model) -> Node<Msg> {
         class![C.text_base, C.lg__flex, C.lg__h_16,],
         a![
             &menu_class,
-            class![C.bg_menu_active => model.page == Page::Dashboard],
+            class![C.bg_menu_active => model.route == Route::Dashboard],
             attrs! {
-                At::Href => Page::Dashboard.to_href()
+                At::Href => Route::Dashboard.to_href()
             },
             span![
                 menu_icon("tachometer-alt"),
                 span![
-                    class![C.group_hover__text_active, C.text_active => model.page == Page::Dashboard],
-                    Page::Dashboard.to_string(),
+                    class![C.group_hover__text_active, C.text_active => model.route == Route::Dashboard],
+                    Route::Dashboard.to_string(),
                 ],
             ]
         ],
@@ -140,29 +140,29 @@ fn main_menu_items(model: &Model) -> Node<Msg> {
         ],
         a![
             &menu_class,
-            class![C.bg_menu_active => model.page == Page::Jobstats],
+            class![C.bg_menu_active => model.route == Route::Jobstats],
             attrs! {
-                At::Href => Page::Jobstats.to_href()
+                At::Href => Route::Jobstats.to_href()
             },
             span![
                 menu_icon("signal"),
                 span![
-                    class![C.group_hover__text_active, C.text_active => model.page == Page::Jobstats],
-                    Page::Jobstats.to_string(),
+                    class![C.group_hover__text_active, C.text_active => model.route == Route::Jobstats],
+                    Route::Jobstats.to_string(),
                 ],
             ]
         ],
         a![
             &menu_class,
-            class![C.bg_menu_active => model.page == Page::Logs],
+            class![C.bg_menu_active => model.route == Route::Logs],
             attrs! {
-                At::Href => Page::Logs.to_href()
+                At::Href => Route::Logs.to_href()
             },
             span![
                 menu_icon("book"),
                 span![
-                    class![C.group_hover__text_active, C.bg_menu_active => model.page == Page::Logs],
-                    Page::Logs.to_string(),
+                    class![C.group_hover__text_active, C.bg_menu_active => model.route == Route::Logs],
+                    Route::Logs.to_string(),
                 ]
             ]
         ],
@@ -178,15 +178,15 @@ fn main_menu_items(model: &Model) -> Node<Msg> {
         ],
         a![
             &menu_class,
-            class![C.bg_menu_active => model.page == Page::Activity],
+            class![C.bg_menu_active => model.route == Route::Activity],
             attrs! {
-                At::Href => Page::Activity.to_href(),
+                At::Href => Route::Activity.to_href(),
             },
             span![
                 activity_indicator(&model.activity_health),
                 span![
-                    class![C.group_hover__text_active, C.bg_menu_active => model.page == Page::Activity],
-                    Page::Activity.to_string(),
+                    class![C.group_hover__text_active, C.bg_menu_active => model.route == Route::Activity],
+                    Route::Activity.to_string(),
                 ]
             ]
         ],
@@ -289,9 +289,9 @@ fn nav(model: &Model) -> Node<Msg> {
                             C.border_transparent
                         ],
                         attrs! {
-                            At::Href => Page::Login.to_href(),
+                            At::Href => Route::Login.to_href(),
                         },
-                        Page::Login.to_string(),
+                        Route::Login.to_string(),
                     ],
                 ],
             ]
@@ -312,7 +312,7 @@ pub fn view(model: &Model) -> impl View<Msg> {
                 C.text_center,
                 C.py_2
             ],
-            model.page.to_string()
+            model.route.to_string()
         ],
     ]
 }

--- a/iml-gui/crate/src/page/server_detail.rs
+++ b/iml-gui/crate/src/page/server_detail.rs
@@ -1,6 +1,6 @@
 use crate::{generated::css_classes::C, Model, Msg};
 use seed::{prelude::*, *};
 
-pub fn view(model: &Model) -> impl View<Msg> {
+pub fn view(model: &Model, id: &str) -> impl View<Msg> {
     seed::empty()
 }

--- a/iml-gui/crate/src/route.rs
+++ b/iml-gui/crate/src/route.rs
@@ -1,0 +1,127 @@
+use seed::prelude::*;
+use std::{borrow::Cow, ops::Deref};
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct RouteId<'a>(Cow<'a, str>);
+
+impl<'a> From<u32> for RouteId<'a> {
+    fn from(n: u32) -> Self {
+        RouteId(Cow::from(n.to_string()))
+    }
+}
+
+impl<'a> From<String> for RouteId<'a> {
+    fn from(n: String) -> Self {
+        RouteId(Cow::from(n))
+    }
+}
+
+impl<'a> Deref for RouteId<'a> {
+    type Target = Cow<'a, str>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub enum Route<'a> {
+    About,
+    Activity,
+    Dashboard,
+    Filesystem,
+    FilesystemDetail,
+    Home,
+    Jobstats,
+    Login,
+    Logs,
+    Mgt,
+    NotFound,
+    PowerControl,
+    Server,
+    ServerDetail(RouteId<'a>),
+    Target,
+    User,
+    Volume,
+}
+
+impl<'a> Route<'a> {
+    pub fn path(&self) -> Vec<&str> {
+        match self {
+            Self::About => vec!["about"],
+            Self::Activity => vec!["activity"],
+            Self::Dashboard => vec!["dashboard"],
+            Self::Filesystem => vec!["filesystem"],
+            Self::FilesystemDetail => vec!["filesystem_detail"],
+            Self::Home => vec![""],
+            Self::Jobstats => vec!["jobstats"],
+            Self::Login => vec!["login"],
+            Self::Logs => vec!["logs"],
+            Self::Mgt => vec!["mgt"],
+            Self::NotFound => vec!["404"],
+            Self::PowerControl => vec!["power_control"],
+            Self::Server => vec!["server"],
+            Self::ServerDetail(id) => vec!["server_detail", &id],
+            Self::Target => vec!["target"],
+            Self::User => vec!["user"],
+            Self::Volume => vec!["volume"],
+        }
+    }
+    pub fn to_href(&self) -> String {
+        format!("/{}", self.path().join("/"))
+    }
+}
+
+impl<'a> ToString for Route<'a> {
+    fn to_string(&self) -> String {
+        match self {
+            Self::About => "About".into(),
+            Self::Activity => "Activity".into(),
+            Self::Dashboard => "Dashboard".into(),
+            Self::Filesystem => "Filesystems".into(),
+            Self::FilesystemDetail => "Filesystem Detail".into(),
+            Self::Home => "Home".into(),
+            Self::Jobstats => "Jobstats".into(),
+            Self::Login => "Login".into(),
+            Self::Logs => "Logs".into(),
+            Self::Mgt => "MGTs".into(),
+            Self::NotFound => "404".into(),
+            Self::PowerControl => "Power Control".into(),
+            Self::Server => "Servers".into(),
+            Self::ServerDetail(_) => "Server Detail".into(),
+            Self::Target => "Target".into(),
+            Self::User => "Users".into(),
+            Self::Volume => "Volumes".into(),
+        }
+    }
+}
+
+impl<'a> From<Url> for Route<'a> {
+    fn from(url: Url) -> Self {
+        let mut path = url.path.into_iter();
+
+        match path.next().as_ref().map(String::as_str) {
+            Some("about") => Self::About,
+            Some("activity") => Self::Activity,
+            Some("dashboard") => Self::Dashboard,
+            Some("filesystem") => Self::Filesystem,
+            Some("filesystem_detail") => Self::FilesystemDetail,
+            None | Some("") => Self::Home,
+            Some("jobstats") => Self::Jobstats,
+            Some("login") => Self::Login,
+            Some("logs") => Self::Logs,
+            Some("mgt") => Self::Mgt,
+            Some("power_control") => Self::PowerControl,
+            Some("server") => Self::Server,
+            Some("server_detail") => path
+                .next()
+                .map(RouteId::from)
+                .map(Self::ServerDetail)
+                .unwrap_or(Self::NotFound),
+            Some("target") => Self::Target,
+            Some("user") => Self::User,
+            Some("volume") => Self::Volume,
+            _ => Self::NotFound,
+        }
+    }
+}


### PR DESCRIPTION
This patch enables us to use a route that contains data (meaning a route
enum variant can now carry some data).

This enables detail pages where we need to include an id in the route.

In addition, this patch renames `Page` enum to `Route`, which seems like
a better name, and extracts it to it's own file.

![detail-routing](https://user-images.githubusercontent.com/458717/70170535-da367c80-169a-11ea-8a17-5d33581361c1.gif)


Signed-off-by: Joe Grund <jgrund@whamcloud.io>