### PR TITLE
Implement server overview page

### DIFF
--- a/iml-gui/crate/Cargo.lock
+++ b/iml-gui/crate/Cargo.lock
@@ -46,6 +46,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-humanize"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,7 +201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -215,6 +223,7 @@ name = "iml-gui"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono-humanize 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gloo-timers 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "im 14.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -225,7 +234,7 @@ dependencies = [
  "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "seed 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-test 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -238,7 +247,7 @@ version = "0.2.0"
 dependencies = [
  "im 14.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -251,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -433,7 +442,7 @@ dependencies = [
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -460,10 +469,10 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -535,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -583,7 +592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -722,6 +731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bumpalo 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb8038c1ddc0a5f73787b130f4cc75151e96ed33e417fde765eb5a81e3532f4"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+"checksum chrono-humanize 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2ff48a655fe8d2dae9a39e66af7fd8ff32a879e8c4e27422c25596a8b5e90d"
 "checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum dbg 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4677188513e0e9d7adced5997cf9a1e7a3c996c994f90093325c5332c1a8b221"
@@ -741,7 +751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum im 14.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e302bf26ba21de289e808230f80fe799fd371268d853783ee7f844c7cb5704b7"
 "checksum indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc"
-"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
@@ -769,7 +779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum seed 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "516cdd85cdde01a3769edc1d921aff431e024ab82b0e608c59e178d8747f902a"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
-"checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
+"checksum serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "eab8f15f15d6c41a154c1b128a22f2dfabe350ef53c40953d84e36155c91192b"
 "checksum sized-chunks 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6f59f81ec9833a580d2448e958d16bd872637798f3ab300b693c48f136fb76ff"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
@@ -779,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
+"checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/iml-gui/crate/Cargo.toml
+++ b/iml-gui/crate/Cargo.toml
@@ -17,6 +17,7 @@ wasm-bindgen-test = "0.3"
 
 [dependencies]
 chrono = { version = "0.4", features = ["wasmbind"] }
+chrono-humanize = "0.0.11"
 futures = "0.3"
 gloo-timers = { version = "0.2", features = ["futures"] }
 im = { version = "14.2", features = ["serde"] }

--- a/iml-gui/crate/src/components/table.rs
+++ b/iml-gui/crate/src/components/table.rs
@@ -5,13 +5,9 @@ pub fn wrapper_cls() -> Attrs {
     class![C.table_auto, C.w_full]
 }
 
-pub fn wrapper_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
-    let mut cls = wrapper_cls();
-
-    cls.merge(more_attrs);
-
+pub fn wrapper_view<T>(children: impl View<T>) -> Node<T> {
     table![
-        cls,
+        wrapper_cls(),
         style! {
             St::BorderSpacing => px(10),
             St::BorderCollapse => "initial"
@@ -28,34 +24,18 @@ pub fn th_cls() -> Attrs {
     class![C.px_3, C.text_gray_800, C.font_normal]
 }
 
-pub fn th_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
-    let mut cls = th_cls();
-
-    cls.merge(more_attrs);
-
-    th![cls, children.els()]
+pub fn th_view<T>(children: impl View<T>) -> Node<T> {
+    th![th_cls(), children.els()]
 }
 
 pub fn th_sortable_cls() -> Attrs {
     class![C.border_b_2, C.border_blue_500]
 }
 
-pub fn th_sortable_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
-    let mut cls = th_sortable_cls();
-
-    cls.merge(more_attrs);
-
-    th_view(cls, children.els())
-}
-
 pub fn td_cls() -> Attrs {
     class![C.px_3, C.bg_gray_100, C.rounded, C.p_4]
 }
 
-pub fn td_view<T>(more_attrs: Attrs, children: impl View<T>) -> Node<T> {
-    let mut cls = td_cls();
-
-    cls.merge(more_attrs);
-
-    td![cls, children.els()]
+pub fn td_view<T>(children: impl View<T>) -> Node<T> {
+    td![td_cls(), children.els()]
 }

--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -23,6 +23,7 @@ pub(crate) use extensions::*;
 use generated::css_classes::C;
 use iml_wire_types::{warp_drive, GroupType, Session};
 use page::login;
+use regex::Regex;
 use route::Route;
 use seed::{app::MessageMapper, prelude::*, Listener, *};
 pub(crate) use sleep::sleep_with_handle;
@@ -46,6 +47,14 @@ const MAX_SIDE_PERCENTAGE: f32 = 35_f32;
 /// ```
 /// help url becomes `https://localhost:8443/help/docs/Graphical_User_Interface_9_0.html`
 const CTX_HELP: &str = "help/docs/Graphical_User_Interface_9_0.html";
+
+pub fn extract_api(s: &str) -> Option<&str> {
+    let re = Regex::new(r"^/?api/[^/]+/(\d+)/?$").unwrap();
+
+    let x = re.captures(s)?;
+
+    x.get(1).map(|x| x.as_str())
+}
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub enum Visibility {
@@ -81,6 +90,7 @@ pub struct Model {
     route: Route<'static>,
     saw_es_locks: bool,
     saw_es_messages: bool,
+    server_page: page::server::Model,
     side_width_percentage: f32,
     track_slider: bool,
     tree: tree::Model,
@@ -129,6 +139,7 @@ fn after_mount(url: Url, orders: &mut impl Orders<Msg, GMsg>) -> AfterMount<Mode
         route: url.into(),
         saw_es_locks: false,
         saw_es_messages: false,
+        server_page: page::server::Model::default(),
         side_width_percentage: 20_f32,
         track_slider: false,
         tree: tree::Model::default(),
@@ -189,6 +200,7 @@ pub enum Msg {
     RecordChange(Box<warp_drive::RecordChange>),
     RemoveRecord(warp_drive::RecordId),
     Locks(warp_drive::Locks),
+    ServerPage(page::server::Msg),
     WindowClick,
     WindowResize,
     Notification(notification::Msg),
@@ -276,6 +288,10 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
                 .proxy(Msg::Notification)
                 .send_msg(notification::generate(None, &old, &model.activity_health));
 
+            orders.proxy(Msg::ServerPage).send_msg(page::server::Msg::SetHosts(
+                model.records.host.values().cloned().collect(),
+            ));
+
             orders.proxy(Msg::Tree).send_msg(tree::Msg::Reset);
         }
         Msg::RecordChange(record_change) => match *record_change {
@@ -309,6 +325,10 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
                             .proxy(Msg::Tree)
                             .send_msg(tree::Msg::Add(warp_drive::RecordId::Host(id)));
                     };
+
+                    orders.proxy(Msg::ServerPage).send_msg(page::server::Msg::SetHosts(
+                        model.records.host.values().cloned().collect(),
+                    ));
                 }
                 warp_drive::Record::ManagedTargetMount(x) => {
                     model.records.managed_target_mount.insert(x.id, x);
@@ -367,6 +387,12 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
         },
         Msg::RemoveRecord(id) => {
             model.records.remove_record(&id);
+
+            if let warp_drive::RecordId::Host(_) = id {
+                orders.proxy(Msg::ServerPage).send_msg(page::server::Msg::SetHosts(
+                    model.records.host.values().cloned().collect(),
+                ));
+            }
         }
         Msg::Locks(locks) => {
             model.locks = locks;
@@ -378,6 +404,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
         Msg::HideMenu => {
             model.menu_visibility = Hidden;
         }
+        Msg::ServerPage(msg) => page::server::update(msg, &mut model.server_page, &mut orders.proxy(Msg::ServerPage)),
         Msg::StartSliderTracking => {
             model.track_slider = true;
         }
@@ -415,6 +442,8 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
             if model.manage_menu_state.should_update() {
                 model.manage_menu_state.update();
             }
+
+            orders.proxy(Msg::ServerPage).send_msg(page::server::Msg::WindowClick);
         }
         Msg::WindowResize => {
             model.breakpoint_size = breakpoints::size();
@@ -566,7 +595,13 @@ pub fn view(model: &Model) -> Vec<Node<Msg>> {
         Route::OstPool => main_panels(model, page::ostpool::view(model)).els(),
         Route::OstPoolDetail(id) => main_panels(model, page::ostpool_detail::view(model, id)).els(),
         Route::PowerControl => main_panels(model, page::power_control::view(model)).els(),
-        Route::Server => main_panels(model, page::server::view(model)).els(),
+        Route::Server => main_panels(
+            model,
+            page::server::view(&model.records, &model.server_page)
+                .els()
+                .map_msg(Msg::ServerPage),
+        )
+        .els(),
         Route::ServerDetail(id) => main_panels(model, page::server_detail::view(model, id)).els(),
         Route::Target => main_panels(model, page::target::view(model)).els(),
         Route::TargetDetail(id) => main_panels(model, page::target_detail::view(model, id)).els(),

--- a/iml-gui/crate/src/page/server.rs
+++ b/iml-gui/crate/src/page/server.rs
@@ -169,9 +169,10 @@ pub fn view(cache: &Cache, model: &Model) -> impl View<Msg> {
                                 alert_indicator(&cache.active_alert, &x.resource_uri, true, Placement::Top)
                             ])
                             .merge_attrs(class![C.text_center]),
-                            table::td_view(span![timeago(&x).unwrap_or("".into())]).merge_attrs(class![C.text_center]),
+                            table::td_view(span![timeago(x).unwrap_or_else(|| "".into())])
+                                .merge_attrs(class![C.text_center]),
                             table::td_view(span![x.server_profile.ui_name]).merge_attrs(class![C.text_center]),
-                            table::td_view(div![lnet_by_server(&x, &cache).unwrap_or(vec![])])
+                            table::td_view(div![lnet_by_server(x, cache).unwrap_or_else(|| vec![])])
                                 .merge_attrs(class![C.text_center])
                         ]
                     })]

--- a/iml-gui/crate/src/page/server.rs
+++ b/iml-gui/crate/src/page/server.rs
@@ -1,6 +1,189 @@
-use crate::{Model, Msg};
-use seed::prelude::*;
+use crate::{
+    components::{alert_indicator, lnet_status, paging, table, Placement},
+    extract_api,
+    generated::css_classes::C,
+    GMsg, MergeAttrs, Route,
+};
+use iml_wire_types::{warp_drive::Cache, Host, Label};
+use seed::{prelude::*, *};
+use std::cmp::Ordering;
 
-pub fn view(_model: &Model) -> impl View<Msg> {
-    seed::empty()
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortField {
+    Label,
+    Profile,
+}
+
+impl Default for SortField {
+    fn default() -> Self {
+        SortField::Label
+    }
+}
+
+#[derive(Default)]
+pub struct Model {
+    hosts: Vec<Host>,
+    pager: paging::Model,
+    sort: (SortField, paging::Dir),
+}
+
+#[derive(Clone)]
+pub enum Msg {
+    SetHosts(Vec<Host>),
+    Page(paging::Msg),
+    Sort,
+    SortBy(SortField),
+    WindowClick,
+}
+
+pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
+    match msg {
+        Msg::SortBy(x) => {
+            let dir = if x == model.sort.0 {
+                model.sort.1.next()
+            } else {
+                paging::Dir::default()
+            };
+
+            model.sort = (x, dir);
+
+            orders.send_msg(Msg::Sort);
+        }
+        Msg::Sort => {
+            let sort_fn = match model.sort {
+                (SortField::Label, paging::Dir::Asc) => {
+                    Box::new(|a: &Host, b: &Host| natord::compare(a.label(), b.label()))
+                        as Box<dyn FnMut(&Host, &Host) -> Ordering>
+                }
+                (SortField::Label, paging::Dir::Desc) => {
+                    Box::new(|a: &Host, b: &Host| natord::compare(b.label(), a.label()))
+                }
+                (SortField::Profile, paging::Dir::Asc) => {
+                    Box::new(|a: &Host, b: &Host| natord::compare(&a.server_profile.ui_name, &b.server_profile.ui_name))
+                }
+                (SortField::Profile, paging::Dir::Desc) => {
+                    Box::new(|a: &Host, b: &Host| natord::compare(&b.server_profile.ui_name, &a.server_profile.ui_name))
+                }
+            };
+
+            model.hosts.sort_by(sort_fn);
+        }
+        Msg::WindowClick => {
+            if model.pager.dropdown.should_update() {
+                model.pager.dropdown.update();
+            }
+        }
+        Msg::SetHosts(hosts) => {
+            model.hosts = hosts;
+
+            orders
+                .proxy(Msg::Page)
+                .send_msg(paging::Msg::SetTotal(model.hosts.len()));
+
+            orders.send_msg(Msg::Sort);
+        }
+        Msg::Page(msg) => {
+            paging::update(msg, &mut model.pager);
+        }
+    }
+}
+
+fn sort_header(label: &str, sort_field: SortField, model: &Model) -> Node<Msg> {
+    let is_active = model.sort.0 == sort_field;
+
+    let table_cls = class![C.text_center];
+
+    let table_cls = if is_active {
+        table_cls.merge_attrs(table::th_sortable_cls())
+    } else {
+        table_cls
+    };
+
+    table::th_view(a![
+        class![C.select_none, C.cursor_pointer, C.font_semibold],
+        mouse_ev(Ev::Click, move |_| Msg::SortBy(sort_field)),
+        label,
+        if is_active {
+            paging::dir_toggle_view(model.sort.1, class![C.w_5, C.h_4, C.inline, C.ml_1, C.text_blue_500])
+        } else {
+            empty![]
+        }
+    ])
+    .merge_attrs(table_cls)
+}
+
+fn lnet_by_server<T>(x: &Host, cache: &Cache) -> Option<Vec<Node<T>>> {
+    let id = extract_api(&x.lnet_configuration)?;
+
+    let id = id.parse::<u32>().unwrap();
+
+    let config = cache.lnet_configuration.get(&id)?;
+
+    Some(vec![
+        lnet_status::view(config).merge_attrs(class![C.mr_1]),
+        alert_indicator(
+            &cache.active_alert,
+            &format!("/api/lnet_configuration/{}/", config.id),
+            true,
+            Placement::Top,
+        ),
+    ])
+}
+
+fn timeago(x: &Host) -> Option<String> {
+    let boot_time = x.boot_time.as_ref()?;
+
+    let dt = chrono::DateTime::parse_from_rfc3339(&format!("{}-00:00", boot_time)).unwrap();
+
+    Some(format!("{}", chrono_humanize::HumanTime::from(dt)))
+}
+
+pub fn view(cache: &Cache, model: &Model) -> impl View<Msg> {
+    div![
+        class![C.bg_white, C.border_t, C.border_b, C.border, C.rounded_lg, C.shadow],
+        div![
+            class![C.flex, C.justify_between, C.px_6, C._mb_px, C.bg_gray_200],
+            h3![class![C.py_4, C.font_normal, C.text_lg], "Servers"]
+        ],
+        if cache.host.is_empty() {
+            p!["No hosts found"]
+        } else {
+            div![
+                table::wrapper_view(vec![
+                    table::thead_view(vec![
+                        sort_header("Host", SortField::Label, model),
+                        table::th_view(Node::new_text("Boot time")).merge_attrs(class![C.text_center]),
+                        sort_header("Profile", SortField::Profile, model),
+                        table::th_view(Node::new_text("LNet")).merge_attrs(class![C.text_center]),
+                    ]),
+                    tbody![model.hosts[model.pager.range()].iter().map(|x| {
+                        tr![
+                            table::td_view(vec![
+                                a![
+                                    class![C.text_blue_500, C.hover__underline, C.mr_2],
+                                    attrs! {
+                                        At::Href => Route::ServerDetail(x.id.into()).to_href()
+                                    },
+                                    x.label()
+                                ],
+                                alert_indicator(&cache.active_alert, &x.resource_uri, true, Placement::Top)
+                            ])
+                            .merge_attrs(class![C.text_center]),
+                            table::td_view(span![timeago(&x).unwrap_or("".into())]).merge_attrs(class![C.text_center]),
+                            table::td_view(span![x.server_profile.ui_name]).merge_attrs(class![C.text_center]),
+                            table::td_view(div![lnet_by_server(&x, &cache).unwrap_or(vec![])])
+                                .merge_attrs(class![C.text_center])
+                        ]
+                    })]
+                ])
+                .merge_attrs(class![C.my_6]),
+                div![
+                    class![C.flex, C.justify_end, C.py_1, C.pr_3],
+                    paging::limit_selection_view(&model.pager).map_msg(Msg::Page),
+                    paging::page_count_view(&model.pager),
+                    paging::next_prev_view(&model.pager).map_msg(Msg::Page)
+                ],
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This patch implements the server overview page. It is not
feature-complete as things like adding servers, detect actions and the action-dropdown
are missing.

However, it should be good enough for a first pass. Everything should update in
near-realtime.

![server-overview-changes](https://user-images.githubusercontent.com/458717/73217412-dddc0200-4125-11ea-8fa6-45d63567722d.gif)

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1530)
<!-- Reviewable:end -->
