### PR TITLE
Move Vagrantfiles repo into IML repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ copr-local.mk
 target
 **/*.rs.bk
 .cargo
-.vagrant/rgloader/loader.rb
+**/.vagrant

--- a/base.dockerfile.dockerignore
+++ b/base.dockerfile.dockerignore
@@ -11,6 +11,7 @@
 benchmark
 example_storage_plugin_package
 tests
+vagrant/
 Vagrantfile
 vagrant-virsh
 requirements.dev

--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,6 @@
+.vagrant
+hosts
+id_rsa*
+*.box
+packer_cache
+*~

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,105 @@
+# Vagrantfiles
+
+## Setup IML with Vagrant and VirtualBox
+
+The IML Team typically uses [Vagrant](https://www.vagrantup.com) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads) for day to day development tasks. The following guide will provide an overview of how to setup a development environment from scratch.
+
+1. Clone the [Integrated Manager For Lustre repo](https://github.com/whamcloud/integrated-manager-for-lustre) from Github:
+
+   ```sh
+   git clone https://github.com/whamcloud/Vagrantfiles.git
+   ```
+
+1. Navigate to the `integrated-manager-for-lustre/vagrant` directory
+
+### MacOS
+
+1. Install Homebrew
+
+   [Homebrew](https://brew.sh/) provides a package manager for macos. We will use this to install dependencies in the following steps. See the [Homebrew](https://brew.sh) website for installation instructions.
+
+1. Install Vagrant and VirtualBox
+
+   Using the `brew cask` command:
+
+   ```sh
+   brew cask install vagrant virtualbox
+   ```
+
+1. Create the default hostonlyif needed by the cluster:
+
+   ```sh
+   VBoxManage hostonlyif create
+   ```
+
+1. Bring up the cluster (manager, 2 mds, 2 oss, 2 client nodes)
+
+   ```sh
+   vagrant up
+   ```
+
+1. You may want the latest packages from upstream repos. If so, run the following provisioner and restart the cluster
+
+   ```sh
+   vagrant provision --provision-with=yum-update
+   vagrant reload
+   ```
+
+1. Install the latest IML from [copr-devel](https://copr.fedorainfracloud.org/coprs/managerforlustre/manager-for-lustre-devel/)
+
+   ```sh
+   vagrant provision --provision-with=install-iml-devel
+   ```
+
+At this point you should be able to access the IML GUI on your host at https://localhost:8443
+
+From here you can decide what type of setup to run.
+
+- Monitored Ldiskfs:
+
+  ```sh
+  vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-network,create-ldiskfs-fs,create-ldiskfs-fs2,mount-ldiskfs-fs,mount-ldiskfs-fs2
+  ```
+
+- Monitored ZFS:
+
+  ```sh
+  vagrant provision --provision-with=install-zfs-no-iml,configure-lustre-network,create-pools,zfs-params,create-zfs-fs
+  ```
+
+- Managed Mode:
+
+  1. ```sh
+     vagrant provision --provision-with=deploy-managed-hosts adm
+     ```
+
+  1. https://whamcloud.github.io/Online-Help/docs/Contributor_Docs/cd_Managed_ZFS.html
+
+### Windows
+
+This is tested on Windows 10 1909.
+
+**Ensure your Windows user home folder doesn't contain non-ASCII chracters.** Common case would be when user name you entered when configuring Windows for first use, was Cyrillic. Windows and apps still don't properly support it, and there are issues with encoding in Ruby, Vagrant and shell scripts in case your home is something like `C:\Users\Михаил`.
+
+1. [Install Chocolatey](https://chocolatey.org/install#individual).
+   If it fails with errors suggesting update of .NET Framework, go to Windows Update and get all the latest updates.
+
+1. Install Vagrant and VirtualBox using Chocolatey:
+
+```sh
+choco install vagrant
+choco upgrade virtualbox --version=6.0.6
+```
+
+**Warning**: there's an unresolved bug which causes guest CentOS 7 to kernel panic in VirtualBox 6.0.14 on modern Windows 10. Hence the requirement of VirtualBox 6.0.6.
+[Details](https://forums.virtualbox.org/viewtopic.php?f=3&t=94358&sid=121c40fa78668a52835a3ce56b63f389&start=15#p457443).
+
+**Further notes**: VirtualBox Extensions 6.0.6 can't be built for CentOS 7. [Details](https://forums.virtualbox.org/viewtopic.php?f=3&t=94777). It's fixed even further upstream (maybe 6.0.14 or later). This means you won't be able to use CentOS in VirtualBox as a development environment (screen resolution, shared folders and other features don't work). Workaround is to use VMWare Player, which is also available on Chocolatey.
+
+1. Bring up the cluster with
+
+```sh
+vagrant up
+```
+
+and continue as with MacOS.

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,855 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'open3'
+require 'fileutils'
+
+# Create a set of /24 networks under a single /16 subnet range
+SUBNET_PREFIX = '10.73'.freeze
+
+# Management network for admin comms
+MGMT_NET_PFX = "#{SUBNET_PREFIX}.10".freeze
+
+# Lustre / HPC network
+LNET_PFX = "#{SUBNET_PREFIX}.20".freeze
+
+ISCI_IP = "#{SUBNET_PREFIX}.40.10".freeze
+
+ISCI_IP2 = "#{SUBNET_PREFIX}.50.10".freeze
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'centos/7'
+
+  config.vm.provider 'virtualbox' do |vbx|
+    vbx.linked_clone = true
+    vbx.memory = 1024
+    vbx.cpus = 4
+    vbx.customize ['modifyvm', :id, '--audio', 'none']
+  end
+
+  # Create a basic hosts file for the VMs.
+  open('hosts', 'w') do |f|
+    f.puts <<-__EOF
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+#{MGMT_NET_PFX}.9 b.local b
+#{MGMT_NET_PFX}.10 adm.local adm
+#{MGMT_NET_PFX}.11 mds1.local mds1
+#{MGMT_NET_PFX}.12 mds2.local mds2
+#{MGMT_NET_PFX}.21 oss1.local oss1
+#{MGMT_NET_PFX}.22 oss2.local oss2
+    __EOF
+    (1..8).each do |cidx|
+      f.puts "#{MGMT_NET_PFX}.3#{cidx} c#{cidx}.local c#{cidx}\n"
+    end
+  end
+
+  provision_yum_updates config
+
+  use_vault_7_6_1810 config
+
+  config.vm.provision 'shell', inline: 'cp -f /vagrant/hosts /etc/hosts'
+
+  config.vm.provision 'shell', path: './scripts/disable_selinux.sh'
+
+  system("ssh-keygen -t rsa -m PEM -N '' -f id_rsa") unless File.exist?('id_rsa')
+
+  config.vm.provision 'ssh', type: 'shell', path: './scripts/key_config.sh'
+
+  config.vm.provision 'deps', type: 'shell', inline: <<-SHELL
+    yum install -y epel-release
+    yum install -y jq htop vim
+  SHELL
+
+  config.vm.define 'iscsi' do |iscsi|
+    iscsi.vm.hostname = 'iscsi.local'
+
+    iscsi.vm.provider 'virtualbox' do |vbx|
+      vbx.memory = 512
+      vbx.cpus = 2
+    end
+
+    provision_iscsi_net iscsi, '10'
+
+    iscsi.vm.provider 'virtualbox' do |vbx|
+      name = get_vm_name('iscsi')
+      create_iscsi_disks(vbx, name)
+    end
+
+    iscsi.vm.provision 'bootstrap',
+                       type: 'shell',
+                       path: './scripts/bootstrap_iscsi.sh',
+                       args: [ISCI_IP, ISCI_IP2]
+  end
+
+  #
+  # Create an admin server for the cluster
+  #
+  config.vm.define 'adm', primary: true do |adm|
+    adm.vm.hostname = 'adm.local'
+
+    adm.vm.network 'forwarded_port', guest: 443, host: 8443
+
+    # Admin / management network
+    provision_mgmt_net adm, '10'
+
+    provision_fence_agents adm
+
+      adm.vm.synced_folder '../',
+                           '/integrated-manager-for-lustre/',
+                           type: 'rsync',
+                           rsync__exclude: [
+                              '.cargo/',
+                              '.git/',
+                              'target/',
+                              'iml-gui/crate/.cargo/',
+                              'iml-gui/crate/target/',
+                              'iml-gui/node_modules/',
+                              'iml-wasm-components/.cargo/',
+                              'iml-wasm-components/target/',
+                              'vagrant/'
+                           ]
+
+    # Install IML onto the admin node
+    # Using the mfl devel repo
+    adm.vm.provision 'install-iml-devel',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/install_iml.sh',
+                     args: 'https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/5.next/chroma_support.repo'
+
+    # Install IML 5.0 onto the admin node
+    # Using the mfl 5.0 repo
+    adm.vm.provision 'install-iml-5',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/install_iml.sh',
+                     args: 'https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/v5.0.0/chroma_support.repo'
+
+    # Install IML 5.1 onto the admin node
+    # Using the mfl 5.1 repo
+    adm.vm.provision 'install-iml-5.1',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/install_iml.sh',
+                     args: 'https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/v5.1.0/chroma_support.repo'
+
+    # Install IML 4.0.10.x onto the admin node
+    # Using the mfl 4.0.10 copr repo
+    adm.vm.provision 'install-iml-4.0.10',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/install_iml_tar.sh',
+                     args: '4.0.10.2'
+
+    # Install IML onto the admin node
+    # This requires you have the IML source tree available at
+    # /integrated-manager-for-lustre
+    adm.vm.provision 'install-iml-local',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/install_iml_local.sh'
+
+    adm.vm.provision 'deploy-managed-hosts',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/deploy_hosts.sh',
+                     args: 'base_managed_patchless'
+
+    adm.vm.provision 'load-diagnostics-db',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/load-diagnostics-db.sh'
+  end
+
+  #
+  # Create the metadata servers (HA pair)
+  #
+  (1..2).each do |i|
+    config.vm.define "mds#{i}" do |mds|
+      mds.vm.hostname = "mds#{i}.local"
+
+      mds.vm.provider 'virtualbox' do |vbx|
+        vbx.name = "mds#{i}"
+      end
+
+      provision_lnet_net mds, "1#{i}"
+
+      # Admin / management network
+      provision_mgmt_net mds, "1#{i}"
+
+      provision_iscsi_net mds, "1#{i}"
+
+      # Private network to simulate crossover.
+      # Used exclusively as additional cluster network
+      mds.vm.network 'private_network',
+                     ip: "#{SUBNET_PREFIX}.230.1#{i}",
+                     netmask: '255.255.255.0',
+                     auto_config: false,
+                     virtualbox__intnet: 'crossover-net-mds'
+
+      provision_iscsi_client mds, 'mds', i
+
+      provision_mpath mds
+
+      provision_fence_agents mds
+
+      cleanup_storage_server mds
+
+      install_lustre_zfs mds
+
+      install_lustre_ldiskfs mds
+
+      install_zfs_no_iml mds
+
+      install_ldiskfs_no_iml mds
+
+      configure_lustre_network mds
+
+      configure_docker_network mds
+
+      if i == 1
+        mds.vm.provision 'create-pools',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           genhostid
+                           zpool create mgt -o multihost=on /dev/mapper/mpatha
+                           zpool create mdt0 -o multihost=on /dev/mapper/mpathb
+                         SHELL
+
+        mds.vm.provision 'import-pools',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           zpool import mgt
+                           zpool import mdt0
+                         SHELL
+
+        mds.vm.provision 'zfs-params',
+                         type: 'shell',
+                         run: 'never',
+                         path: './scripts/zfs_params.sh'
+
+        mds.vm.provision 'create-zfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           mkfs.lustre --failover 10.73.20.12@tcp --mgs --backfstype=zfs mgt/mgt
+                           mkdir -p /lustre/zfsmo/mgs
+                           mount -t lustre mgt/mgt /lustre/zfsmo/mgs
+
+                           mkfs.lustre --reformat --failover 10.73.20.12@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=0 --mgsnode=10.73.20.11@tcp mdt0/mdt0
+                           mkdir -p /lustre/zfsmo/mdt0
+                           mount -t lustre mdt0/mdt0 /lustre/zfsmo/mdt0
+                         SHELL
+
+        mds.vm.provision 'create-ldiskfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                              mkfs.lustre --mgs --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp /dev/mapper/mpatha
+                              mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=0 --mgsnode=10.73.20.11@tcp --fsname=fs /dev/mapper/mpathb
+                         SHELL
+
+        mds.vm.provision 'mount-ldiskfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           mkdir -p /mnt/mgs
+                           mkdir -p /mnt/mdt0
+                           mount -t lustre /dev/mapper/mpatha /mnt/mgs
+                           mount -t lustre /dev/mapper/mpathb /mnt/mdt0
+                         SHELL
+
+      else
+        mds.vm.provision 'create-pools',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           genhostid
+                           zpool create mdt1 -o multihost=on /dev/mapper/mpathc
+                         SHELL
+
+      mds.vm.provision 'import-pools',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           zpool import mdt1
+                         SHELL
+
+        mds.vm.provision 'zfs-params',
+                         type: 'shell',
+                         run: 'never',
+                         path: './scripts/zfs_params.sh'
+
+        mds.vm.provision 'create-zfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           mkfs.lustre --failover 10.73.20.11@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=1 --mgsnode=10.73.20.11@tcp mdt1/mdt1
+                           mkdir -p /lustre/zfsmo/mdt1
+                           mount -t lustre mdt1/mdt1 /lustre/zfsmo/mdt1
+                         SHELL
+
+        mds.vm.provision 'create-ldiskfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                            mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=1 --mgsnode=10.73.20.11@tcp --fsname=fs /dev/mapper/mpathc
+                         SHELL
+
+        mds.vm.provision 'create-ldiskfs-fs2',
+                            type: 'shell',
+                            run: 'never',
+                            inline: <<-SHELL
+                              mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=0 --mgsnode=10.73.20.11@tcp --fsname=fs2 /dev/mapper/mpathd
+                            SHELL
+
+        mds.vm.provision 'mount-ldiskfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           mkdir -p /mnt/mdt1
+                           mount -t lustre /dev/mapper/mpathc /mnt/mdt1
+                         SHELL
+
+        mds.vm.provision 'mount-ldiskfs-fs2',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           mkdir -p /mnt/mdt2
+                           mount -t lustre /dev/mapper/mpathd /mnt/mdt2
+                         SHELL
+      end
+    end
+  end
+
+  #
+  # Create the object storage servers (OSS)
+  # Servers are configured in HA pairs
+  #
+  (1..2).each do |i|
+    config.vm.define "oss#{i}",
+                     autostart: i <= 2 do |oss|
+
+      oss.vm.hostname = "oss#{i}.local"
+
+      oss.vm.provider 'virtualbox' do |vbx|
+        vbx.name = "oss#{i}"
+      end
+
+      # Lustre / application network
+      provision_lnet_net oss, "2#{i}"
+
+      # Admin / management network
+      provision_mgmt_net oss, "2#{i}"
+
+      provision_iscsi_net oss, "2#{i}"
+
+      # Private network to simulate crossover.
+      # Used exclusively as additional cluster network
+      oss.vm.network 'private_network',
+                     ip: "#{SUBNET_PREFIX}.231.2#{i}",
+                     netmask: '255.255.255.0',
+                     auto_config: false,
+                     virtualbox__intnet: 'crossover-net-oss'
+
+      provision_iscsi_client oss, 'oss', i
+
+      provision_mpath oss
+
+      provision_fence_agents oss
+
+      cleanup_storage_server oss
+
+      install_lustre_zfs oss
+
+      install_lustre_ldiskfs oss
+
+      install_ldiskfs_no_iml oss
+
+      install_zfs_no_iml oss
+
+      configure_lustre_network oss
+
+      configure_docker_network oss
+
+      if i == 1
+        oss.vm.provision 'create-pools',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           genhostid
+                           zpool create ost0 -o multihost=on /dev/mapper/mpatha
+                           zpool create ost1 -o multihost=on /dev/mapper/mpathb
+                           zpool create ost2 -o multihost=on /dev/mapper/mpathc
+                           zpool create ost3 -o multihost=on /dev/mapper/mpathd
+                           zpool create ost4 -o multihost=on /dev/mapper/mpathe
+                           zpool create ost5 -o multihost=on /dev/mapper/mpathf
+                           zpool create ost6 -o multihost=on /dev/mapper/mpathg
+                           zpool create ost7 -o multihost=on /dev/mapper/mpathh
+                           zpool create ost8 -o multihost=on /dev/mapper/mpathi
+                           zpool create ost9 -o multihost=on /dev/mapper/mpathj
+                         SHELL
+
+        oss.vm.provision 'import-pools',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           zpool import ost0
+                           zpool import ost1
+                           zpool import ost2
+                           zpool import ost3
+                           zpool import ost4
+                           zpool import ost5
+                           zpool import ost6
+                           zpool import ost7
+                           zpool import ost8
+                           zpool import ost9
+                         SHELL
+
+        oss.vm.provision 'zfs-params',
+                         type: 'shell',
+                         run: 'never',
+                         path: './scripts/zfs_params.sh'
+
+        oss.vm.provision 'create-zfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=0 --mgsnode=10.73.20.11@tcp ost0/ost0
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=1 --mgsnode=10.73.20.11@tcp ost1/ost1
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=2 --mgsnode=10.73.20.11@tcp ost2/ost2
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=3 --mgsnode=10.73.20.11@tcp ost3/ost3
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=4 --mgsnode=10.73.20.11@tcp ost4/ost4
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=5 --mgsnode=10.73.20.11@tcp ost5/ost5
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=6 --mgsnode=10.73.20.11@tcp ost6/ost6
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=7 --mgsnode=10.73.20.11@tcp ost7/ost7
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=8 --mgsnode=10.73.20.11@tcp ost8/ost8
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=9 --mgsnode=10.73.20.11@tcp ost9/ost9
+                              mkdir -p /lustre/zfsmo/ost{0..9}
+                              mount -t lustre ost0/ost0 /lustre/zfsmo/ost0
+                              mount -t lustre ost1/ost1 /lustre/zfsmo/ost1
+                              mount -t lustre ost2/ost2 /lustre/zfsmo/ost2
+                              mount -t lustre ost3/ost3 /lustre/zfsmo/ost3
+                              mount -t lustre ost4/ost4 /lustre/zfsmo/ost4
+                              mount -t lustre ost5/ost5 /lustre/zfsmo/ost5
+                              mount -t lustre ost6/ost6 /lustre/zfsmo/ost6
+                              mount -t lustre ost7/ost7 /lustre/zfsmo/ost7
+                              mount -t lustre ost8/ost8 /lustre/zfsmo/ost8
+                              mount -t lustre ost9/ost9 /lustre/zfsmo/ost9
+                         SHELL
+
+        oss.vm.provision 'create-ldiskfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         path: 'scripts/create_ldiskfs_fs_osts.sh',
+                         args: ['a', 'e', 0, 'fs']
+
+        oss.vm.provision 'mount-ldiskfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                          mkdir -p /mnt/ost{0,1,2,3,4}
+                          mount -t lustre /dev/mapper/mpatha /mnt/ost0
+                          mount -t lustre /dev/mapper/mpathb /mnt/ost1
+                          mount -t lustre /dev/mapper/mpathc /mnt/ost2
+                          mount -t lustre /dev/mapper/mpathd /mnt/ost3
+                          mount -t lustre /dev/mapper/mpathe /mnt/ost4
+                         SHELL
+
+        oss.vm.provision 'create-ldiskfs-fs2',
+                         type: 'shell',
+                         run: 'never',
+                         path: 'scripts/create_ldiskfs_fs_osts.sh',
+                         args: ['f', 'j', 0, 'fs2']
+
+        oss.vm.provision 'mount-ldiskfs-fs2',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                          mkdir -p /mnt/ost2-{0,1,2,3,4}
+                          mount -t lustre /dev/mapper/mpathf /mnt/ost2-0
+                          mount -t lustre /dev/mapper/mpathg /mnt/ost2-1
+                          mount -t lustre /dev/mapper/mpathh /mnt/ost2-2
+                          mount -t lustre /dev/mapper/mpathi /mnt/ost2-3
+                          mount -t lustre /dev/mapper/mpathj /mnt/ost2-4
+                         SHELL
+
+      else
+        oss.vm.provision 'create-pools',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           genhostid
+                           zpool create ost10 -o multihost=on /dev/mapper/mpathk
+                           zpool create ost11 -o multihost=on /dev/mapper/mpathl
+                           zpool create ost12 -o multihost=on /dev/mapper/mpathm
+                           zpool create ost13 -o multihost=on /dev/mapper/mpathn
+                           zpool create ost14 -o multihost=on /dev/mapper/mpatho
+                           zpool create ost15 -o multihost=on /dev/mapper/mpathp
+                           zpool create ost16 -o multihost=on /dev/mapper/mpathq
+                           zpool create ost17 -o multihost=on /dev/mapper/mpathr
+                           zpool create ost18 -o multihost=on /dev/mapper/mpaths
+                           zpool create ost19 -o multihost=on /dev/mapper/mpatht
+                         SHELL
+
+        oss.vm.provision 'import-pools',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           zpool import ost10
+                           zpool import ost11
+                           zpool import ost12
+                           zpool import ost13
+                           zpool import ost14
+                           zpool import ost15
+                           zpool import ost16
+                           zpool import ost17
+                           zpool import ost18
+                           zpool import ost19
+                         SHELL
+
+        oss.vm.provision 'zfs-params',
+                         type: 'shell',
+                         run: 'never',
+                         path: './scripts/zfs_params.sh'
+
+        oss.vm.provision 'create-zfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=10 --mgsnode=10.73.20.11@tcp ost10/ost10
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=11 --mgsnode=10.73.20.11@tcp ost11/ost11
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=12 --mgsnode=10.73.20.11@tcp ost12/ost12
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=13 --mgsnode=10.73.20.11@tcp ost13/ost13
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=14 --mgsnode=10.73.20.11@tcp ost14/ost14
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=15 --mgsnode=10.73.20.11@tcp ost15/ost15
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=16 --mgsnode=10.73.20.11@tcp ost16/ost16
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=17 --mgsnode=10.73.20.11@tcp ost17/ost17
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=18 --mgsnode=10.73.20.11@tcp ost18/ost18
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=19 --mgsnode=10.73.20.11@tcp ost19/ost19
+                              mkdir -p /lustre/zfsmo/ost{10..19}
+                              mount -t lustre ost10/ost10 /lustre/zfsmo/ost10
+                              mount -t lustre ost11/ost11 /lustre/zfsmo/ost11
+                              mount -t lustre ost12/ost12 /lustre/zfsmo/ost12
+                              mount -t lustre ost13/ost13 /lustre/zfsmo/ost13
+                              mount -t lustre ost14/ost14 /lustre/zfsmo/ost14
+                              mount -t lustre ost15/ost15 /lustre/zfsmo/ost15
+                              mount -t lustre ost16/ost16 /lustre/zfsmo/ost16
+                              mount -t lustre ost17/ost17 /lustre/zfsmo/ost17
+                              mount -t lustre ost18/ost18 /lustre/zfsmo/ost18
+                              mount -t lustre ost19/ost19 /lustre/zfsmo/ost19
+                         SHELL
+
+        oss.vm.provision 'create-ldiskfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         path: 'scripts/create_ldiskfs_fs_osts.sh',
+                         args: ['k', 'o', 5, 'fs']
+
+        oss.vm.provision 'mount-ldiskfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                             mkdir -p /mnt/ost{5,6,7,8,9}
+                             mount -t lustre /dev/mapper/mpathk /mnt/ost5
+                             mount -t lustre /dev/mapper/mpathl /mnt/ost6
+                             mount -t lustre /dev/mapper/mpathm /mnt/ost7
+                             mount -t lustre /dev/mapper/mpathn /mnt/ost8
+                             mount -t lustre /dev/mapper/mpatho /mnt/ost9
+                         SHELL
+
+        oss.vm.provision 'create-ldiskfs-fs2',
+                         type: 'shell',
+                         run: 'never',
+                         path: 'scripts/create_ldiskfs_fs_osts.sh',
+                         args: ['p', 't', 5, 'fs2']
+
+        oss.vm.provision 'mount-ldiskfs-fs2',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                             mkdir -p /mnt/ost2-{5,6,7,8,9}
+                             mount -t lustre /dev/mapper/mpathp /mnt/ost2-5
+                             mount -t lustre /dev/mapper/mpathq /mnt/ost2-6
+                             mount -t lustre /dev/mapper/mpathr /mnt/ost2-7
+                             mount -t lustre /dev/mapper/mpaths /mnt/ost2-8
+                             mount -t lustre /dev/mapper/mpatht /mnt/ost2-9
+                         SHELL
+      end
+    end
+  end
+
+  # Create a set of compute nodes.
+  # By default, only 2 compute nodes are created.
+  # The configuration supports a maximum of 8 compute nodes.
+  (1..8).each do |i|
+    config.vm.define "c#{i}",
+                     autostart: i <= 2 do |c|
+      c.vm.hostname = "c#{i}.local"
+
+      # Admin / management network
+      provision_mgmt_net c, "3#{i}"
+
+      # Lustre / application network
+      provision_lnet_net c, "3#{i}"
+
+      c.vm.provision 'install-lustre-client',
+                     type: 'shell',
+                     run: 'never',
+                     inline: <<-SHELL
+                            yum-config-manager --add-repo https://downloads.whamcloud.com/public/lustre/lustre-2.12.3/el7/client/
+                            yum install -y --nogpgcheck lustre-client
+                     SHELL
+    end
+  end
+end
+
+def provision_iscsi_net(config, num)
+  config.vm.network 'private_network',
+                    ip: "#{SUBNET_PREFIX}.40.#{num}",
+                    netmask: '255.255.255.0',
+                    virtualbox__intnet: 'iscsi-net'
+
+  config.vm.network 'private_network',
+                    ip: "#{SUBNET_PREFIX}.50.#{num}",
+                    netmask: '255.255.255.0',
+                    virtualbox__intnet: 'iscsi-net'
+end
+
+def provision_lnet_net(config, num)
+  config.vm.network 'private_network',
+                    ip: "#{LNET_PFX}.#{num}",
+                    netmask: '255.255.255.0',
+                    virtualbox__intnet: 'lnet-net'
+end
+
+module OS
+  def OS.windows?
+    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RbConfig::CONFIG["host_os"]) != nil
+  end
+
+  def OS.mac?
+    (/darwin/ =~ RbConfig::CONFIG["host_os"]) != nil
+  end
+
+  def OS.unix?
+    !OS.windows?
+  end
+
+  def OS.linux?
+    OS.unix? and not OS.mac?
+  end
+end
+
+def provision_mgmt_net(config, num)
+  interface_name = if OS.windows? then 'VirtualBox Host-Only Ethernet Adapter' else 'vboxnet0' end
+  
+  config.vm.network 'private_network',
+                    ip: "#{MGMT_NET_PFX}.#{num}",
+                    netmask: '255.255.255.0',
+                    name: interface_name
+end
+
+def provision_mpath(config)
+  config.vm.provision 'mpath', type: 'shell', inline: <<-SHELL
+    yum -y install device-mapper-multipath
+    cp /usr/share/doc/device-mapper-multipath-*/multipath.conf /etc/multipath.conf
+    systemctl start multipathd.service
+    systemctl enable multipathd.service
+  SHELL
+end
+
+def provision_fence_agents(config)
+  config.vm.provision 'fence-agents', type: 'shell', inline: <<-SHELL
+    yum install -y epel-release
+    yum install -y yum-plugin-copr
+    yum -y copr enable managerforlustre/manager-for-lustre-devel
+    yum install -y fence-agents-vbox
+    yum -y copr disable managerforlustre/manager-for-lustre-devel
+  SHELL
+end
+
+def cleanup_storage_server(config)
+  config.vm.provision 'cleanup', type: 'shell', run: 'never', inline: <<-SHELL
+    yum autoremove -y chroma-agent
+    rm -rf /etc/iml
+    rm -rf /var/lib/{chroma,iml}
+    rm -rf /etc/yum.repos.d/Intel-Lustre-Agent.repo
+  SHELL
+end
+
+def provision_iscsi_client(config, name, idx)
+  config.vm.provision 'iscsi-client', type: 'shell', inline: <<-SHELL
+    yum -y install iscsi-initiator-utils lsscsi
+    echo "InitiatorName=iqn.2015-01.com.whamcloud:#{name}#{idx}" > /etc/iscsi/initiatorname.iscsi
+    iscsiadm --mode discoverydb --type sendtargets --portal #{ISCI_IP}:3260 --discover
+    iscsiadm --mode node --targetname iqn.2015-01.com.whamcloud.lu:#{name} --portal #{ISCI_IP}:3260 -o update -n node.startup -v automatic
+    iscsiadm --mode node --targetname iqn.2015-01.com.whamcloud.lu:#{name} --portal #{ISCI_IP}:3260 -o update -n node.conn[0].startup -v automatic
+    iscsiadm --mode node --targetname iqn.2015-01.com.whamcloud.lu:#{name} --portal #{ISCI_IP2}:3260 -o update -n node.startup -v automatic
+    iscsiadm --mode node --targetname iqn.2015-01.com.whamcloud.lu:#{name} --portal #{ISCI_IP2}:3260 -o update -n node.conn[0].startup -v automatic
+    systemctl start iscsi
+  SHELL
+end
+
+def configure_lustre_network(config)
+  config.vm.provision 'configure-lustre-network',
+                      type: 'shell',
+                      run: 'never',
+                      path: './scripts/configure_lustre_network.sh'
+end
+
+def install_lustre_zfs(config)
+  config.vm.provision 'install-lustre-zfs', type: 'shell', run: 'never', inline: <<-SHELL
+    yum clean all
+    yum install -y --nogpgcheck lustre-zfs
+    genhostid
+  SHELL
+end
+
+def install_lustre_ldiskfs(config)
+  config.vm.provision 'install-lustre-ldiskfs',
+                      type: 'shell',
+                      run: 'never',
+                      inline: 'yum install -y lustre-ldiskfs'
+end
+
+def install_ldiskfs_no_iml(config)
+  config.vm.provision 'install-ldiskfs-no-iml',
+                      type: 'shell',
+                      run: 'never',
+                      path: './scripts/install_ldiskfs_no_iml.sh'
+end
+
+def install_zfs_no_iml(config)
+  config.vm.provision 'install-zfs-no-iml',
+                      type: 'shell',
+                      run: 'never',
+                      path: './scripts/install_zfs_no_iml.sh'
+end
+
+def use_vault_7_6_1810(config)
+  config.vm.provision 'use-vault-7-6-1810',
+                      type: 'shell',
+                      run: 'never',
+                      path: './scripts/use_vault.sh',
+                      args: '7.6.1810'
+end
+
+def provision_yum_updates(config)
+  config.vm.provision 'yum-update',
+                     type: 'shell',
+                     run: 'never',
+                     inline: 'yum clean metadata; yum update -y'
+end
+
+def get_machine_folder()
+  out, err = Open3.capture2e('VBoxManage list systemproperties')
+  raise out unless err.exitstatus.zero?
+
+  out.split(/\n/)
+      .select { |x| x.start_with? 'Default machine folder:' }
+      .map { |x| x.split('Default machine folder:')[1].strip }
+      .first
+end
+
+def get_vm_name(id)
+  out, err = Open3.capture2e('VBoxManage list vms')
+  raise out unless err.exitstatus.zero?
+
+  path = path = File.dirname(__FILE__).split('/').last
+  name = out.split(/\n/)
+            .select { |x| x.start_with? "\"#{path}_#{id}" }
+            .map { |x| x.tr('"', '') }
+            .map { |x| x.split(' ')[0].strip }
+            .first
+
+  name
+end
+
+# Checks if a scsi controller exists.
+# This is used as a predicate to create controllers,
+# as vagrant does not provide this
+# functionality by default.
+def controller_exists(name, controller_name)
+  return false if name.nil?
+
+  out, err = Open3.capture2e("VBoxManage showvminfo #{name}")
+  raise out unless err.exitstatus.zero?
+
+  out.split(/\n/)
+     .select { |x| x.start_with? 'Storage Controller Name' }
+     .map { |x| x.split(':')[1].strip }
+     .any? { |x| x == controller_name }
+end
+
+# Creates a SATA Controller and attaches 10 disks to it
+def create_iscsi_disks(vbox, name)
+  unless controller_exists(name, 'SATA Controller')
+    vbox.customize ['storagectl', :id,
+                    '--name', 'SATA Controller',
+                    '--add', 'sata']
+  end
+
+  dir = "#{get_machine_folder()}/vdisks"
+  FileUtils.mkdir_p dir unless File.directory?(dir)
+
+  osts = (1..20).map { |x| ["OST#{x}", '5120'] }
+
+  [
+    %w[mgt 512],
+    %w[mdt1 5120],
+    %w[mdt2 5120],
+    %w[mdt3 5120],
+  ].concat(osts).each_with_index do |(name, size), i|
+    file_to_disk = "#{dir}/#{name}.vdi"
+    port = (i + 1).to_s
+
+    unless File.exist?(file_to_disk)
+      vbox.customize ['createmedium',
+                      'disk',
+                      '--filename',
+                      file_to_disk,
+                      '--size',
+                      size,
+                      '--format',
+                      'VDI',
+                      '--variant',
+                      'standard']
+    end
+
+    vbox.customize ['storageattach', :id,
+                    '--storagectl', 'SATA Controller',
+                    '--port', port,
+                    '--type', 'hdd',
+                    '--medium', file_to_disk,
+                    '--device', '0']
+
+    vbox.customize ['setextradata', :id,
+                    "VBoxInternal/Devices/ahci/0/Config/Port#{port}/SerialNumber",
+                    name.ljust(20, '0')]
+  end
+end
+
+def configure_docker_network(config)
+  config.trigger.before :provision, name: 'configure-docker-network-trigger' do |t|
+    t.ruby do |_, machine|
+      if ARGV[3] == 'configure-docker-network'
+        puts 'Copying identify file to job scheduler container.'
+        puts `docker ps --format '{{.Names}}' | grep job-scheduler | xargs -I {} docker exec {} sh -c 'mkdir -p /root/.ssh'`
+        puts `docker ps --format '{{.Names}}' | grep job-scheduler | xargs -I {} docker cp id_rsa {}:/root/.ssh`
+        puts "Writing authorized keys to #{machine.name}"
+        puts `cat ~/.ssh/id_rsa.pub | ssh -i ./.vagrant/machines/#{machine.name}/virtualbox/private_key vagrant@#{machine.name} \
+             "cat > /tmp/id_rsa.pub && sudo su - -c 'mkdir -p /root/.ssh && touch /root/.ssh/authorized_keys && cat /tmp/id_rsa.pub \
+             >> /root/.ssh/authorized_keys && rm -f /tmp/id_rsa.pub'"`
+      end
+    end
+  end
+
+  config.vm.provision 'configure-docker-network', type: 'shell', run: 'never', inline: <<-SHELL
+    echo "10.73.10.1 nginx" >> /etc/hosts
+  SHELL
+end

--- a/vagrant/scripts/bootstrap_iscsi.sh
+++ b/vagrant/scripts/bootstrap_iscsi.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+ISCI_IP=$1
+ISCI_IP2=$2
+IDX=1
+
+yum -y install targetcli lsscsi
+targetcli /backstores/block create mgt1 /dev/sdb
+targetcli /backstores/block create mdt1 /dev/sdc
+targetcli /backstores/block create mdt2 /dev/sdd
+targetcli /backstores/block create mdt3 /dev/sde
+targetcli /iscsi set global auto_add_default_portal=false
+targetcli /iscsi create iqn.2015-01.com.whamcloud.lu:mds
+targetcli /iscsi create iqn.2015-01.com.whamcloud.lu:oss
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/luns/ create /backstores/block/mgt1
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/luns/ create /backstores/block/mdt1
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/luns/ create /backstores/block/mdt2
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/luns/ create /backstores/block/mdt3
+
+
+for x in {f..y}
+do
+    targetcli /backstores/block create ost${IDX} /dev/sd${x}
+    targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:oss/tpg1/luns/ create /backstores/block/ost${IDX}
+    ((IDX++))
+done
+
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/portals/ create ${ISCI_IP}
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:oss/tpg1/portals/ create ${ISCI_IP}
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/portals/ create ${ISCI_IP2}
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:oss/tpg1/portals/ create ${ISCI_IP2}
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/acls create iqn.2015-01.com.whamcloud:mds1
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/acls create iqn.2015-01.com.whamcloud:mds2
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:oss/tpg1/acls create iqn.2015-01.com.whamcloud:oss1
+targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:oss/tpg1/acls create iqn.2015-01.com.whamcloud:oss2
+targetcli saveconfig
+systemctl enable target

--- a/vagrant/scripts/configure_lustre_network.sh
+++ b/vagrant/scripts/configure_lustre_network.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+modprobe lnet
+lnetctl lnet configure
+lnetctl net add --net tcp0 --if eth1
+lnetctl net show --net tcp > /etc/lnet.conf
+systemctl enable lnet.service

--- a/vagrant/scripts/create_ldiskfs_fs_osts.sh
+++ b/vagrant/scripts/create_ldiskfs_fs_osts.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+START=$1
+END=$2
+IDX=$3
+FSNAME=$4
+
+for x in $(eval echo {$START..$END}); do
+     mkfs.lustre --ost --reformat --servicenode=10.73.20.21@tcp --servicenode=10.73.20.22@tcp --index=$IDX --mgsnode=10.73.20.11@tcp --fsname=$FSNAME /dev/mapper/mpath$x
+     ((IDX++))
+done

--- a/vagrant/scripts/create_ldiskfs_fs_osts.sh
+++ b/vagrant/scripts/create_ldiskfs_fs_osts.sh
@@ -5,7 +5,7 @@ END=$2
 IDX=$3
 FSNAME=$4
 
-for x in $(eval echo {$START..$END}); do
+for x in $(eval echo "{$START..$END}"); do
      mkfs.lustre --ost --reformat --servicenode=10.73.20.21@tcp --servicenode=10.73.20.22@tcp --index=$IDX --mgsnode=10.73.20.11@tcp --fsname=$FSNAME /dev/mapper/mpath$x
      ((IDX++))
 done

--- a/vagrant/scripts/deploy_hosts.sh
+++ b/vagrant/scripts/deploy_hosts.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+iml server add --hosts mds[1,2].local,oss[1,2].local --profile $1

--- a/vagrant/scripts/disable_selinux.sh
+++ b/vagrant/scripts/disable_selinux.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+selinuxenabled && setenforce 0
+
+cat >/etc/selinux/config<<__EOF
+SELINUX=disabled
+SELINUXTYPE=targeted
+__EOF

--- a/vagrant/scripts/install_iml.sh
+++ b/vagrant/scripts/install_iml.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+yum-config-manager --add-repo=$1
+yum install -y python2-iml-manager
+chroma-config setup admin lustre localhost --no-dbspace-check

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+yum copr enable -y managerforlustre/manager-for-lustre-devel
+yum install -y rpmdevtools git ed epel-release python-setuptools
+cd /integrated-manager-for-lustre
+make rpms
+cp ./chroma_support.repo /etc/yum.repos.d/
+yum install -y /integrated-manager-for-lustre/_topdir/RPMS/noarch/python2-iml-manager-*
+chroma-config setup admin lustre localhost --no-dbspace-check

--- a/vagrant/scripts/install_iml_tar.sh
+++ b/vagrant/scripts/install_iml_tar.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 mkdir -p /tmp/iml-install
 cd /tmp/iml-install
 curl -L https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/v$1/iml-$1.tar.gz | tar zx --strip 1

--- a/vagrant/scripts/install_iml_tar.sh
+++ b/vagrant/scripts/install_iml_tar.sh
@@ -1,0 +1,6 @@
+mkdir -p /tmp/iml-install
+cd /tmp/iml-install
+curl -L https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/v$1/iml-$1.tar.gz | tar zx --strip 1
+yum install -y expect
+curl -O https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/v$1/chroma-manager/tests/utils/install.exp
+/usr/bin/expect install.exp admin "" lustre ""

--- a/vagrant/scripts/install_ldiskfs_no_iml.sh
+++ b/vagrant/scripts/install_ldiskfs_no_iml.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-2.12.3/el7/patchless-ldiskfs-server/
+yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
+yum install -y --nogpgcheck lustre kmod-lustre-osd-ldiskfs

--- a/vagrant/scripts/install_zfs_no_iml.sh
+++ b/vagrant/scripts/install_zfs_no_iml.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-2.12.3/el7/patchless-ldiskfs-server/
+yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
+yum-config-manager --add-repo=http://download.zfsonlinux.org/epel/7.6/kmod/x86_64/
+yum install -y --nogpgcheck lustre zfs kmod-lustre-osd-ldiskfs kmod-lustre-osd-zfs
+systemctl enable --now zfs-zed

--- a/vagrant/scripts/key_config.sh
+++ b/vagrant/scripts/key_config.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+mkdir -m 0700 -p /root/.ssh
+cp /vagrant/id_rsa /root/.ssh/.
+chmod 0600 /root/.ssh/id_rsa
+
+[ -f /vagrant/id_rsa.pub ] && (awk -v pk="`cat /vagrant/id_rsa.pub`" 'BEGIN{split(pk,s," ")} $2 == s[2] {m=1;exit}END{if (m==0)print pk}' /root/.ssh/authorized_keys ) >> /root/.ssh/authorized_keys
+chmod 0600 /root/.ssh/authorized_keys
+
+cat > /etc/ssh/ssh_config <<__EOF
+    Host *
+      StrictHostKeyChecking no
+__EOF

--- a/vagrant/scripts/key_config.sh
+++ b/vagrant/scripts/key_config.sh
@@ -4,7 +4,7 @@ mkdir -m 0700 -p /root/.ssh
 cp /vagrant/id_rsa /root/.ssh/.
 chmod 0600 /root/.ssh/id_rsa
 
-[ -f /vagrant/id_rsa.pub ] && (awk -v pk="`cat /vagrant/id_rsa.pub`" 'BEGIN{split(pk,s," ")} $2 == s[2] {m=1;exit}END{if (m==0)print pk}' /root/.ssh/authorized_keys ) >> /root/.ssh/authorized_keys
+[ -f /vagrant/id_rsa.pub ] && (awk -v pk="$(cat /vagrant/id_rsa.pub)" 'BEGIN{split(pk,s," ")} $2 == s[2] {m=1;exit}END{if (m==0)print pk}' /root/.ssh/authorized_keys ) >> /root/.ssh/authorized_keys
 chmod 0600 /root/.ssh/authorized_keys
 
 cat > /etc/ssh/ssh_config <<__EOF

--- a/vagrant/scripts/load-diagnostics-db.sh
+++ b/vagrant/scripts/load-diagnostics-db.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+gunzip /tmp/chromadb_*.sql.gz
+chroma-config stop
+
+
+cd /tmp && \
+sudo -u postgres -- pg_dump -U chroma -F p -w -f other-db-bits.sql -t 'chroma_core_series' -t 'chroma_core_sample_*' -t 'chroma_core_logmessage'
+
+sudo -u postgres -- dropdb chroma
+sudo -u postgres -- createdb chroma
+
+cd /tmp && \
+sudo -u postgres -- psql chroma < chromadb_*.sql && \
+sudo -u postgres -- psql chroma < other-db-bits.sql
+
+chroma-config start

--- a/vagrant/scripts/use_vault.sh
+++ b/vagrant/scripts/use_vault.sh
@@ -1,0 +1,5 @@
+yum-config-manager --disable base extras updates
+yum-config-manager \
+  --add-repo http://vault.centos.org/${1}/os/x86_64/ \
+  --add-repo http://vault.centos.org/${1}/extras/x86_64/ \
+  --add-repo http://vault.centos.org/${1}/updates/x86_64/ || true

--- a/vagrant/scripts/use_vault.sh
+++ b/vagrant/scripts/use_vault.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 yum-config-manager --disable base extras updates
 yum-config-manager \
   --add-repo http://vault.centos.org/${1}/os/x86_64/ \

--- a/vagrant/scripts/zfs_params.sh
+++ b/vagrant/scripts/zfs_params.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p /sys/module/zfs/parameters
+echo 100 > /sys/module/zfs/parameters/zfs_multihost_history
+echo 60 > /sys/module/zfs/parameters/zfs_multihost_fail_intervals
+echo options zfs zfs_multihost_history=100 > /etc/modprobe.d/iml_zfs_module_parameters.conf
+echo options zfs zfs_multihost_fail_intervals=60 >> /etc/modprobe.d/iml_zfs_module_parameters.conf


### PR DESCRIPTION
Take the repo from https://github.com/whamcloud/Vagrantfiles and plop it
into `integrated-manager-for-lustre/vagrant`.

This will replace https://github.com/whamcloud/Vagrantfiles which will
be marked as deprecated.

Co-locating this repo is the first step of using it to run automated
testing instead of vagrant-libvirt which has been flakey and largely
unmaintained upstream.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1451)
<!-- Reviewable:end -->
