### PR TITLE
Implement checking of loaded kernel modules

### DIFF
--- a/iml-agent/src/action_plugins/action_plugin.rs
+++ b/iml-agent/src/action_plugins/action_plugin.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     action_plugins::{
-        check_ha, check_stonith, lctl,
+        check_ha, check_stonith, kernel_module, lctl,
         ntp::action_configure,
         ostpool, package_installed,
         stratagem::{action_purge, action_warning, server},
@@ -25,6 +25,7 @@ pub fn create_registry() -> action_plugins::Actions {
         .add_plugin("disable_unit", systemd::disable_unit)
         .add_plugin("restart_unit", systemd::restart_unit)
         .add_plugin("get_unit_run_state", systemd::get_run_state)
+        .add_plugin("kernel_module_loaded", kernel_module::loaded)
         .add_plugin("package_installed", package_installed::package_installed)
         .add_plugin("start_scan_stratagem", server::trigger_scan)
         .add_plugin("stream_fidlists_stratagem", server::stream_fidlists)

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -1,0 +1,5 @@
+use crate::agent_error::ImlAgentError;
+
+pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
+    Ok(false)
+}

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -10,21 +10,16 @@ pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let mut modules = stdout.lines().into_iter().filter_map(|m| {
-            println!("{:?}", m);
             let mut fields = m.split(' ').filter(|s| *s != "");
             let (name, _, refcount) = (fields.next(), fields.next(), fields.next());
-            println!("{:?} {:?}", name, refcount);
-            if let (Some(name), Some(refcount)) = (name, refcount) {
-                if let Ok(refcount) = refcount.parse::<u32>() {
-                    dbg!(Some((name, refcount)))
-                } else {
-                    dbg!(None)
-                }
+            let refcount = refcount.map(|x| x.parse::<u32>());
+            if let (Some(name), Some(Ok(refcount))) = (name, refcount) {
+                Some((name, refcount))
             } else {
-                dbg!(None)
+                None
             }
         });
-        println!("{:#?}", modules);
+
         let module = modules.find(|(m, refcount)| *m == module && *refcount > 0);
 
         if module.is_some() {

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -9,17 +9,15 @@ pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let mut modules = stdout.lines().into_iter().filter_map(|m| {
+        let module = stdout.lines().into_iter().find(|m| {
             let mut fields = m.split(' ').filter(|s| *s != "");
             let name = fields.next();
             if let Some(name) = name {
-                Some(name)
+                name == module
             } else {
-                None
+                false
             }
         });
-
-        let module = modules.find(|m| *m == module);
 
         if module.is_some() {
             Ok(true)

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -2,21 +2,17 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::{agent_error::ImlAgentError, cmd::cmd_output};
+use crate::{agent_error::ImlAgentError, cmd::cmd_output_success};
 
 pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
-    let output = cmd_output("lsmod", vec![]).await?;
+    let output = cmd_output_success("lsmod", vec![]).await?;
 
-    if output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let module = stdout.lines().into_iter().find(|m| {
-            let mut fields = m.split(' ').filter(|s| *s != "");
-            let name = fields.next();
-            name == Some(&module)
-        });
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let module = stdout.lines().into_iter().find(|m| {
+        let mut fields = m.split(' ').filter(|s| *s != "");
+        let name = fields.next();
+        name == Some(&module)
+    });
 
-        Ok(module.is_some())
-    } else {
-        Err(ImlAgentError::CmdOutputError(output))
-    }
+    Ok(module.is_some())
 }

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -12,11 +12,7 @@ pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
         let module = stdout.lines().into_iter().find(|m| {
             let mut fields = m.split(' ').filter(|s| *s != "");
             let name = fields.next();
-            if let Some(name) = name {
-                name == module
-            } else {
-                false
-            }
+            name == Some(&module)
         });
 
         Ok(module.is_some())

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -1,5 +1,40 @@
-use crate::agent_error::ImlAgentError;
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{agent_error::ImlAgentError, cmd::cmd_output};
 
 pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
-    Ok(false)
+    let output = cmd_output("lsmod", vec![]).await?;
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let lines: Vec<_> = stdout.lines().collect();
+        println!("{:#?}", lines);
+        let mut modules = lines.into_iter().filter_map(|m| {
+            println!("{:?}", m);
+            let mut fields = m.split(' ').filter(|s| *s != "");
+            let (name, _, refcount) = (fields.next(), fields.next(), fields.next());
+            println!("{:?} {:?}", name, refcount);
+            if let (Some(name), Some(refcount)) = (name, refcount) {
+                if let Ok(refcount) = refcount.parse::<u32>() {
+                    dbg!(Some((name, refcount)))
+                } else {
+                    dbg!(None)
+                }
+            } else {
+                dbg!(None)
+            }
+        });
+        println!("{:#?}", modules);
+        let module = modules.find(|(m, refcount)| *m == module && *refcount > 0);
+
+        if module.is_some() {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    } else {
+        Err(ImlAgentError::CmdOutputError(output))
+    }
 }

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -9,9 +9,7 @@ pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
 
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let lines: Vec<_> = stdout.lines().collect();
-        println!("{:#?}", lines);
-        let mut modules = lines.into_iter().filter_map(|m| {
+        let mut modules = stdout.lines().into_iter().filter_map(|m| {
             println!("{:?}", m);
             let mut fields = m.split(' ').filter(|s| *s != "");
             let (name, _, refcount) = (fields.next(), fields.next(), fields.next());

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -19,11 +19,7 @@ pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
             }
         });
 
-        if module.is_some() {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        Ok(module.is_some())
     } else {
         Err(ImlAgentError::CmdOutputError(output))
     }

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -11,16 +11,15 @@ pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let mut modules = stdout.lines().into_iter().filter_map(|m| {
             let mut fields = m.split(' ').filter(|s| *s != "");
-            let (name, _, refcount) = (fields.next(), fields.next(), fields.next());
-            let refcount = refcount.map(|x| x.parse::<u32>());
-            if let (Some(name), Some(Ok(refcount))) = (name, refcount) {
-                Some((name, refcount))
+            let name = fields.next();
+            if let Some(name) = name {
+                Some(name)
             } else {
                 None
             }
         });
 
-        let module = modules.find(|(m, refcount)| *m == module && *refcount > 0);
+        let module = modules.find(|m| *m == module);
 
         if module.is_some() {
             Ok(true)

--- a/iml-agent/src/action_plugins/mod.rs
+++ b/iml-agent/src/action_plugins/mod.rs
@@ -12,5 +12,4 @@ pub mod ntp;
 pub mod ostpool;
 pub mod package_installed;
 pub mod stratagem;
-
 pub use action_plugin::create_registry;

--- a/iml-agent/src/action_plugins/mod.rs
+++ b/iml-agent/src/action_plugins/mod.rs
@@ -6,9 +6,11 @@ pub mod action_plugin;
 pub mod check_ha;
 pub mod check_kernel;
 pub mod check_stonith;
+pub mod kernel_module;
 pub mod lctl;
 pub mod ntp;
 pub mod ostpool;
 pub mod package_installed;
 pub mod stratagem;
+
 pub use action_plugin::create_registry;

--- a/iml-agent/src/cli.rs
+++ b/iml-agent/src/cli.rs
@@ -7,7 +7,7 @@ use iml_agent::action_plugins::stratagem::{
     server::{generate_cooked_config, trigger_scan, Counter, StratagemCounters},
 };
 use iml_agent::action_plugins::{
-    check_ha, check_kernel, check_stonith, ostpool, package_installed,
+    check_ha, check_kernel, check_stonith, kernel_module, ostpool, package_installed,
 };
 use liblustreapi as llapi;
 use prettytable::{cell, row, Table};
@@ -211,6 +211,9 @@ pub enum App {
     #[structopt(name = "get_kernel")]
     /// Get latest kernel which supports listed modules
     GetKernel { modules: Vec<String> },
+
+    #[structopt(name = "kernel_module")]
+    KernelModule { module: String },
 }
 
 fn input_to_iter(input: Option<String>, fidlist: Vec<String>) -> Box<dyn Iterator<Item = String>> {
@@ -449,6 +452,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 exit(exitcode::SOFTWARE);
             }
         }
+        App::KernelModule { module } => match kernel_module::loaded(module).await {
+            Ok(b) => {
+                println!("{}", if b { "Loaded" } else { "Not Loaded" });
+            }
+            Err(e) => {
+                eprintln!("{}", e);
+                exit(exitcode::SOFTWARE);
+            }
+        },
     };
 
     Ok(())


### PR DESCRIPTION
This is another shot at point 3 of https://github.com/whamcloud/integrated-manager-for-lustre/issues/1187#issuecomment-559830336

Contrary to https://github.com/whamcloud/integrated-manager-for-lustre/pull/1371 this doesn't bind to native libraries and parses output of `lsmod`.