### PR TITLE
Use Centos:7 for rust-base and systemd-base

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,6 +8,7 @@ clean:
 
 build: clean
 	DOCKER_BUILDKIT=1 docker build -t imlteam/manager-service-base:5.1.1-dev -f base.dockerfile ../
+	DOCKER_BUILDKIT=1 docker build -t imlteam/systemd-base:5.1.1-dev -f systemd-base.dockerfile ../
 	DOCKER_BUILDKIT=1 docker build -t rust-iml-base -f rust-base.dockerfile ../
 	COMPOSE_DOCKER_CLI_BUILD=1 docker-compose build
 

--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -1,4 +1,4 @@
-FROM centos as builder
+FROM centos:7 as builder
 WORKDIR /build
 COPY . .
 RUN yum update -y

--- a/docker/iml-mailbox.dockerfile
+++ b/docker/iml-mailbox.dockerfile
@@ -1,6 +1,6 @@
 FROM rust-iml-base as builder
 
-FROM imlteam/systemd-base
+FROM imlteam/systemd-base:5.1.1-dev
 COPY --from=builder /build/target/release/iml-mailbox /bin/
 COPY docker/iml-mailbox/iml-mailbox.service /etc/systemd/system/
 COPY docker/iml-mailbox/iml-mailbox.conf /etc/systemd/system/

--- a/docker/rust-base.dockerfile
+++ b/docker/rust-base.dockerfile
@@ -1,4 +1,12 @@
-FROM rust:1.41
+FROM centos:7
 WORKDIR /build
+ARG toolchain=stable
+RUN yum install -y gcc openssl openssl-devel \
+    && yum clean all \
+    && cd /root \
+    && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $toolchain
+ENV PATH $PATH:/root/.cargo/bin
+ENV CARGO_HOME /root/.cargo
+ENV RUSTUP_HOME /root/.rustup
 COPY . .
 RUN cargo build --release

--- a/docker/systemd-base.dockerfile
+++ b/docker/systemd-base.dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM centos:7
 
 ENV container docker
 STOPSIGNAL SIGRTMIN+3


### PR DESCRIPTION
Use Centos:7 for rust-base and systemd-base.

This will remove the Centos:8 image from being bundled and should
hopefully save a few hundred MBs in the final RPM.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1565)
<!-- Reviewable:end -->
