### PR TITLE
GH-1384 Setup NTP Storage Servers for Docker

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -312,7 +312,7 @@ COVERAGE_REPORT_HTML_OUTPUT_DIR = "/tmp/test_html"
 
 # If you really want to point the Lustre servers at a specific NTP server
 # NTP_SERVER_HOSTNAME = "myntpserver.mydoman"
-NTP_SERVER_HOSTNAME = None
+NTP_SERVER_HOSTNAME = os.getenv("NTP_SERVER_HOSTNAME", None)
 
 # Maximum latency between server and agent: used to
 # check if clocks are 'reasonably' in sync


### PR DESCRIPTION
Fixes #1384.

The docker setup currently sets the ntp server to be the job scheduler. This is an issue because the server nodes will not be able to use the job scheduler as a time manager.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>