### PR TITLE
IML CLI: Fix cmd error state

### DIFF
--- a/iml-manager-cli/src/api_utils.rs
+++ b/iml-manager-cli/src/api_utils.rs
@@ -48,7 +48,7 @@ pub async fn create_command<T: serde::Serialize>(
 }
 
 fn cmd_finished(cmd: &Command) -> bool {
-    cmd.errored || cmd.cancelled || cmd.complete
+    cmd.complete
 }
 
 pub async fn wait_for_cmd(cmd: Command) -> Result<Command, ImlManagerCliError> {

--- a/iml-manager-cli/src/display_utils.rs
+++ b/iml-manager-cli/src/display_utils.rs
@@ -39,12 +39,12 @@ pub fn start_spinner(msg: &str) -> impl FnOnce(Option<String>) -> () {
 }
 
 pub fn format_cmd_state(cmd: &Command) -> String {
-    if cmd.complete {
-        format_success(format!("{} successful", cmd.message))
-    } else if cmd.errored {
+    if cmd.errored {
         format_error(format!("{} errored", cmd.message))
-    } else {
+    } else if cmd.cancelled {
         format_cancelled(&format!("{} cancelled", cmd.message))
+    } else {
+        format_success(format!("{} successful", cmd.message))
     }
 }
 


### PR DESCRIPTION
Report error if cmd is "errored".
Command.complete is only set if commanded has completed, does not
indicate success.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>