### PR TITLE
Add media breakpoint tracking

### DIFF
--- a/iml-gui/crate/src/breakpoints.rs
+++ b/iml-gui/crate/src/breakpoints.rs
@@ -6,26 +6,21 @@
 
 use seed::window;
 
-pub(crate) const SM: f64 = 569.;
-pub(crate) const MD: f64 = 769.;
-pub(crate) const LG: f64 = 1025.;
-pub(crate) const XL: f64 = 1701.;
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) enum Size {
-    XS,
-    SM,
-    MD,
-    LG,
-    XL,
+    XS = 0,
+    SM = 569,
+    MD = 769,
+    LG = 1025,
+    XL = 1701,
 }
 
-fn inner_width() -> f64 {
+fn inner_width() -> u64 {
     window()
         .inner_width()
         .expect("Could not get inner_width")
         .as_f64()
-        .expect("Could not parse inner_width to f64")
+        .expect("Could not parse inner_width to f64") as u64
 }
 
 /// Returns *maximum* matching breakpoint based on `window.inner_width`.
@@ -33,13 +28,13 @@ fn inner_width() -> f64 {
 pub(crate) fn size() -> Size {
     let w = inner_width();
 
-    if w >= XL {
+    if w >= Size::XL as u64 {
         Size::XL
-    } else if w >= LG {
+    } else if w >= Size::LG as u64 {
         Size::LG
-    } else if w >= MD {
+    } else if w >= Size::MD as u64 {
         Size::MD
-    } else if w >= SM {
+    } else if w >= Size::SM as u64 {
         Size::SM
     } else {
         Size::XS

--- a/iml-gui/crate/src/breakpoints.rs
+++ b/iml-gui/crate/src/breakpoints.rs
@@ -1,0 +1,47 @@
+//! # Breakpoints
+//!
+//! This module lists the existing media breakpoints we use and contains some helper functions for working with them.
+//!
+//! It should be kept in sync with any breakpoint changes to `tailwind.config.js`.
+
+use seed::window;
+
+pub(crate) const SM: f64 = 569.;
+pub(crate) const MD: f64 = 769.;
+pub(crate) const LG: f64 = 1025.;
+pub(crate) const XL: f64 = 1701.;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) enum Size {
+    XS,
+    SM,
+    MD,
+    LG,
+    XL,
+}
+
+fn inner_width() -> f64 {
+    window()
+        .inner_width()
+        .expect("Could not get inner_width")
+        .as_f64()
+        .expect("Could not parse inner_width to f64")
+}
+
+/// Returns *maximum* matching breakpoint based on `window.inner_width`.
+/// This models the behavior of breakpoints in tailwind: https://tailwindcss.com/docs/responsive-design/
+pub(crate) fn size() -> Size {
+    let w = inner_width();
+
+    if w >= XL {
+        Size::XL
+    } else if w >= LG {
+        Size::LG
+    } else if w >= MD {
+        Size::MD
+    } else if w >= SM {
+        Size::SM
+    } else {
+        Size::XS
+    }
+}

--- a/iml-gui/crate/src/page/partial/header.rs
+++ b/iml-gui/crate/src/page/partial/header.rs
@@ -1,4 +1,5 @@
 use crate::{
+    breakpoints,
     components::{activity_indicator, breadcrumbs, font_awesome},
     ctx_help::CtxHelp,
     generated::css_classes::C,
@@ -252,7 +253,7 @@ fn nav(model: &Model) -> Node<Msg> {
                 ],
             ],
         ],
-        if model.menu_visibility == Visible {
+        if model.menu_visibility == Visible || model.breakpoint_size >= breakpoints::Size::LG {
             div![
                 class![
                     C.w_full,


### PR DESCRIPTION
Add a new module that will track current breakpoint size via the window resize event.

This can be used to handle responsive rendering changes in Rust code.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1519)
<!-- Reviewable:end -->
