### PR TITLE
Fix or silence warnings in iml-agent

### DIFF
--- a/iml-agent/src/poller.rs
+++ b/iml-agent/src/poller.rs
@@ -83,6 +83,7 @@ pub async fn create_poller(
                         sessions.reset_empty(&name)
                     });
 
+                    #[allow(unused_must_use)]
                     tokio::spawn(async {
                         fut.await;
                     });
@@ -100,6 +101,7 @@ pub async fn create_poller(
                 now,
             );
 
+            #[allow(unused_must_use)]
             tokio::spawn(async move {
                 fut.await.map_err(|e| {
                     error!("{}", e);

--- a/iml-agent/src/poller.rs
+++ b/iml-agent/src/poller.rs
@@ -83,9 +83,8 @@ pub async fn create_poller(
                         sessions.reset_empty(&name)
                     });
 
-                    #[allow(unused_must_use)]
                     tokio::spawn(async {
-                        fut.await;
+                        fut.map(drop).await;
                     });
                 }
                 _ => (),
@@ -101,11 +100,10 @@ pub async fn create_poller(
                 now,
             );
 
-            #[allow(unused_must_use)]
             tokio::spawn(async move {
-                fut.await.map_err(|e| {
+                if let Err(e) = fut.await {
                     error!("{}", e);
-                });
+                };
             });
         }
     }

--- a/iml-agent/src/reader.rs
+++ b/iml-agent/src/reader.rs
@@ -62,7 +62,7 @@ async fn get_delivery(
             }
             ManagerMessage::Data {
                 plugin,
-                session_id,
+                session_id: _,
                 body,
                 ..
             } => {


### PR DESCRIPTION
The intent is to have clean compilation to easily spot newly introduced warnings.

With `poller`, the behavior stays the same, since it's unclear how to fix the warnings w/o silencing them.

Signed-off-by: Michael Pankov <work@michaelpankov.com>