### PR TITLE
Fix: install-iml-local provisioner agent packages are overwritten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,11 @@ all: copr-rpms rpms
 
 rpms:
 	$(MAKE) -f .copr/Makefile iml-srpm outdir=.
-	rpmbuild -D "_topdir $(CURDIR)/_topdir" -bb _topdir/SPECS/python-iml-manager.spec
+	rpmbuild --rebuild -D "_topdir $(CURDIR)/_topdir" _topdir/SRPMS/python-iml-manager-*.src.rpm
 
 copr-rpms:
 	$(MAKE) -f .copr/Makefile srpm outdir=.
-	rpmbuild -D "_topdir $(CURDIR)/_topdir" -bb _topdir/SPECS/rust-iml.spec
+	rpmbuild --rebuild -D "_topdir $(CURDIR)/_topdir" _topdir/SRPMS/rust-iml-*.src.rpm
 
 cleandist:
 	rm -rf dist

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -5,15 +5,31 @@ yum install -y rpmdevtools git ed epel-release python-setuptools gcc openssl-dev
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 source $HOME/.cargo/env
 cd /integrated-manager-for-lustre
-make copr-rpms
 
+# Bump the release number. This should ensure we get picked 
+#even if copr-devel has something newer
+rpmdev-bumpspec rust-iml.spec
+rpmdev-bumpspec python-iml-manager.spec
+
+# Use current timestamp to ensure running this again
+# causes a re-install
+TS=$(date +%s)
+
+V=$(rpmspec -q --srpm --queryformat='%{VERSION}' /integrated-manager-for-lustre/rust-iml.spec)
+rpmdev-bumpspec -n $V.$TS rust-iml.spec
+
+V=$(rpmspec -q --srpm --queryformat='%{VERSION}' /integrated-manager-for-lustre/python-iml-manager.spec)
+rpmdev-bumpspec -n $V.$TS python-iml-manager.spec
+
+make all
+
+rm -rf /tmp/{manager,agent}-rpms
 mkdir -p /tmp/{manager,agent}-rpms
-cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-{action-runner,cli,ostpool,stratagem,agent-comms,mailbox,warp-drive}-*.rpm /tmp/manager-rpms/
-cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-agent-[0-9]*.rpm /tmp/agent-rpms
-make rpms
-cp /integrated-manager-for-lustre/_topdir/RPMS/noarch/python2-iml-manager-* /tmp/manager-rpms/
 
+cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-{action-runner,cli,ostpool,stratagem,agent-comms,mailbox,warp-drive}-*.rpm,python2-iml-manager-* /tmp/manager-rpms/
+cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-agent-[0-9]*.rpm /tmp/agent-rpms
 cp /integrated-manager-for-lustre/chroma_support.repo /etc/yum.repos.d/
-yum localinstall -y /tmp/manager-rpms/*.rpm
+
+yum install -y /tmp/manager-rpms/*.rpm
 
 chroma-config setup admin lustre localhost --no-dbspace-check

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 yum copr enable -y managerforlustre/manager-for-lustre-devel
-yum install -y rpmdevtools git ed epel-release python-setuptools gcc openssl-devel
+# Add buildtools repo to get latest rpmdevtools
+yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/managerforlustre/buildtools/repo/epel-8/managerforlustre-buildtools-epel-8.repo
+yum install -y rpmdevtools git ed epel-release python-setuptools gcc openssl-devel postgresql-devel
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 source $HOME/.cargo/env
 cd /integrated-manager-for-lustre
@@ -18,15 +20,15 @@ TS=$(date +%s)
 V=$(rpmspec -q --srpm --queryformat='%{VERSION}' /integrated-manager-for-lustre/rust-iml.spec)
 rpmdev-bumpspec -n $V.$TS rust-iml.spec
 
-V=$(rpmspec -q --srpm --queryformat='%{VERSION}' /integrated-manager-for-lustre/python-iml-manager.spec)
-rpmdev-bumpspec -n $V.$TS python-iml-manager.spec
-
 make all
+
+yum autoremove -y rpmdevtools
 
 rm -rf /tmp/{manager,agent}-rpms
 mkdir -p /tmp/{manager,agent}-rpms
 
-cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-{action-runner,cli,ostpool,stratagem,agent-comms,mailbox,warp-drive}-*.rpm,python2-iml-manager-* /tmp/manager-rpms/
+cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-{action-runner,cli,ostpool,stratagem,agent-comms,mailbox,warp-drive}-*.rpm /tmp/manager-rpms/
+cp /integrated-manager-for-lustre/_topdir/RPMS/noarch/python2-iml-manager-*.rpm /tmp/manager-rpms/
 cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-agent-[0-9]*.rpm /tmp/agent-rpms
 cp /integrated-manager-for-lustre/chroma_support.repo /etc/yum.repos.d/
 

--- a/vagrant/scripts/install_iml_local_agent.sh
+++ b/vagrant/scripts/install_iml_local_agent.sh
@@ -2,6 +2,7 @@
 
 yum install -y yum-plugin-copr
 yum copr enable -y managerforlustre/manager-for-lustre-devel
+rm -rf /tmp/agent-rpms
 mkdir -p /tmp/agent-rpms
 scp adm:/tmp/agent-rpms/*.rpm /tmp/agent-rpms
 yum localinstall -y /tmp/agent-rpms/*.rpm


### PR DESCRIPTION
Fixes #1483.

These changes should ensure the locally built packages get chosen (within a comparable range).

It also enables reinstall capabilities.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1484)
<!-- Reviewable:end -->
