### PR TITLE
Fixup alert type endpoint

### DIFF
--- a/chroma_api/alert.py
+++ b/chroma_api/alert.py
@@ -125,7 +125,11 @@ class AlertTypeResource(Resource):
         return self._build_reverse_url(url_name, kwargs=kwargs)
 
     def get_object_list(self, request):
-        return [ContentType.objects.get_for_model(cls) for cls in AlertStateBase.subclasses() if cls is not AlertState]
+        return [
+            ContentType.objects.get_for_model(cls, False)
+            for cls in AlertStateBase.subclasses()
+            if cls is not AlertState
+        ]
 
     def obj_get_list(self, bundle, **kwargs):
         return self.get_object_list(bundle.request)


### PR DESCRIPTION
The `/api/alert_type` endpoint was returning multiple copies of
`AlertStateBase`.

This is because we weren't accounting for proxy objects when looking up
the content type.

Pass in `False` to looking up the proxy model correctly.

ref: https://docs.djangoproject.com/en/1.11/ref/contrib/contenttypes/#django.contrib.contenttypes.models.ContentTypeManager.get_for_model

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1503)
<!-- Reviewable:end -->
