### PR TITLE
Remove extra save from RemoveOstPoolJob and AddOstPoolJob

### DIFF
--- a/chroma_core/models/filesystem.py
+++ b/chroma_core/models/filesystem.py
@@ -597,7 +597,6 @@ class AddOstPoolJob(Job):
     def on_success(self):
         super(AddOstPoolJob, self).on_success()
         self.pool.osts.add(self.ost)
-        self.pool.save()
 
 
 class AddOstPoolStep(Step):
@@ -652,7 +651,6 @@ class RemoveOstPoolJob(Job):
     def on_success(self):
         super(RemoveOstPoolJob, self).on_success()
         self.pool.osts.remove(self.ost)
-        self.pool.save()
 
 
 class RemoveOstPoolStep(Step):


### PR DESCRIPTION
Remove the `.save()` from the main model for `AddOstPoolJob` and
`RemoveOstPoolJob`.

This was causing an extra commit in the db on the main model, which
doesn't have any direct fk fields to the ost pool osts.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1456)
<!-- Reviewable:end -->
