### PR TITLE
Integrate grafana into docker stack

### DIFF
--- a/chroma-manager.conf.template
+++ b/chroma-manager.conf.template
@@ -139,6 +139,8 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Server $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
         proxy_pass {{HTTP_API_PROXY_PASS}}/api/auth/;
     }
 
@@ -151,7 +153,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-WEBAUTH-USER "admin";
         rewrite  ^/grafana/(.*)  /$1 break;
-        proxy_pass http://localhost:3000/;
+        proxy_pass {{GRAFANA_PROXY_PASS}};
     }
 
     location /influx {

--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -333,45 +333,6 @@ class ServiceConfig(CommandLine):
             log.error(error)
             raise RuntimeError(error)
 
-        # Add Datasources
-        url = "http://localhost:3000/api/datasources"
-        headers = {"X-WEBAUTH-USER": "admin"}
-        urlname = "{}/id/{}".format(url, "iml-postgres")
-        r = requests.get(urlname, headers=headers)
-        if not r.ok:
-            db = settings.DATABASES["default"]
-            resp = requests.post(
-                url,
-                headers=headers,
-                json={
-                    "name": "iml-postgres",
-                    "type": "postgres",
-                    "access": "proxy",
-                    "user": db["USER"],
-                    "password": db["PASSWORD"],
-                    "database": db["NAME"],
-                    "url": ":".join((x for x in [db["HOST"], db["PORT"]] if x)) or "localhost",
-                    "jsonData": {"sslmode": "disable"},
-                },
-            )
-        for db in [settings.INFLUXDB_IML_DB, settings.INFLUXDB_STRATAGEM_SCAN_DB]:
-            name = "iml-influx-{}".format(db)
-            urlname = "{}/id/{}".format(url, name)
-            r = requests.get(urlname, headers=headers)
-            if not r.ok:
-                resp = requests.post(
-                    url,
-                    headers=headers,
-                    json={
-                        "name": name,
-                        "type": "influxdb",
-                        "database": db,
-                        "url": "http://localhost:8086",
-                        "jsonData": {"httpMode": "GET"},
-                        "access": "proxy",
-                    },
-                )
-
     def _setup_crypto(self):
         if not os.path.exists(settings.CRYPTO_FOLDER):
             os.makedirs(settings.CRYPTO_FOLDER)
@@ -663,6 +624,8 @@ class ServiceConfig(CommandLine):
             "DEVICE_AGGREGATOR_PORT",
             "DEVICE_AGGREGATOR_PROXY_PASS",
             "UPDATE_HANDLER_PROXY_PASS",
+            "GRAFANA_PORT",
+            "GRAFANA_PROXY_PASS",
         ]
 
         with open(conf_template, "r") as f:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,10 +36,19 @@ services:
     ports:
       - 8086:8086
   grafana:
-    image: "grafana/grafana"
+    image: "imlteam/grafana:5.1"
+    build:
+      context: ../
+      dockerfile: ./docker/grafana.dockerfile
     hostname: "grafana"
     deploy: *default-deploy
+    environment:
+      - GF_SERVER_DOMAIN=grafana
+      - GF_SERVER_HTTP_PORT=3000
+      - GF_SERVER_PROTOCOL=http
+      - "GF_DATABASE_HOST=postgres:5432"
     volumes:
+      - "manager-config:/var/lib/chroma"
       - grafana-storage:/var/lib/grafana
     ports:
       - 3000:3000

--- a/docker/grafana.dockerfile
+++ b/docker/grafana.dockerfile
@@ -1,0 +1,19 @@
+FROM grafana/grafana
+USER root
+RUN apk add postgresql-client curl python \
+  && mkdir -p /usr/share/chroma-manager/grafana/dashboards/
+
+COPY docker/grafana/setup-grafana /usr/share/grafana/
+COPY docker/grafana/setup-grafana.sh /usr/local/bin/
+COPY grafana/grafana-iml.ini /etc/grafana/grafana.ini
+COPY grafana/datasources/influxdb-iml-datasource.yml /etc/grafana/provisioning/datasources/
+COPY grafana/dashboards/iml-dashboards.yaml /etc/grafana/provisioning/dashboards/
+COPY grafana/dashboards/stratagem-dashboard-1.json /usr/share/chroma-manager/grafana/dashboards/
+COPY docker/wait-for-dependencies-postgres.sh /usr/bin/
+
+# Remove whitelist entry from grafana config as docker will not work with a whitelist
+RUN sed -i '/^whitelist/d' /etc/grafana/grafana.ini \
+  && sed -i 's/.*url: http:\/\/localhost:8086/    url: http:\/\/influxdb:8086/g' /etc/grafana/provisioning/datasources/influxdb-iml-datasource.yml
+
+ENTRYPOINT [ "wait-for-dependencies-postgres.sh" ]
+CMD ["setup-grafana.sh"]

--- a/docker/grafana/setup-grafana
+++ b/docker/grafana/setup-grafana
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+
+
+def psql_sql(sql):
+    p = subprocess.Popen(["psql", "-h", "postgres", "-U", "chroma", "-tAc {}".format(sql)], stdout=subprocess.PIPE)
+    return p.stdout.read()
+
+
+cmd = psql_sql(
+    "SELECT 'CREATE DATABASE grafana' WHERE NOT EXISTS (SELECT * FROM pg_database WHERE datname = 'grafana')"
+)
+if cmd:
+    psql_sql(cmd)
+    print("Grafana database created!")
+else:
+    print("Grafana database already exists.")

--- a/docker/grafana/setup-grafana.sh
+++ b/docker/grafana/setup-grafana.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+  /usr/share/grafana/setup-grafana \
+  && /run.sh

--- a/docker/setup-nginx
+++ b/docker/setup-nginx
@@ -15,7 +15,8 @@ vars = {
     "UPDATE_HANDLER_PROXY_PASS": "http://update-handler:8080",
     "WARP_DRIVE_PROXY_PASS": "http://iml-warp-drive:8890",
     "MAILBOX_PATH": "/var/spool/iml/mailbox",
-    "MAILBOX_PROXY_PASS": "http://mailbox:8891",
+    "MAILBOX_PROXY_PASS": "http://localhost:8891",
+    "GRAFANA_PROXY_PASS": "http://grafana:3000",
 }
 
 conf_template = "./chroma-manager.conf.template"
@@ -23,11 +24,7 @@ conf_template = "./chroma-manager.conf.template"
 with open(conf_template, "r") as f:
     config = f.read()
 
-    config = re.sub(
-        r"proxy_pass {{(.+)}}.*;",
-        r"set $proxy_upstream {{\g<1>}};\n        proxy_pass $proxy_upstream$uri$is_args$query_string;",
-        config,
-    )
+    config = re.sub(r"proxy_pass {{(.+)}}(.*);", r"proxy_pass {{\g<1>}}\g<2>;", config)
     config = re.sub(
         r"proxy_read_timeout (.+);",
         r"proxy_read_timeout \g<1>;\n    resolver 127.0.0.11 ipv6=off valid=5s;\n    resolver_timeout 5s;",
@@ -43,12 +40,6 @@ with open(conf_template, "r") as f:
         config = config.replace("{{%s}}" % k, v)
 
     config = re.sub(r"{{(.+)}}", r"{{ .Env.\g<1> }}", config)
-
-    config = re.sub(
-        r".+set \$proxy_upstream http://iml-agent-comms:(\d+);\n.+proxy_pass \$proxy_upstream\$uri\$is_args\$query_string;",
-        r"        set $proxy_upstream http://iml-agent-comms:\g<1>;\n        proxy_pass $proxy_upstream/message/$is_args$query_string;",
-        config,
-    )
 
     with open("iml.template", "w") as f2:
         f2.write(config)

--- a/grafana/datasources/influxdb-iml-datasource.yml
+++ b/grafana/datasources/influxdb-iml-datasource.yml
@@ -1,0 +1,19 @@
+apiVersion: 1
+
+datasources:
+  - name: "iml-influx-iml"
+    type: influxdb
+    access: proxy
+    database: iml
+    url: http://localhost:8086
+    jsonData: { httpMode: GET }
+
+  - name: "iml-influx-iml_stratagem_scans"
+    type: influxdb
+    access: proxy
+    database: "iml_stratagem_scans"
+    url: http://localhost:8086
+    jsonData: { httpMode: GET }
+
+version: 1
+editable: false

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -179,9 +179,11 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/rabbitmq
 touch $RPM_BUILD_ROOT%{_sysconfdir}/nginx/conf.d/chroma-manager.conf
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/rabbitmq
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/grafana/provisioning/dashboards
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/grafana/provisioning/datasources
 cp -r grafana $RPM_BUILD_ROOT%{manager_root}
 mv $RPM_BUILD_ROOT%{manager_root}/grafana/grafana-iml.ini $RPM_BUILD_ROOT%{_sysconfdir}/grafana/
 mv $RPM_BUILD_ROOT%{manager_root}/grafana/dashboards/iml-dashboards.yaml $RPM_BUILD_ROOT%{_sysconfdir}/grafana/provisioning/dashboards
+mv $RPM_BUILD_ROOT%{manager_root}/grafana/datasources/influxdb-iml-datasource.yml $RPM_BUILD_ROOT%{_sysconfdir}/grafana/provisioning/datasources
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}/grafana-server.service.d/
 mv $RPM_BUILD_ROOT%{manager_root}/grafana/dropin-iml.conf $RPM_BUILD_ROOT%{_unitdir}/grafana-server.service.d/90-iml.conf
 cp iml-manager-redirect.conf $RPM_BUILD_ROOT%{_sysconfdir}/nginx/default.d/iml-manager-redirect.conf
@@ -303,6 +305,7 @@ fi
 %attr(0644,root,root)%{_sysconfdir}/logrotate.d/chroma-manager
 %attr(0644,root,grafana)%{_sysconfdir}/grafana/provisioning/dashboards/iml-dashboards.yaml
 %attr(0644,root,grafana)%{manager_root}/grafana/dashboards/stratagem-dashboard*.json
+%attr(0644,root,grafana)%{_sysconfdir}/grafana/provisioning/datasources/influxdb-iml-datasource.yml
 %attr(0644,root,root)%{_unitdir}/iml-manager.target
 %attr(0644,root,root)%{_unitdir}/*.service
 %attr(0644,root,root)%{_unitdir}/device-aggregator.service.d/10-device-aggregator.service.conf

--- a/settings.py
+++ b/settings.py
@@ -74,6 +74,10 @@ ACTION_RUNNER_PORT = 8009
 
 UPDATE_HANDLER_PROXY_PASS = "http://unix:/var/run/iml-update-handler.sock"
 
+GRAFANA_PORT = 3000
+
+GRAFANA_PROXY_PASS = "http://{}:{}".format(PROXY_HOST, GRAFANA_PORT)
+
 ALLOWED_HOSTS = ["*"]
 
 ADMINS = (


### PR DESCRIPTION
Fixes #1388 

Grafana is currently only setup to run using a manager node. This is very restrictive and will not work on certain setups. In an effort to support systems without a management node, docker support should be added.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1401)
<!-- Reviewable:end -->
