### PR TITLE
Fix breadcrumbs for new routing

### DIFF
--- a/iml-gui/crate/src/components/breadcrumbs.rs
+++ b/iml-gui/crate/src/components/breadcrumbs.rs
@@ -1,4 +1,5 @@
-use crate::{generated::css_classes::C, Msg, Page};
+use crate::route::Route;
+use crate::{generated::css_classes::C, Msg};
 use seed::{prelude::*, *};
 use std::cmp::PartialEq;
 use std::collections::LinkedList;
@@ -42,7 +43,7 @@ impl<Crumb: PartialEq> BreadCrumbs<Crumb> {
     }
 }
 
-pub fn view(bc: &BreadCrumbs<Page>) -> impl View<Msg> {
+pub fn view(bc: &BreadCrumbs<Route>) -> impl View<Msg> {
     let mut ol = ol![class![C.justify_center, C.truncate, C.mx_4, C.rtl]];
 
     // XXX the list has "direction: rtl" to put ellipsis to the left on overflow,

--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -102,7 +102,7 @@ pub struct Model {
     pub records: warp_drive::Cache,
     pub locks: warp_drive::Locks,
     pub activity_health: ActivityHealth,
-    pub breadcrumbs: BreadCrumbs<Page>,
+    pub breadcrumbs: BreadCrumbs<Route<'static>>,
 }
 
 pub fn register_eventsource_handle<T, F>(
@@ -223,10 +223,10 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         Msg::RouteChanged(url) => {
             model.route = url.into();
             orders.send_msg(Msg::UpdatePageTitle);
-            if model.page == Page::Home {
+            if model.route == Route::Home {
                 model.breadcrumbs.clear();
             }
-            model.breadcrumbs.push(model.page);
+            model.breadcrumbs.push(model.route.clone());
         }
         Msg::UpdatePageTitle => {
             let title =


### PR DESCRIPTION
The breacrumbs were merged after bab14f6989cd2d8ceec7b8cdee26f20040ae68dd
and thus would not compile.

In addition use explicit .clone() because the Route type no longer
implements Copy.

Signed-off-by: Igor Pashev <pashev.igor@gmail.com>