### PR TITLE
Use a separate order to remove a record

### DIFF
--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -220,6 +220,7 @@ pub enum Msg {
     EventSourceError(JsValue),
     Records(Box<warp_drive::Cache>),
     RecordChange(Box<warp_drive::RecordChange>),
+    RemoveRecord(warp_drive::RecordId),
     Locks(warp_drive::Locks),
     WindowClick,
     Notification(notification::Msg),
@@ -356,9 +357,12 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
                     _ => {}
                 };
 
-                model.records.remove_record(&record_id);
+                orders.send_msg(Msg::RemoveRecord(record_id));
             }
         },
+        Msg::RemoveRecord(id) => {
+            model.records.remove_record(&id);
+        }
         Msg::Locks(locks) => {
             model.locks = locks;
         }


### PR DESCRIPTION
We currently remove a record inline, but send a message to child
components when one is removed.

We expect the child components to be able to access the record in the
cache before it's deleted, however the child message is async and
happens after the inline delete is processed.

Add a new Msg variant to remove the record. By doing this, we ensure the
remove is scheduled after the chilren can process the delete.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1452)
<!-- Reviewable:end -->
