### PR TITLE
Add Series Check to Stragem Library

### DIFF
--- a/chroma_core/lib/stratagem.py
+++ b/chroma_core/lib/stratagem.py
@@ -123,8 +123,12 @@ def aggregate_points(measurement_query):
     )
 
     results = json.loads(response._content).get("results")[0]
-    values = results.get("series")[0].get("values")
-    columns = results.get("series")[0].get("columns")
+    series = results.get("series")
+    if not series:
+        return []
+
+    values = series[0].get("values")
+    columns = series[0].get("columns")
 
     points = [dict(zip(columns, xs)) for xs in values]
 


### PR DESCRIPTION
The aggregate_points function assumes that the series will always be in
the influxdb results. I ran into a case in which the series was not in
the results. We should check to make sure that series is not empty
before attempting to get the values and columns from it.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1556)
<!-- Reviewable:end -->
