### PR TITLE
Create a base systemd dockerfile

### DIFF
--- a/docker/systemd-base.dockerfile
+++ b/docker/systemd-base.dockerfile
@@ -1,0 +1,18 @@
+FROM centos:8
+
+ENV container docker
+STOPSIGNAL SIGRTMIN+3
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+  systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+  rm -f /lib/systemd/system/multi-user.target.wants/*;\
+  rm -f /etc/systemd/system/*.wants/*;\
+  rm -f /lib/systemd/system/local-fs.target.wants/*; \
+  rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+  rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+  rm -f /lib/systemd/system/basic.target.wants/*; \
+  rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME ["sys/fs/cgroup"]
+
+CMD ["/usr/sbin/init"]


### PR DESCRIPTION
Both the iml-timer and iml-mailbox docker containers are based on
systemd. Create a base systemd dockerfile that can be used as a base
when creating systemd-based containers.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1533)
<!-- Reviewable:end -->
