### PR TITLE
GH-1504 Create post office manager plugin

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -37,9 +37,10 @@ srpm:
 	mkdir -p ${TMPDIR}/_topdir/{SOURCES,SPECS}
 	mkdir -p ${TMPDIR}/release/rust-iml
 	cargo build --release
-	cp target/release/iml-{action-runner,agent,agent-comms,agent-daemon,mailbox,ostpool,stratagem,warp-drive} \
+	cp target/release/iml-{action-runner,agent,agent-comms,agent-daemon,mailbox,postoffice,ostpool,stratagem,warp-drive} \
 		iml-agent-comms.service \
 		iml-mailbox.service \
+		iml-postoffice.service \
 		iml-ostpool.service \
 		iml-stratagem.service \
 		iml-action-runner.service \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iml-postoffice"
+version = "0.1.0"
+dependencies = [
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iml-rabbit 0.1.0",
+ "iml-service-queue 0.1.0",
+ "iml-wire-types 0.2.0",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "iml-rabbit"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     'iml-services/iml-ostpool',
     'iml-services/iml-service-queue',
     'iml-services/iml-stratagem',
+    'iml-services/iml-postoffice',
     'iml-util',
     'iml-warp-drive',
     'iml-wire-types',

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -48,6 +48,8 @@ services:
     restart: on-failure
   iml-stratagem:
     restart: on-failure
+  iml-postoffice:
+    restart: on-failure
 secrets:
   iml_pw:
     file: /tmp/iml_pw

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -266,6 +266,17 @@ services:
       - "manager-config:/var/lib/chroma"
     environment:
       - RUST_LOG=info
+  iml-stratagem:
+    image: "imlteam/iml-postoffice:5.1"
+    hostname: "iml-postoffice"
+    build:
+      context: ../
+      dockerfile: ./docker/iml-postoffice.dockerfile
+    deploy: *default-deploy
+    volumes:
+      - "manager-config:/var/lib/chroma"
+    environment:
+      - PROXY_HOST=iml-postoffice
   setup:
     image: "imlteam/manager-setup:5.1"
     command: ["tail", "-f", "/dev/null"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -266,7 +266,7 @@ services:
       - "manager-config:/var/lib/chroma"
     environment:
       - RUST_LOG=info
-  iml-stratagem:
+  iml-postoffice:
     image: "imlteam/iml-postoffice:5.1"
     hostname: "iml-postoffice"
     build:

--- a/docker/iml-postoffice.dockerfile
+++ b/docker/iml-postoffice.dockerfile
@@ -1,0 +1,11 @@
+FROM rust-iml-base as builder
+
+FROM ubuntu
+COPY --from=builder /build/target/release/iml-postoffice /usr/local/bin
+
+RUN apt-get update \
+  && apt-get install -y curl
+
+COPY docker/wait-for-dependencies.sh /usr/local/bin/
+ENTRYPOINT [ "wait-for-dependencies.sh" ]
+CMD ["iml-postoffice"]

--- a/iml-manager.target
+++ b/iml-manager.target
@@ -46,6 +46,9 @@ After=iml-stratagem.service
 Requires=iml-mailbox.service
 After=iml-mailbox.service
 
+Requires=iml-postoffice.service
+After=iml-postoffice.service
+
 Requires=iml-ostpool.service
 After=iml-ostpool.service
 

--- a/iml-postoffice.service
+++ b/iml-postoffice.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=IML Postoffice Service
+PartOf=iml-manager.target
+After=rabbitmq-server.service
+After=iml-settings-populator.service
+Requires=iml-settings-populator.service
+
+
+[Service]
+Type=simple
+Environment=RUST_LOG=info
+EnvironmentFile=/var/lib/chroma/iml-settings.conf
+ExecStart=/bin/iml-postoffice
+Restart=always
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=iml-manager.target

--- a/iml-services/iml-postoffice/Cargo.toml
+++ b/iml-services/iml-postoffice/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "iml-postoffice"
+version = "0.1.0"
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+
+[dependencies]
+futures = "0.3"
+iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
+iml-rabbit = { path = "../../iml-rabbit", version = "0.1.0" }
+iml-service-queue = { path = "../iml-service-queue", version = "0.1.0" }
+tokio = "0.2"
+tracing = "0.1"
+tracing-subscriber = "0.1"

--- a/iml-services/iml-postoffice/src/main.rs
+++ b/iml-services/iml-postoffice/src/main.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use futures::TryStreamExt;
+use iml_service_queue::service_queue::consume_data;
+use tracing_subscriber::{fmt::Subscriber, EnvFilter};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = Subscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    let mut s = consume_data::<String>("rust_agent_postoffice_rx");
+
+    while let Some((fqdn, s)) = s.try_next().await? {
+        tracing::info!("Got some postoffice data from {:?}: {:?}", fqdn, s);
+    }
+
+    Ok(())
+}

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -88,6 +88,7 @@ Requires:       rust-iml-action-runner >= 0.1.2
 Requires:       rust-iml-ostpool >= 0.1.2
 Requires:       rust-iml-agent-comms >= 0.1.2
 Requires:       rust-iml-mailbox >= 0.1.2
+Requires:       rust-iml-postoffice >= 0.1.0
 Requires:       rust-iml-stratagem >= 0.1.2
 Requires:       rust-iml-warp-drive >= 0.1.2
 Requires:       rust-iml-cli >= 0.1.2

--- a/rust-iml.spec
+++ b/rust-iml.spec
@@ -36,6 +36,7 @@ cp iml-agent-comms %{buildroot}%{_bindir}
 cp iml-action-runner %{buildroot}%{_bindir}
 cp iml-warp-drive %{buildroot}%{_bindir}
 cp iml-mailbox %{buildroot}%{_bindir}
+cp iml-postoffice %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_unitdir}
 cp iml-stratagem.service %{buildroot}%{_unitdir}
 cp iml-ostpool.service %{buildroot}%{_unitdir}
@@ -44,6 +45,7 @@ cp iml-action-runner.{socket,service} %{buildroot}%{_unitdir}
 cp rust-iml-agent.{service,path} %{buildroot}%{_unitdir}
 cp iml-warp-drive.service %{buildroot}%{_unitdir}
 cp iml-mailbox.service %{buildroot}%{_unitdir}
+cp iml-postoffice.service %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_tmpfilesdir}
 cp iml-mailbox.conf %{buildroot}%{_tmpfilesdir}
 cp tmpfiles.conf %{buildroot}%{_tmpfilesdir}/iml-agent.conf

--- a/rust-iml.spec
+++ b/rust-iml.spec
@@ -225,6 +225,28 @@ systemctl preset iml-mailbox.service
 %attr(0644,root,root)%{_unitdir}/iml-mailbox.service
 %attr(0644,root,root)%{_tmpfilesdir}/iml-mailbox.conf
 
+%package postoffice
+Summary: Consumer of IML Agent Postoffice push queue
+License: MIT
+Group: System Environment/Libraries
+Requires: rust-iml-agent-comms
+
+%description postoffice
+%{summary}
+
+%post postoffice
+systemctl preset iml-postoffice.service
+
+%preun postoffice
+%systemd_preun iml-postoffice.service
+
+%postun postoffice
+%systemd_postun_with_restart iml-postoffice.service
+
+%files postoffice
+%{_bindir}/iml-postoffice
+%attr(0644,root,root)%{_unitdir}/iml-postoffice.service
+
 %changelog
 * Wed Mar 6 2019 Joe Grund <jgrund@whamcloud.com> - 0.1.0-1
 - Initial package

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -27,7 +27,7 @@ yum autoremove -y rpmdevtools
 rm -rf /tmp/{manager,agent}-rpms
 mkdir -p /tmp/{manager,agent}-rpms
 
-cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-{action-runner,cli,ostpool,stratagem,agent-comms,mailbox,warp-drive}-*.rpm /tmp/manager-rpms/
+cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-{action-runner,cli,ostpool,stratagem,agent-comms,mailbox,postoffice,warp-drive}-*.rpm /tmp/manager-rpms/
 cp /integrated-manager-for-lustre/_topdir/RPMS/noarch/python2-iml-manager-*.rpm /tmp/manager-rpms/
 cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-agent-[0-9]*.rpm /tmp/agent-rpms
 cp /integrated-manager-for-lustre/chroma_support.repo /etc/yum.repos.d/


### PR DESCRIPTION
Fixes #1504.

After installing a new local RPM based installation of IML I added two MDS nodes that had been configured in monitored mode and noticed that the manager was receiving disconnects every few seconds. Looking into the logs, I discovered the following error message:

```
session create request for postoffice failed: Reqwest(reqwest::Error { kind: Status(502), url: "https://adm.local/agent2/message/" })
Jan 21 16:07:16 mds1.local iml-agent-daemon[8147]: Jan 21 16:07:16.529  INFO iml_agent::poller: session create request for ostpool failed: Reqwest(reqwest::Error { kind: Status(502), url: "https://adm.local/agent2/message/" })
Jan 21 16:07:16 mds1.local iml-agent-daemon[8147]: Jan 21 16:07:16.530  INFO iml_agent::poller: session create request for stratagem failed: Reqwest(reqwest::Error { kind: Status(502), url: "https://adm.local/agent2/message/" })
Jan 21 16:07:16 mds1.local iml-agent-daemon[8147]: Jan 21 16:07:16.530  INFO iml_agent::poller: session create request for action_runner failed: Reqwest(reqwest::Error { kind: Status(502), url: "https://adm.local/agent2/message/" })
```

After discussing, it appears that we need to add a post office manager plugin so that the session is created appropriately.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1505)
<!-- Reviewable:end -->
