### PR TITLE
Add edition to rustfmt.toml

### DIFF
--- a/iml-gui/crate/rustfmt.toml
+++ b/iml-gui/crate/rustfmt.toml
@@ -1,5 +1,6 @@
 # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
 
+edition = "2018"
 newline_style = "Unix"
 use_field_init_shorthand = true
 use_try_shorthand = true


### PR DESCRIPTION
This is to make rustfmt understand async/.await (and other modern things) when running in Vim with rust.vim. Ref.: https://github.com/rust-lang/rust.vim/issues/368