### PR TITLE
Remove Flatten Trait

### DIFF
--- a/iml-fs/src/lib.rs
+++ b/iml-fs/src/lib.rs
@@ -187,7 +187,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use futures::stream;
-    use std::{fs::File, io::Write as _};
+    use std::fs::File;
     use tempdir::TempDir;
     use tempfile::NamedTempFile;
 

--- a/iml-util/util.rs
+++ b/iml-util/util.rs
@@ -2,19 +2,6 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-pub trait Flatten<T> {
-    fn flatten(self) -> Option<T>;
-}
-
-/// Implement flatten for the `Option` type.
-/// See https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten
-/// for more information.
-impl<T> Flatten<T> for Option<Option<T>> {
-    fn flatten(self) -> Option<T> {
-        self.unwrap_or(None)
-    }
-}
-
 pub trait Pick<A, B> {
     fn fst(self) -> A;
     fn snd(self) -> B;
@@ -208,34 +195,5 @@ pub mod action_plugins {
         pub fn get(&self, name: &ActionName) -> Option<&Callback> {
             self.0.get(name)
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_option_of_some() {
-        let x = Some(Some(7));
-        assert_eq!(x.flatten(), Some(7));
-    }
-
-    #[test]
-    fn test_option_of_none() {
-        let x: Option<Option<i32>> = Some(None);
-        assert_eq!(x.flatten(), None);
-    }
-
-    #[test]
-    fn test_option_of_option_of_some() {
-        let x = Some(Some(Some(7)));
-        assert_eq!(x.flatten().flatten(), Some(7));
-    }
-
-    #[test]
-    fn test_option_of_option_of_none() {
-        let x: Option<Option<Option<u32>>> = Some(Some(None));
-        assert_eq!(x.flatten().flatten(), None);
     }
 }


### PR DESCRIPTION
`Option::flatten` is now stable on Rust 1.40. We can remove our custom
trait for it.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>