### PR TITLE
Use target host nids instead of mgs nids

### DIFF
--- a/chroma_core/models/host.py
+++ b/chroma_core/models/host.py
@@ -1582,8 +1582,7 @@ class ReplaceNidsStep(Step):
     def run(self, args):
         target = args["target"]
         nids = args["nids"]
-        flattened_nids = [e for t in nids for e in t]
-        agent_args = ["replace_nids", target] + [",".join(flattened_nids)]
+        agent_args = ["replace_nids", target] + [",".join(nids)]
         return self.invoke_rust_agent_expect_result(args["fqdn"], "lctl", agent_args)
 
 
@@ -1685,7 +1684,7 @@ class UpdateNidsJob(HostListMixin):
                         ReplaceNidsStep,
                         {
                             "target": "%s" % target,
-                            "nids": target.filesystem.mgs.nids(),
+                            "nids": target.best_available_host().lnet_configuration.get_nids(),
                             "fqdn": target.filesystem.mgs.best_available_host().fqdn,
                         },
                     )

--- a/chroma_core/models/host.py
+++ b/chroma_core/models/host.py
@@ -1582,7 +1582,7 @@ class ReplaceNidsStep(Step):
     def run(self, args):
         target = args["target"]
         nids = args["nids"]
-        agent_args = ["replace_nids", target] + [",".join(nids)]
+        agent_args = ["replace_nids", target] + [":".join([",".join(x) for x in nids])]
         return self.invoke_rust_agent_expect_result(args["fqdn"], "lctl", agent_args)
 
 
@@ -1684,7 +1684,7 @@ class UpdateNidsJob(HostListMixin):
                         ReplaceNidsStep,
                         {
                             "target": "%s" % target,
-                            "nids": target.best_available_host().lnet_configuration.get_nids(),
+                            "nids": target.nids(),
                             "fqdn": target.filesystem.mgs.best_available_host().fqdn,
                         },
                     )

--- a/tests/unit/services/job_scheduler/host/test_host.py
+++ b/tests/unit/services/job_scheduler/host/test_host.py
@@ -119,8 +119,8 @@ class TestUpdateNids(NidTestCase):
         self.assertState(self.fs, "stopped")
 
         expected_calls = [
-            call("mgs", "lctl", ["replace_nids", "%s" % self.mdt, "192.168.0.99@tcp0"],),
-            call("mgs", "lctl", ["replace_nids", "%s" % self.ost, "192.168.0.99@tcp0"],),
+            call("mgs", "lctl", ["replace_nids", "%s" % self.mdt, "192.168.0.2@tcp0"],),
+            call("mgs", "lctl", ["replace_nids", "%s" % self.ost, "192.168.0.3@tcp0"],),
         ]
 
         self.assertEqual(expected_calls, invoke.call_args_list)


### PR DESCRIPTION
Fixes #1523.

`replace_nids` is currently using the mgs nids for every target.

Instead we should use the most relevant target nids for the operation.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1524)
<!-- Reviewable:end -->
