### PR TITLE
Flush after write-all in mailbox

### DIFF
--- a/iml-mailbox/src/lib.rs
+++ b/iml-mailbox/src/lib.rs
@@ -105,6 +105,8 @@ pub async fn ingest_data(
         file.write_all(line.as_bytes()).await?;
     }
 
+    file.flush().await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #1409

Call
https://docs.rs/tokio/0.2.6/tokio/io/trait.AsyncWriteExt.html#method.flush
after `write_all` which apparently is required to ensure all bytes have
been written to the file.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>