### PR TITLE
Create `create_lpurge_conf` action plugin

### DIFF
--- a/iml-agent/src/action_plugins/action_plugin.rs
+++ b/iml-agent/src/action_plugins/action_plugin.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     action_plugins::{
-        check_ha, check_kernel, check_stonith, kernel_module, lctl, ltuer,
+        check_ha, check_kernel, check_stonith, kernel_module, lctl, lpurge, ltuer,
         ntp::action_configure,
         ostpool, package,
         stratagem::{action_purge, action_warning, server},
@@ -41,6 +41,7 @@ pub fn create_registry() -> action_plugins::Actions {
         .add_plugin("ostpool_destroy", ostpool::action_pool_destroy)
         .add_plugin("ostpool_add", ostpool::action_pool_add)
         .add_plugin("ostpool_remove", ostpool::action_pool_remove)
+        .add_plugin("create_lpurge_conf", lpurge::create_lpurge_conf)
         .add_plugin(
             "configure_ntp",
             action_configure::update_and_write_new_config,

--- a/iml-agent/src/action_plugins/lpurge.rs
+++ b/iml-agent/src/action_plugins/lpurge.rs
@@ -1,0 +1,90 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::agent_error::ImlAgentError;
+use futures::future::TryFutureExt;
+use std::fmt;
+use std::path::Path;
+use tokio::fs;
+
+#[derive(serde::Deserialize, structopt::StructOpt, Debug)]
+pub struct Config {
+    #[structopt(long)]
+    /// Filesystem name
+    fs: String,
+    #[structopt(long)]
+    /// Object Storage Target name
+    ost: String,
+    #[structopt(long)]
+    /// OST pool name
+    pool: String,
+    #[structopt(long)]
+    freelo: u8,
+    #[structopt(long)]
+    freehi: u8,
+}
+
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "\
+             device={fs}-{ost}\n\
+             dryrun=true\n\
+             freehi={freehi}\n\
+             freelo={freelo}\n\
+             listen_socket=/run/lpurge-{fs}-{ost}-{pool}.sock\n\
+             max_jobs=0\n\
+             pool={fs}.{pool}\n\
+             ",
+            freehi = self.freehi,
+            freelo = self.freelo,
+            fs = self.fs,
+            ost = self.ost,
+            pool = self.pool,
+        )
+    }
+}
+
+pub async fn create_lpurge_conf(c: Config) -> Result<(), ImlAgentError> {
+    write("/etc/lpurge", &c).err_into().await
+}
+
+async fn write<P: AsRef<Path>>(dir: P, c: &Config) -> std::io::Result<()> {
+    fs::create_dir_all(&dir).await?;
+
+    let file = dir.as_ref().join(format!("{}.conf", c.ost));
+    let cnt = format!("{}", c);
+    fs::write(file, cnt.as_bytes()).await
+}
+
+#[cfg(test)]
+mod lpurge_conf_tests {
+    use super::*;
+    use insta::assert_display_snapshot;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn works() {
+        let cfg = Config {
+            fs: "lima".to_string(),
+            pool: "santiago".to_string(),
+            ost: "montevideo".to_string(),
+            freehi: 123,
+            freelo: 60,
+        };
+
+        let dir = tempdir().expect("could not create tmpdir");
+        let expected_file = dir.path().join("montevideo.conf");
+
+        write(&dir, &cfg).await.expect("could not write");
+
+        let cnt = String::from_utf8(
+            std::fs::read(&expected_file).expect(expected_file.to_str().unwrap()),
+        )
+        .unwrap();
+
+        assert_display_snapshot!(cnt);
+    }
+}

--- a/iml-agent/src/action_plugins/mod.rs
+++ b/iml-agent/src/action_plugins/mod.rs
@@ -8,6 +8,7 @@ pub mod check_kernel;
 pub mod check_stonith;
 pub mod kernel_module;
 pub mod lctl;
+pub mod lpurge;
 pub mod ltuer;
 pub mod ntp;
 pub mod ostpool;

--- a/iml-agent/src/action_plugins/snapshots/lpurge_conf_tests__works.snap
+++ b/iml-agent/src/action_plugins/snapshots/lpurge_conf_tests__works.snap
@@ -1,0 +1,12 @@
+---
+source: iml-agent/src/action_plugins/lpurge.rs
+expression: cnt
+---
+device=lima-montevideo
+dryrun=true
+freehi=123
+freelo=60
+listen_socket=/run/lpurge-lima-montevideo-santiago.sock
+max_jobs=0
+pool=lima.santiago
+

--- a/iml-agent/src/cli.rs
+++ b/iml-agent/src/cli.rs
@@ -7,7 +7,7 @@ use iml_agent::action_plugins::stratagem::{
     server::{generate_cooked_config, trigger_scan, Counter, StratagemCounters},
 };
 use iml_agent::action_plugins::{
-    check_ha, check_kernel, check_stonith, kernel_module, ltuer, ostpool, package,
+    check_ha, check_kernel, check_stonith, kernel_module, lpurge, ltuer, ostpool, package,
 };
 use liblustreapi as llapi;
 use prettytable::{cell, row, Table};
@@ -243,6 +243,13 @@ pub enum App {
 
     #[structopt(name = "kernel_module")]
     KernelModule { module: String },
+
+    #[structopt(name = "lpurge")]
+    /// Write lpurge configuration file
+    LPurge {
+        #[structopt(flatten)]
+        c: lpurge::Config,
+    },
 }
 
 fn input_to_iter(input: Option<String>, fidlist: Vec<String>) -> Box<dyn Iterator<Item = String>> {
@@ -511,6 +518,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 exit(exitcode::SOFTWARE);
             }
         },
+        App::LPurge { c } => {
+            if let Err(e) = lpurge::create_lpurge_conf(c).await {
+                eprintln!("{}", e);
+                exit(exitcode::SOFTWARE);
+            }
+        }
     };
 
     Ok(())


### PR DESCRIPTION
Fixes #1381 
```
$ ../target/debug/iml-agent lpurge --help
iml-agent-lpurge 0.1.0
IML Team <iml@whamcloud.com>
Write lpurge configuration file

USAGE:
    iml-agent lpurge --freehi <freehi> --freelo <freelo> --fs <fs> --ost <ost> --pool <pool>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --freehi <freehi>    
        --freelo <freelo>    
        --fs <fs>            Filesystem name
        --ost <ost>          Object Storage Target name
        --pool <pool>        OST pool name
```
```
$ ../target/debug/iml-agent lpurge --freehi 23 --freelo 56 --fs foo --ost bar --pool xxx
Permission denied (os error 13)
$ sudo ../target/debug/iml-agent lpurge --freehi 23 --freelo 56 --fs foo --ost bar --pool xxx
$ cat /etc/lpurge/bar.conf 
device=foo-bar
dryrun=true
freehi=23
freelo=56
listen_socket=/run/lpurge-foo-bar-xxx.sock
max_jobs=0
pool=foo.xxx
```