### PR TITLE
Suppress excessive warnings in IML-GUI

### DIFF
--- a/.github/workflows/iml-gui.yml
+++ b/.github/workflows/iml-gui.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path iml-gui/crate/Cargo.toml --all-features -- --deny clippy::nursery
+          args: --manifest-path iml-gui/crate/Cargo.toml --all-features -- --deny clippy::nursery --deny warnings
 
   rustfmt:
     name: Format

--- a/iml-gui/crate/Cargo.lock
+++ b/iml-gui/crate/Cargo.lock
@@ -213,6 +213,7 @@ name = "iml-gui"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "im 14.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-wire-types 0.2.0",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/iml-gui/crate/Cargo.toml
+++ b/iml-gui/crate/Cargo.toml
@@ -17,6 +17,7 @@ wasm-bindgen-test = "0.3"
 
 [dependencies]
 chrono = { version = "0.4", features = ["wasmbind"] }
+futures = "0.3"
 im = { version = "14.1", features = ["serde"] }
 iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
 js-sys = "0.3"
@@ -40,6 +41,7 @@ features = [
   "NotificationOptions",
   "NotificationPermission",
   "ServiceWorkerContainer",
+
   "ServiceWorkerRegistration",
   "Window",
 ]

--- a/iml-gui/crate/Makefile.toml
+++ b/iml-gui/crate/Makefile.toml
@@ -68,4 +68,4 @@ description = "Lint with Clippy"
 clear = true
 install_crate = { rustup_component_name = "clippy", binary = "cargo-clippy", test_arg = "--help" }
 command = "cargo"
-args = ["clippy", "--all-features", "--", "--deny", "clippy::nursery"]
+args = ["clippy", "--all-features", "--", "--deny", "clippy::nursery", "--deny", "warnings"]

--- a/iml-gui/crate/src/components/dropdown.rs
+++ b/iml-gui/crate/src/components/dropdown.rs
@@ -1,8 +1,7 @@
 use crate::{components::Placement, generated::css_classes::C};
 use seed::{prelude::*, virtual_dom::Attrs, Style, *};
 
-#[allow(unused)]
-pub(crate) fn wrapper_view<T>(attrs: Attrs, placement: Placement, open: bool, children: impl View<T>) -> Node<T> {
+pub fn wrapper_view<T>(attrs: Attrs, placement: Placement, open: bool, children: impl View<T>) -> Node<T> {
     if !open {
         return empty![];
     }
@@ -44,7 +43,6 @@ pub(crate) fn wrapper_view<T>(attrs: Attrs, placement: Placement, open: bool, ch
     div![cls, st, children.els(),]
 }
 
-#[allow(unused)]
 pub fn item_view<T>(children: impl View<T>) -> Node<T> {
     div![
         class![

--- a/iml-gui/crate/src/components/dropdown.rs
+++ b/iml-gui/crate/src/components/dropdown.rs
@@ -1,6 +1,7 @@
 use crate::{components::Placement, generated::css_classes::C};
 use seed::{prelude::*, virtual_dom::Attrs, Style, *};
 
+#[allow(unused)]
 pub(crate) fn wrapper_view<T>(attrs: Attrs, placement: Placement, open: bool, children: impl View<T>) -> Node<T> {
     if !open {
         return empty![];
@@ -43,6 +44,7 @@ pub(crate) fn wrapper_view<T>(attrs: Attrs, placement: Placement, open: bool, ch
     div![cls, st, children.els(),]
 }
 
+#[allow(unused)]
 pub fn item_view<T>(children: impl View<T>) -> Node<T> {
     div![
         class![

--- a/iml-gui/crate/src/components/lnet_status.rs
+++ b/iml-gui/crate/src/components/lnet_status.rs
@@ -2,6 +2,7 @@ use crate::{components::font_awesome, generated::css_classes::C};
 use iml_wire_types::db::LnetConfigurationRecord;
 use seed::{prelude::*, *};
 
+#[allow(unused)] // actually used
 fn network<T>(color: impl Into<Option<&'static str>>) -> Node<T> {
     if let Some(color) = color.into() {
         font_awesome(class![C.w_4, C.h_4, C.inline, C.mr_1, color], "network-wired")
@@ -10,6 +11,7 @@ fn network<T>(color: impl Into<Option<&'static str>>) -> Node<T> {
     }
 }
 
+#[allow(unused)] // actually used
 pub fn view<T>(x: &LnetConfigurationRecord) -> Node<T> {
     match x.state.as_str() {
         "lnet_up" => span![network(C.text_green_500), "Up"],

--- a/iml-gui/crate/src/components/lnet_status.rs
+++ b/iml-gui/crate/src/components/lnet_status.rs
@@ -2,8 +2,7 @@ use crate::{components::font_awesome, generated::css_classes::C};
 use iml_wire_types::db::LnetConfigurationRecord;
 use seed::{prelude::*, *};
 
-#[allow(unused)] // actually used
-fn network<T>(color: impl Into<Option<&'static str>>) -> Node<T> {
+pub fn network<T>(color: impl Into<Option<&'static str>>) -> Node<T> {
     if let Some(color) = color.into() {
         font_awesome(class![C.w_4, C.h_4, C.inline, C.mr_1, color], "network-wired")
     } else {
@@ -11,7 +10,6 @@ fn network<T>(color: impl Into<Option<&'static str>>) -> Node<T> {
     }
 }
 
-#[allow(unused)] // actually used
 pub fn view<T>(x: &LnetConfigurationRecord) -> Node<T> {
     match x.state.as_str() {
         "lnet_up" => span![network(C.text_green_500), "Up"],

--- a/iml-gui/crate/src/components/mod.rs
+++ b/iml-gui/crate/src/components/mod.rs
@@ -1,15 +1,16 @@
+pub mod dropdown;
+pub mod lnet_status;
+pub mod paging;
+pub mod popover;
+pub mod table;
+pub mod tooltip;
+
 pub(crate) mod activity_indicator;
 pub(crate) mod alert_indicator;
 pub(crate) mod arrow;
 pub(crate) mod breadcrumbs;
-pub(crate) mod dropdown;
 pub(crate) mod font_awesome;
-pub(crate) mod lnet_status;
 pub(crate) mod logo;
-pub(crate) mod paging;
-pub(crate) mod popover;
-pub(crate) mod table;
-pub(crate) mod tooltip;
 pub(crate) mod tree;
 
 pub(crate) use activity_indicator::{activity_indicator, update_activity_health, ActivityHealth};
@@ -18,9 +19,8 @@ pub(crate) use arrow::arrow;
 pub(crate) use font_awesome::{font_awesome, font_awesome_outline};
 pub(crate) use logo::logo;
 
-#[allow(unused)]
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum Placement {
+pub enum Placement {
     Left,
     Right,
     Top,

--- a/iml-gui/crate/src/components/mod.rs
+++ b/iml-gui/crate/src/components/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use arrow::arrow;
 pub(crate) use font_awesome::{font_awesome, font_awesome_outline};
 pub(crate) use logo::logo;
 
+#[allow(unused)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Placement {
     Left,

--- a/iml-gui/crate/src/components/paging.rs
+++ b/iml-gui/crate/src/components/paging.rs
@@ -62,7 +62,6 @@ impl Model {
     pub fn next_page(&mut self) {
         self.offset = self.end();
     }
-    #[allow(unused)]
     pub fn range(&self) -> Range<usize> {
         self.offset..self.end()
     }
@@ -101,7 +100,6 @@ pub fn update(msg: Msg, model: &mut Model) {
     }
 }
 
-#[allow(unused)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Dir {
     Asc,
@@ -115,7 +113,6 @@ impl Default for Dir {
 }
 
 impl Dir {
-    #[allow(unused)]
     pub fn next(self) -> Self {
         match self {
             Dir::Asc => Dir::Desc,
@@ -127,7 +124,6 @@ impl Dir {
 // View
 
 /// Given a direction, renders the correct chevron for that direction.
-#[allow(unused)]
 pub fn dir_toggle_view<T>(dir: Dir, more_attrs: Attrs) -> Node<T> {
     let x = match dir {
         Dir::Asc => "chevron-up",
@@ -137,8 +133,7 @@ pub fn dir_toggle_view<T>(dir: Dir, more_attrs: Attrs) -> Node<T> {
     font_awesome(more_attrs, x)
 }
 
-#[allow(unused)]
-pub(crate) fn limit_selection_view(p: &Model) -> Node<Msg> {
+pub fn limit_selection_view(p: &Model) -> Node<Msg> {
     let mut btn = button![
         class![
             C.bg_transparent,
@@ -183,7 +178,6 @@ pub(crate) fn limit_selection_view(p: &Model) -> Node<Msg> {
 }
 
 /// Given a paging `Model`, renders the current range and total records.
-#[allow(unused)]
 pub fn page_count_view<T>(p: &Model) -> Node<T> {
     span![
         class![C.self_center, C.text_sm, C.mr_1],

--- a/iml-gui/crate/src/components/paging.rs
+++ b/iml-gui/crate/src/components/paging.rs
@@ -62,6 +62,7 @@ impl Model {
     pub fn next_page(&mut self) {
         self.offset = self.end();
     }
+    #[allow(unused)]
     pub fn range(&self) -> Range<usize> {
         self.offset..self.end()
     }
@@ -100,6 +101,7 @@ pub fn update(msg: Msg, model: &mut Model) {
     }
 }
 
+#[allow(unused)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Dir {
     Asc,
@@ -113,6 +115,7 @@ impl Default for Dir {
 }
 
 impl Dir {
+    #[allow(unused)]
     pub fn next(self) -> Self {
         match self {
             Dir::Asc => Dir::Desc,
@@ -124,6 +127,7 @@ impl Dir {
 // View
 
 /// Given a direction, renders the correct chevron for that direction.
+#[allow(unused)]
 pub fn dir_toggle_view<T>(dir: Dir, more_attrs: Attrs) -> Node<T> {
     let x = match dir {
         Dir::Asc => "chevron-up",
@@ -133,6 +137,7 @@ pub fn dir_toggle_view<T>(dir: Dir, more_attrs: Attrs) -> Node<T> {
     font_awesome(more_attrs, x)
 }
 
+#[allow(unused)]
 pub(crate) fn limit_selection_view(p: &Model) -> Node<Msg> {
     let mut btn = button![
         class![
@@ -178,6 +183,7 @@ pub(crate) fn limit_selection_view(p: &Model) -> Node<Msg> {
 }
 
 /// Given a paging `Model`, renders the current range and total records.
+#[allow(unused)]
 pub fn page_count_view<T>(p: &Model) -> Node<T> {
     span![
         class![C.self_center, C.text_sm, C.mr_1],

--- a/iml-gui/crate/src/components/popover.rs
+++ b/iml-gui/crate/src/components/popover.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use seed::{prelude::*, *};
 
+#[allow(unused)]
 pub fn title_view<T>(content: &str) -> Node<T> {
     div![
         class![C.bg_gray_200, C.py_1, C.px_3],
@@ -11,10 +12,12 @@ pub fn title_view<T>(content: &str) -> Node<T> {
     ]
 }
 
+#[allow(unused)]
 pub fn content_view<T>(content: impl View<T>) -> Node<T> {
     div![class![C.py_2, C.px_3, C.w_64], content.els()]
 }
 
+#[allow(unused)]
 pub(crate) fn view<T>(content: impl View<T>, placement: Placement, visible: bool) -> Node<T> {
     let color = "#e2e8f0";
 

--- a/iml-gui/crate/src/components/popover.rs
+++ b/iml-gui/crate/src/components/popover.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use seed::{prelude::*, *};
 
-#[allow(unused)]
 pub fn title_view<T>(content: &str) -> Node<T> {
     div![
         class![C.bg_gray_200, C.py_1, C.px_3],
@@ -12,13 +11,11 @@ pub fn title_view<T>(content: &str) -> Node<T> {
     ]
 }
 
-#[allow(unused)]
 pub fn content_view<T>(content: impl View<T>) -> Node<T> {
     div![class![C.py_2, C.px_3, C.w_64], content.els()]
 }
 
-#[allow(unused)]
-pub(crate) fn view<T>(content: impl View<T>, placement: Placement, visible: bool) -> Node<T> {
+pub fn view<T>(content: impl View<T>, placement: Placement, visible: bool) -> Node<T> {
     let color = "#e2e8f0";
 
     let popover_top_styles = style! {

--- a/iml-gui/crate/src/components/table.rs
+++ b/iml-gui/crate/src/components/table.rs
@@ -1,12 +1,10 @@
 use crate::generated::css_classes::C;
 use seed::{prelude::*, Attrs, *};
 
-#[allow(unused)]
 pub fn wrapper_cls() -> Attrs {
     class![C.table_auto, C.w_full]
 }
 
-#[allow(unused)]
 pub fn wrapper_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     let mut cls = wrapper_cls();
 
@@ -22,17 +20,14 @@ pub fn wrapper_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     ]
 }
 
-#[allow(unused)]
 pub fn thead_view<T>(children: impl View<T>) -> Node<T> {
     thead![style! { St::BorderSpacing => "0 10px"}, tr![children.els()]]
 }
 
-#[allow(unused)]
 pub fn th_cls() -> Attrs {
     class![C.px_3, C.text_gray_800, C.font_normal]
 }
 
-#[allow(unused)]
 pub fn th_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     let mut cls = th_cls();
 
@@ -41,12 +36,10 @@ pub fn th_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     th![cls, children.els()]
 }
 
-#[allow(unused)]
 pub fn th_sortable_cls() -> Attrs {
     class![C.border_b_2, C.border_blue_500]
 }
 
-#[allow(unused)]
 pub fn th_sortable_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     let mut cls = th_sortable_cls();
 
@@ -55,12 +48,10 @@ pub fn th_sortable_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T>
     th_view(cls, children.els())
 }
 
-#[allow(unused)]
 pub fn td_cls() -> Attrs {
     class![C.px_3, C.bg_gray_100, C.rounded, C.p_4]
 }
 
-#[allow(unused)]
 pub fn td_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     let mut cls = td_cls();
 

--- a/iml-gui/crate/src/components/table.rs
+++ b/iml-gui/crate/src/components/table.rs
@@ -1,10 +1,12 @@
 use crate::generated::css_classes::C;
 use seed::{prelude::*, Attrs, *};
 
+#[allow(unused)]
 pub fn wrapper_cls() -> Attrs {
     class![C.table_auto, C.w_full]
 }
 
+#[allow(unused)]
 pub fn wrapper_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     let mut cls = wrapper_cls();
 
@@ -20,14 +22,17 @@ pub fn wrapper_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     ]
 }
 
+#[allow(unused)]
 pub fn thead_view<T>(children: impl View<T>) -> Node<T> {
     thead![style! { St::BorderSpacing => "0 10px"}, tr![children.els()]]
 }
 
+#[allow(unused)]
 pub fn th_cls() -> Attrs {
     class![C.px_3, C.text_gray_800, C.font_normal]
 }
 
+#[allow(unused)]
 pub fn th_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     let mut cls = th_cls();
 
@@ -36,10 +41,12 @@ pub fn th_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     th![cls, children.els()]
 }
 
+#[allow(unused)]
 pub fn th_sortable_cls() -> Attrs {
     class![C.border_b_2, C.border_blue_500]
 }
 
+#[allow(unused)]
 pub fn th_sortable_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     let mut cls = th_sortable_cls();
 
@@ -48,10 +55,12 @@ pub fn th_sortable_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T>
     th_view(cls, children.els())
 }
 
+#[allow(unused)]
 pub fn td_cls() -> Attrs {
     class![C.px_3, C.bg_gray_100, C.rounded, C.p_4]
 }
 
+#[allow(unused)]
 pub fn td_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
     let mut cls = td_cls();
 

--- a/iml-gui/crate/src/components/tooltip.rs
+++ b/iml-gui/crate/src/components/tooltip.rs
@@ -83,7 +83,6 @@ pub(crate) fn view<T>(content: &str, direction: Placement) -> Node<T> {
 }
 
 /// Render a tooltip with a red error color.
-#[allow(unused)]
-pub(crate) fn error_view<T>(content: &str, direction: Placement) -> Node<T> {
+pub fn error_view<T>(content: &str, direction: Placement) -> Node<T> {
     color_view(content, direction, "red")
 }

--- a/iml-gui/crate/src/components/tooltip.rs
+++ b/iml-gui/crate/src/components/tooltip.rs
@@ -83,6 +83,7 @@ pub(crate) fn view<T>(content: &str, direction: Placement) -> Node<T> {
 }
 
 /// Render a tooltip with a red error color.
+#[allow(unused)]
 pub(crate) fn error_view<T>(content: &str, direction: Placement) -> Node<T> {
     color_view(content, direction, "red")
 }

--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -5,8 +5,9 @@
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::enum_glob_use)]
 
+pub mod components;
+
 mod breakpoints;
-mod components;
 mod ctx_help;
 mod generated;
 mod notification;

--- a/iml-gui/crate/src/notification.rs
+++ b/iml-gui/crate/src/notification.rs
@@ -35,7 +35,8 @@ pub(crate) fn update(u: Msg, m: &mut Model, orders: &mut impl Orders<Msg>) {
                 .body(body.as_str());
 
             if let Some(svc) = &m.svc {
-                let _ = svc.show_notification_with_options(title.as_str(), &opts).unwrap();
+                let promise = svc.show_notification_with_options(title.as_str(), &opts).unwrap();
+                orders.perform_cmd(JsFuture::from(promise).map(|_| Ok(Msg::Nothing)));
             } else {
                 let n = N::new_with_options(title.as_str(), &opts).unwrap();
                 seed::set_timeout(Box::new(move || n.close()), 9000);

--- a/iml-gui/crate/src/notification.rs
+++ b/iml-gui/crate/src/notification.rs
@@ -35,7 +35,7 @@ pub(crate) fn update(u: Msg, m: &mut Model, orders: &mut impl Orders<Msg>) {
                 .body(body.as_str());
 
             if let Some(svc) = &m.svc {
-                svc.show_notification_with_options(title.as_str(), &opts).unwrap();
+                let _ = svc.show_notification_with_options(title.as_str(), &opts).unwrap();
             } else {
                 let n = N::new_with_options(title.as_str(), &opts).unwrap();
                 seed::set_timeout(Box::new(move || n.close()), 9000);

--- a/iml-gui/crate/src/notification.rs
+++ b/iml-gui/crate/src/notification.rs
@@ -1,4 +1,5 @@
 use crate::components::ActivityHealth;
+use futures::FutureExt;
 use seed::prelude::Orders;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;

--- a/iml-wire-types/wire-types.rs
+++ b/iml-wire-types/wire-types.rs
@@ -2213,6 +2213,7 @@ pub mod warp_drive {
 
     impl Cache {
         /// Removes the record from the cache
+        #[allow(clippy::trivially_copy_pass_by_ref)]
         pub fn remove_record(&mut self, x: &RecordId) -> bool {
             match x {
                 RecordId::ActiveAlert(id) => self.active_alert.remove(id).is_some(),

--- a/iml-wire-types/wire-types.rs
+++ b/iml-wire-types/wire-types.rs
@@ -2076,20 +2076,6 @@ impl fmt::Display for ResourceAgentType {
     }
 }
 
-impl PartialEq<String> for ResourceAgentType {
-    #[allow(clippy::cmp_owned)]
-    fn eq(&self, other: &String) -> bool {
-        self.to_string() == *other
-    }
-}
-
-impl PartialEq<&str> for ResourceAgentType {
-    #[allow(clippy::cmp_owned)]
-    fn eq(&self, other: &&str) -> bool {
-        self.to_string() == *other
-    }
-}
-
 /// Information about pacemaker resource agents
 #[derive(serde::Deserialize, serde::Serialize, PartialEq, Clone, Debug)]
 pub struct ResourceAgentInfo {

--- a/iml-wire-types/wire-types.rs
+++ b/iml-wire-types/wire-types.rs
@@ -2077,12 +2077,14 @@ impl fmt::Display for ResourceAgentType {
 }
 
 impl PartialEq<String> for ResourceAgentType {
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &String) -> bool {
         self.to_string() == *other
     }
 }
 
 impl PartialEq<&str> for ResourceAgentType {
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &&str) -> bool {
         self.to_string() == *other
     }
@@ -2280,6 +2282,7 @@ pub mod warp_drive {
         }
     }
 
+    #[allow(clippy::large_enum_variant)]
     #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
     #[serde(tag = "tag", content = "payload")]
     pub enum Record {
@@ -2332,6 +2335,7 @@ pub mod warp_drive {
         }
     }
 
+    #[allow(clippy::large_enum_variant)]
     #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
     #[serde(tag = "tag", content = "payload")]
     pub enum RecordChange {
@@ -2340,6 +2344,7 @@ pub mod warp_drive {
     }
 
     /// Message variants.
+    #[allow(clippy::large_enum_variant)]
     #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
     #[serde(tag = "tag", content = "payload")]
     pub enum Message {


### PR DESCRIPTION
There are lot of warnings from clippy and rustc, that are just noise, because they are mostly false positives. E.g `unused function` warning is emitted just because all the calls are inside `seed` macros.

This patch supresses these warnings, the only warning is left is
```
2230 |         pub fn remove_record(&mut self, x: &RecordId) -> bool {
     |                                            ^^^^^^^^^ help: consider passing by value instead: `RecordId`
```
which I'm going to fix in `Arc` PR.

I understand this is rather effect fix (not the reason), so rejecting is okay.

Signed-off-by: Nick Linker <nlinker@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1526)
<!-- Reviewable:end -->
