### PR TITLE
Fix Django warnings

### DIFF
--- a/chroma_api/alert.py
+++ b/chroma_api/alert.py
@@ -53,7 +53,7 @@ class AlertSubscriptionAuthorization(PatchedDjangoAuthorization):
         if request.method is None:
             # Internal request, it's all good.
             return object_list
-        elif not request.user.is_authenticated():
+        elif not request.user.is_authenticated:
             # Nothing for Anonymous
             return object_list.none()
         elif "superusers" in [g.name for g in request.user.groups.all()]:
@@ -189,7 +189,7 @@ class AlertResource(SeverityResource):
         ]
 
     def dismiss_all(self, request, **kwargs):
-        if (request.method != "PUT") or (not request.user.is_authenticated()):
+        if (request.method != "PUT") or (not request.user.is_authenticated):
             return http.HttpUnauthorized()
 
         AlertState.objects.filter(dismissed=False).exclude(active=True, severity__in=[40, 30]).update(dismissed=True)

--- a/chroma_api/authentication.py
+++ b/chroma_api/authentication.py
@@ -72,10 +72,10 @@ class AnonymousAuthentication(CsrfAuthentication):
         if not super(AnonymousAuthentication, self).is_authenticated(request, object):
             return False
 
-        return settings.ALLOW_ANONYMOUS_READ or request.user.is_authenticated()
+        return settings.ALLOW_ANONYMOUS_READ or request.user.is_authenticated
 
     def get_identifier(self, request):
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             return request.user.username
         else:
             return "Anonymous user"

--- a/chroma_api/command.py
+++ b/chroma_api/command.py
@@ -105,7 +105,7 @@ class CommandResource(ChromaModelResource):
         ]
 
     def dismiss_all(self, request, **kwargs):
-        if (request.method != "PUT") or (not request.user.is_authenticated()):
+        if (request.method != "PUT") or (not request.user.is_authenticated):
             return http.HttpUnauthorized()
 
         Command.objects.filter(dismissed=False, complete=True).update(dismissed=True)

--- a/chroma_api/log.py
+++ b/chroma_api/log.py
@@ -24,7 +24,7 @@ class LogAuthorization(PatchedDjangoAuthorization):
     def read_list(self, object_list, bundle):
         request = bundle.request
         if (
-            request.user.is_authenticated()
+            request.user.is_authenticated
             and request.user.groups.filter(name__in=["filesystem_administrators", "superusers"]).exists()
         ):
             return object_list

--- a/chroma_api/session.py
+++ b/chroma_api/session.py
@@ -131,7 +131,7 @@ class SessionResource(Resource):
         request.session.modified = True
 
         user = request.user
-        if not user.is_authenticated():
+        if not user.is_authenticated:
             # Anonymous user
             user = None
         bundle = self.build_bundle(obj=Session(user), request=request)
@@ -176,7 +176,7 @@ class AuthResource(Resource):
         django.middleware.csrf.get_token(request)
 
         user = request.user
-        if not user.is_authenticated():
+        if not user.is_authenticated:
             error = {"__all__": "Authentication Failed."}
             resp = self.create_response(request, error, response_class=http.HttpUnauthorized)
             raise ImmediateHttpResponse(response=resp)

--- a/chroma_api/user.py
+++ b/chroma_api/user.py
@@ -39,7 +39,7 @@ class UserAuthorization(PatchedDjangoAuthorization):
             # internal request being done by Resource.get_via_uri()
             # and is therefore safe.
             return object_list
-        elif not request.user.is_authenticated():
+        elif not request.user.is_authenticated:
             # Anonymous sees nothing
             return object_list.none()
         elif request.user.has_perm("add_user"):


### PR DESCRIPTION
```
/root/iml/chroma_api/session.py:134: RemovedInDjango20Warning: Using user.is_authenticated() and user.is_anonymous() as a method is deprecated. Remove the parentheses to use it as an attribute
```

Signed-off-by: Michael Pankov <work@michaelpankov.com>