### PR TITLE
Allow Client vm's to be configured for docker networking

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -617,6 +617,8 @@ Vagrant.configure('2') do |config|
       # Lustre / application network
       provision_lnet_net c, "3#{i}"
 
+      configure_docker_network c
+
       c.vm.provision 'install-iml-local',
             type: 'shell',
             run: 'never',


### PR DESCRIPTION
Client vm's are not able to be added to the server page when using
docker because they do not contain the "configure_docker_network"
provisioning script. Add this ability to the client vm's.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1531)
<!-- Reviewable:end -->
