### PR TITLE
Update to newer Vagrantfile

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -29,6 +29,7 @@ ISCI_IP2 = "#{SUBNET_PREFIX}.50.10".freeze
 
 Vagrant.configure('2') do |config|
   config.vm.box = 'centos/7'
+  config.vm.box_url = "http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-2001_01.VirtualBox.box"
 
   config.vm.provider 'virtualbox' do |vbx|
     vbx.linked_clone = true

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -28,8 +28,10 @@ ISCI_IP = "#{SUBNET_PREFIX}.40.10".freeze
 ISCI_IP2 = "#{SUBNET_PREFIX}.50.10".freeze
 
 Vagrant.configure('2') do |config|
-  config.vm.box = 'centos/7'
-  config.vm.box_url = "http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-2001_01.VirtualBox.box"
+  config.vm.box = 'centos/7.7'
+  config.vm.box_url = 'http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-2001_01.VirtualBox.box'
+  config.vm.box_download_checksum = 'e1a26038fb036ab8e76a6a4dfcd49856'
+  config.vm.box_download_checksum_type = 'md5'
 
   config.vm.provider 'virtualbox' do |vbx|
     vbx.linked_clone = true


### PR DESCRIPTION
Even though it's not available on vagrant cloud yet, we can pull the
newest CentOS 7 Vbox directly from cloud.centos.org.

This should allow for us to skip updating the kernel on each vm before
installing Lustre.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1559)
<!-- Reviewable:end -->
