### PR TITLE
Fix dependencies of subcrates

### DIFF
--- a/iml-agent/Cargo.toml
+++ b/iml-agent/Cargo.toml
@@ -25,7 +25,7 @@ http = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = "0.2"
-tokio = { version = "0.2.4", features = ["process"] }
+tokio = { version = "0.2.4", features = ["fs", "process", "macros", "net"] }
 tracing = "0.1"
 tracing-subscriber = "0.1"
 native-tls = "0.2"

--- a/iml-fs/Cargo.toml
+++ b/iml-fs/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-tokio = "0.2.4"
-tokio-util = "0.2"
+tokio = { version = "0.2.4", features = ["blocking", "fs", "io-util", "stream"] }
+tokio-util = { version = "0.2", features = ["codec"] }
 tempfile = "3.1"
 bytes = "0.5"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
 tempdir = "0.3"
+tokio = { version = "0.2.4", features = ["macros"] }

--- a/iml-manager-cli/Cargo.toml
+++ b/iml-manager-cli/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1"
 spinners = "1.0.0"
 structopt = "0.2"
 termion = "1"
-tokio = "0.2.4"
+tokio = { version = "0.2.4", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = "0.1"
 number-formatter = { path = "../number-formatter", version = "0.1" }

--- a/iml-rabbit/Cargo.toml
+++ b/iml-rabbit/Cargo.toml
@@ -13,4 +13,5 @@ serde_json = "1"
 tracing = "0.1"
 
 [dev-dependencies]
-tokio = "0.2.4"
+tokio = { version = "0.2.4", features = ["macros"] }
+

--- a/iml-util/Cargo.toml
+++ b/iml-util/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3"
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
 serde = { version = "1", features = ['derive'] }
 serde_json = "1.0"
-tokio = "0.2.4"
+tokio = { version = "0.2.4", features = ["net", "stream"] }
 tracing = "0.1"
 
 [lib]


### PR DESCRIPTION
So that individual crates can be built.

I suppose that when building the entire workspace cargo chooses the most
wide set of features and use it to build all members. And thus some crates
are buildable by accident, but they should list their dependencies explicitly.

Signed-off-by: Igor Pashev <pashev.igor@gmail.com>