### PR TITLE
Implement checking for loaded kernel modules

### DIFF
--- a/.github/actions/copr-kmod/action.yml
+++ b/.github/actions/copr-kmod/action.yml
@@ -2,4 +2,4 @@ name: copr kmod
 description: build in the copr-kmod image
 runs:
   using: "docker"
-  image: "docker://imlteam/copr-kmod:stable"
+  image: "docker://imlteam/copr-kmod:latest"

--- a/.github/actions/copr-kmod/action.yml
+++ b/.github/actions/copr-kmod/action.yml
@@ -1,0 +1,5 @@
+name: copr kmod
+description: build in the copr-kmod image
+runs:
+  using: "docker"
+  image: "docker://imlteam/copr-kmod:stable"

--- a/.github/actions/copr-rust/action.yml
+++ b/.github/actions/copr-rust/action.yml
@@ -1,5 +1,5 @@
 name: copr rust
-description: build in the copr-kmod image
+description: build in the copr-rust image
 runs:
   using: "docker"
-  image: "docker://imlteam/copr-kmod:stable"
+  image: "docker://imlteam/copr-rust:stable"

--- a/.github/actions/copr-rust/action.yml
+++ b/.github/actions/copr-rust/action.yml
@@ -1,5 +1,5 @@
 name: copr rust
-description: build in the copr-rust image
+description: build in the copr-kmod image
 runs:
   using: "docker"
-  image: "docker://imlteam/copr-rust:stable"
+  image: "docker://imlteam/copr-kmod:stable"

--- a/.github/workflows/devel-release.yml
+++ b/.github/workflows/devel-release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Push RPM
-        uses: ./.github/actions/copr-rust
+        uses: ./.github/actions/copr-kmod
         env:
           PROD: false
           OWNER: managerforlustre

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Push RPM
-        uses: ./.github/actions/copr-rust
+        uses: ./.github/actions/copr-kmod
         env:
           PROD: true
           OWNER: managerforlustre

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Build rpm
-        uses: ./.github/actions/copr-rust
+        uses: ./.github/actions/copr-kmod
         env:
           SPEC: rust-iml.spec
           LOCAL_ONLY: true

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -73,6 +73,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
 
+      - name: Install kmod-dev
+        run: sudo apt install libkmod-dev
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1062,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "elementtree 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "exitcode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1060,6 +1070,7 @@ dependencies = [
  "iml-util 0.1.0",
  "iml-wire-types 0.2.0",
  "insta 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kmod 0.4.0 (git+https://github.com/whamcloud/kmod-rs.git)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "liblustreapi 0.1.0",
@@ -1362,6 +1373,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kmod"
+version = "0.4.0"
+source = "git+https://github.com/whamcloud/kmod-rs.git#e05299fcf5a37452864cfb2559b98c232e403a5c"
+dependencies = [
+ "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kmod-sys 0.1.2 (git+https://github.com/whamcloud/kmod-rs.git)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kmod-sys"
+version = "0.1.2"
+source = "git+https://github.com/whamcloud/kmod-rs.git#e05299fcf5a37452864cfb2559b98c232e403a5c"
+dependencies = [
+ "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3570,6 +3600,7 @@ dependencies = [
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+"checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum exitcode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
@@ -3621,6 +3652,8 @@ dependencies = [
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum kmod 0.4.0 (git+https://github.com/whamcloud/kmod-rs.git)" = "<none>"
+"checksum kmod-sys 0.1.2 (git+https://github.com/whamcloud/kmod-rs.git)" = "<none>"
 "checksum lapin 0.28.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5c9054d1fc8d4b5a9d67aa003fbbd26b33f89357fb60940a518c75021796f601"
 "checksum lapin-futures 0.28.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6ddde94e66adaf729ad2b6060a2912eb3d8d9a50f64a4aa2cd8567dc04af84ab"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,10 +1378,9 @@ dependencies = [
 [[package]]
 name = "kmod"
 version = "0.4.0"
-source = "git+https://github.com/whamcloud/kmod-rs.git#e05299fcf5a37452864cfb2559b98c232e403a5c"
+source = "git+https://github.com/whamcloud/kmod-rs.git#7719ab22aaff72ccf2ab1679c7bed7fe017ca8d7"
 dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kmod-sys 0.1.2 (git+https://github.com/whamcloud/kmod-rs.git)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1389,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "kmod-sys"
 version = "0.1.2"
-source = "git+https://github.com/whamcloud/kmod-rs.git#e05299fcf5a37452864cfb2559b98c232e403a5c"
+source = "git+https://github.com/whamcloud/kmod-rs.git#7719ab22aaff72ccf2ab1679c7bed7fe017ca8d7"
 dependencies = [
  "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,15 +637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,7 +1053,6 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "elementtree 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "exitcode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3599,7 +3589,6 @@ dependencies = [
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
-"checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum exitcode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ dependencies = [
  "iml-util 0.1.0",
  "iml-wire-types 0.2.0",
  "insta 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kmod 0.4.0 (git+https://github.com/whamcloud/kmod-rs.git)",
+ "kmod 0.5.0 (git+https://github.com/whamcloud/kmod-rs.git)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "liblustreapi 0.1.0",
@@ -1367,18 +1367,18 @@ dependencies = [
 
 [[package]]
 name = "kmod"
-version = "0.4.0"
-source = "git+https://github.com/whamcloud/kmod-rs.git#7719ab22aaff72ccf2ab1679c7bed7fe017ca8d7"
+version = "0.5.0"
+source = "git+https://github.com/whamcloud/kmod-rs.git#c06e0102997eaa34cea301d917b99c7663f47a47"
 dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "kmod-sys 0.1.2 (git+https://github.com/whamcloud/kmod-rs.git)",
+ "kmod-sys 0.2.0 (git+https://github.com/whamcloud/kmod-rs.git)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kmod-sys"
-version = "0.1.2"
-source = "git+https://github.com/whamcloud/kmod-rs.git#7719ab22aaff72ccf2ab1679c7bed7fe017ca8d7"
+version = "0.2.0"
+source = "git+https://github.com/whamcloud/kmod-rs.git#c06e0102997eaa34cea301d917b99c7663f47a47"
 dependencies = [
  "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3640,8 +3640,8 @@ dependencies = [
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kmod 0.4.0 (git+https://github.com/whamcloud/kmod-rs.git)" = "<none>"
-"checksum kmod-sys 0.1.2 (git+https://github.com/whamcloud/kmod-rs.git)" = "<none>"
+"checksum kmod 0.5.0 (git+https://github.com/whamcloud/kmod-rs.git)" = "<none>"
+"checksum kmod-sys 0.2.0 (git+https://github.com/whamcloud/kmod-rs.git)" = "<none>"
 "checksum lapin 0.28.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5c9054d1fc8d4b5a9d67aa003fbbd26b33f89357fb60940a518c75021796f601"
 "checksum lapin-futures 0.28.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6ddde94e66adaf729ad2b6060a2912eb3d8d9a50f64a4aa2cd8567dc04af84ab"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"

--- a/docker/rust-base.dockerfile
+++ b/docker/rust-base.dockerfile
@@ -1,5 +1,6 @@
 FROM rust:1.39
 WORKDIR /build
 COPY . .
-RUN sudo apt install libkmod-dev
+RUN apt update
+RUN apt install libkmod-dev
 RUN cargo build --release

--- a/docker/rust-base.dockerfile
+++ b/docker/rust-base.dockerfile
@@ -2,5 +2,5 @@ FROM rust:1.39
 WORKDIR /build
 COPY . .
 RUN apt update
-RUN apt install -y libkmod-dev
+RUN apt install -y clang libkmod-dev
 RUN cargo build --release

--- a/docker/rust-base.dockerfile
+++ b/docker/rust-base.dockerfile
@@ -2,5 +2,5 @@ FROM rust:1.39
 WORKDIR /build
 COPY . .
 RUN apt update
-RUN apt install libkmod-dev
+RUN apt install -y libkmod-dev
 RUN cargo build --release

--- a/docker/rust-base.dockerfile
+++ b/docker/rust-base.dockerfile
@@ -1,4 +1,5 @@
 FROM rust:1.39
 WORKDIR /build
 COPY . .
+RUN sudo apt install libkmod-dev
 RUN cargo build --release

--- a/iml-agent/Cargo.toml
+++ b/iml-agent/Cargo.toml
@@ -42,7 +42,6 @@ liblustreapi = { path = "../liblustreapi", version = "0.1" }
 iml-fs = { path = "../iml-fs", version = "0.1.0" }
 iml-util = { path = "../iml-util", version = "0.1.0" }
 kmod = { git = "https://github.com/whamcloud/kmod-rs.git" }
-error-chain = "0.12.1"
 
 [dependencies.regex]
 version = "1.3"

--- a/iml-agent/Cargo.toml
+++ b/iml-agent/Cargo.toml
@@ -41,6 +41,8 @@ iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
 liblustreapi = { path = "../liblustreapi", version = "0.1" }
 iml-fs = { path = "../iml-fs", version = "0.1.0" }
 iml-util = { path = "../iml-util", version = "0.1.0" }
+kmod = { git = "https://github.com/whamcloud/kmod-rs.git" }
+error-chain = "0.12.1"
 
 [dependencies.regex]
 version = "1.3"

--- a/iml-agent/Cargo.toml
+++ b/iml-agent/Cargo.toml
@@ -41,7 +41,7 @@ iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
 liblustreapi = { path = "../liblustreapi", version = "0.1" }
 iml-fs = { path = "../iml-fs", version = "0.1.0" }
 iml-util = { path = "../iml-util", version = "0.1.0" }
-kmod = { git = "https://github.com/whamcloud/kmod-rs.git" }
+kmod = { git = "https://github.com/whamcloud/kmod-rs.git", version = "0.5" }
 
 [dependencies.regex]
 version = "1.3"

--- a/iml-agent/src/action_plugins/action_plugin.rs
+++ b/iml-agent/src/action_plugins/action_plugin.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     action_plugins::{
-        check_ha, check_stonith,
+        check_ha, check_stonith, kernel_module,
         ntp::action_configure,
         ostpool, package_installed,
         stratagem::{action_purge, action_warning, server},
@@ -25,6 +25,7 @@ pub fn create_registry() -> action_plugins::Actions {
         .add_plugin("disable_unit", systemd::disable_unit)
         .add_plugin("restart_unit", systemd::restart_unit)
         .add_plugin("get_unit_run_state", systemd::get_run_state)
+        .add_plugin("kernel_module_loaded", kernel_module::loaded)
         .add_plugin("package_installed", package_installed::package_installed)
         .add_plugin("start_scan_stratagem", server::trigger_scan)
         .add_plugin("stream_fidlists_stratagem", server::stream_fidlists)

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -1,5 +1,19 @@
-use crate::agent_error::ImlAgentError;
+use crate::agent_error::{ImlAgentError, MyKmodError};
+
+use kmod;
 
 pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
-    Ok(false)
+    let ctx = kmod::Context::new().map_err(|e| MyKmodError::from(e))?;
+
+    let mut result = false;
+    for m in ctx.modules_loaded().map_err(|e| MyKmodError::from(e))? {
+        let name = m.name();
+
+        if name == module {
+            result = true;
+        } else {
+            continue;
+        }
+    }
+    Ok(result)
 }

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -5,15 +5,5 @@ use kmod;
 pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
     let ctx = kmod::Context::new()?;
 
-    let mut result = false;
-    for m in ctx.modules_loaded()? {
-        let name = m.name();
-
-        if name == module {
-            result = true;
-        } else {
-            continue;
-        }
-    }
-    Ok(result)
+    Ok(ctx.modules_loaded()?.find(|m| m.name() == module).is_some())
 }

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -1,0 +1,5 @@
+use crate::agent_error::ImlAgentError;
+
+pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
+    Ok(false)
+}

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -1,12 +1,12 @@
-use crate::agent_error::{ImlAgentError, MyKmodError};
+use crate::agent_error::ImlAgentError;
 
 use kmod;
 
 pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
-    let ctx = kmod::Context::new().map_err(|e| MyKmodError::from(e))?;
+    let ctx = kmod::Context::new()?;
 
     let mut result = false;
-    for m in ctx.modules_loaded().map_err(|e| MyKmodError::from(e))? {
+    for m in ctx.modules_loaded()? {
         let name = m.name();
 
         if name == module {

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -10,7 +10,10 @@ pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
     run(move || {
         let ctx = kmod::Context::new()?;
 
-        Ok(ctx.modules_loaded()?.find(|m| m.name() == module).is_some())
+        Ok(ctx
+            .modules_loaded()?
+            .find(|m| m.name() == module && m.refcount() > 0)
+            .is_some())
     })
     .await
 }

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -10,10 +10,7 @@ pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
     run(move || {
         let ctx = kmod::Context::new()?;
 
-        Ok(ctx
-            .modules_loaded()?
-            .find(|m| m.name() == module && m.refcount() > 0)
-            .is_some())
+        Ok(ctx.modules_loaded()?.find(|m| m.name() == module).is_some())
     })
     .await
 }

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 use crate::agent_error::ImlAgentError;
 use kmod;
 use tokio_executor::blocking::run;

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -1,9 +1,12 @@
 use crate::agent_error::ImlAgentError;
-
 use kmod;
+use tokio_executor::blocking::run;
 
 pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
-    let ctx = kmod::Context::new()?;
+    run(move || {
+        let ctx = kmod::Context::new()?;
 
-    Ok(ctx.modules_loaded()?.find(|m| m.name() == module).is_some())
+        Ok(ctx.modules_loaded()?.find(|m| m.name() == module).is_some())
+    })
+    .await
 }

--- a/iml-agent/src/action_plugins/mod.rs
+++ b/iml-agent/src/action_plugins/mod.rs
@@ -6,8 +6,10 @@ pub mod action_plugin;
 pub mod check_ha;
 pub mod check_kernel;
 pub mod check_stonith;
+pub mod kernel_module;
 pub mod ntp;
 pub mod ostpool;
 pub mod package_installed;
 pub mod stratagem;
+
 pub use action_plugin::create_registry;

--- a/iml-agent/src/agent_error.rs
+++ b/iml-agent/src/agent_error.rs
@@ -6,8 +6,6 @@ use iml_fs::ImlFsError;
 use iml_wire_types::PluginName;
 use kmod::Error as KmodError;
 
-use error_chain::ChainedError;
-
 use std::{fmt, process::Output};
 
 pub type Result<T> = std::result::Result<T, ImlAgentError>;
@@ -99,7 +97,7 @@ pub enum ImlAgentError {
     CibError(CibError),
     UnexpectedStatusError,
     MarkerNotFound,
-    KmodError(MyKmodError),
+    KmodError(KmodError),
 }
 
 impl std::fmt::Display for ImlAgentError {
@@ -320,34 +318,9 @@ impl From<CibError> for ImlAgentError {
     }
 }
 
-impl From<MyKmodError> for ImlAgentError {
-    fn from(err: MyKmodError) -> Self {
-        ImlAgentError::KmodError(err)
-    }
-}
-
-#[derive(Debug)]
-pub struct MyKmodError {
-    kind: <kmod::Error as ChainedError>::ErrorKind,
-}
-
-impl fmt::Display for MyKmodError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "MyKmodError")
-    }
-}
-
-impl std::error::Error for MyKmodError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
-
-impl From<KmodError> for MyKmodError {
+impl From<KmodError> for ImlAgentError {
     fn from(err: KmodError) -> Self {
-        match err {
-            kmod::Error(e, _) => Self { kind: e },
-        }
+        ImlAgentError::KmodError(err)
     }
 }
 

--- a/iml-agent/src/cli.rs
+++ b/iml-agent/src/cli.rs
@@ -7,7 +7,7 @@ use iml_agent::action_plugins::stratagem::{
     server::{generate_cooked_config, trigger_scan, Counter, StratagemCounters},
 };
 use iml_agent::action_plugins::{
-    check_ha, check_kernel, check_stonith, ostpool, package_installed,
+    check_ha, check_kernel, check_stonith, kernel_module, ostpool, package_installed,
 };
 use liblustreapi as llapi;
 use prettytable::{cell, row, Table};
@@ -211,6 +211,9 @@ pub enum App {
     #[structopt(name = "get_kernel")]
     /// Get latest kernel which supports listed modules
     GetKernel { modules: Vec<String> },
+
+    #[structopt(name = "kernel_module")]
+    KernelModule { module: String },
 }
 
 fn input_to_iter(input: Option<String>, fidlist: Vec<String>) -> Box<dyn Iterator<Item = String>> {
@@ -449,6 +452,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 exit(exitcode::SOFTWARE);
             }
         }
+        App::KernelModule { module } => match kernel_module::loaded(module).await {
+            Ok(b) => {
+                println!("{}", if b { "Loaded" } else { "Not Loaded" });
+            }
+            Err(e) => {
+                eprintln!("{}", e);
+                exit(exitcode::SOFTWARE);
+            }
+        },
     };
 
     Ok(())


### PR DESCRIPTION
The main pain point here is `MyKmodError`. I introduced it because wrapping `kmod::Error` directly in a variant of `ImlAgentError` broke code in unrelated parts of IML because `ImlAgentError` stopped being `Sync` apparently. So there's this middleware conversion.

Anyone knows how to deal with that?

#1187 