### PR TITLE
Keep sosreports in archive format

### DIFF
--- a/tests/integration/utils/chroma_log_collector.py
+++ b/tests/integration/utils/chroma_log_collector.py
@@ -177,32 +177,12 @@ class ChromaLogCollector(object):
 
         errors = []
 
-        # Copy and expand the diagnostics locally, so they will be
-        # able to be read in browser in Jenkins.
         errors.append(self.fetch_log(server, "/var/tmp/%s" % diagnostics, ""))
 
-        if diagnostics.endswith("tar.xz"):
-            if shell_run(
-                ["tar", "-xvJf", "%s/%s" % (self.destination_path, diagnostics), "-C", self.destination_path]
-            ).rc:
-                errors.append("Error tar --xvJf the iml diagnostics file")
-        elif diagnostics.endswith("tar.gz"):
-            if shell_run(
-                ["tar", "-xvzf", "%s/%s" % (self.destination_path, diagnostics), "-C", self.destination_path]
-            ).rc:
-                errors.append("Error tar -xvzf the iml diagnostics file")
-        else:
-            errors = "Didn't recognize iml-diagnostics file format"
-
-        diagnostics_dir = re.compile("(sosreport-.*)\.tar\..*").search(diagnostics).group(1)
-
-        if shell_run(["chmod", "-R", "777", "%s/%s" % (self.destination_path, diagnostics_dir)]).rc:
+        if shell_run(["chmod", "777", "%s/%s" % (self.destination_path, diagnostics)]).rc:
             errors.append(
-                "Unable to change perms on expanded diagnostics at %s/%s" % (self.destination_path, diagnostics_dir)
+                "Unable to change perms on diagnostics at %s/%s" % (self.destination_path, diagnostics)
             )
-
-        if shell_run(["rm", "-f", "%s/%s" % (self.destination_path, diagnostics)]).rc:
-            errors.append("Unable to remove the diagnostics %s/%s" % (self.destination_path, diagnostics))
 
         return errors
 


### PR DESCRIPTION
Try to work around Jenkins archive step hanging by never expanding the
sosreports.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1542)
<!-- Reviewable:end -->
