### PR TITLE
Call rustup update after loading environment

### DIFF
--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -7,7 +7,6 @@ yum copr enable -y managerforlustre/manager-for-lustre-devel
 yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/managerforlustre/buildtools/repo/epel-8/managerforlustre-buildtools-epel-8.repo
 yum install -y rpmdevtools git ed epel-release python-setuptools gcc openssl-devel postgresql-devel
 curl https://sh.rustup.rs -sSf | sh -s -- -y
-rustup update
 source $HOME/.cargo/env
 rustup update
 rustc --version

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -9,6 +9,9 @@ yum install -y rpmdevtools git ed epel-release python-setuptools gcc openssl-dev
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 rustup update
 source $HOME/.cargo/env
+rustup update
+rustc --version
+cargo --version
 cd /integrated-manager-for-lustre
 
 # Bump the release number. This should ensure we get picked 


### PR DESCRIPTION
Previously it wouldn't update the toolchain - my setup still had 1.40 because of it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1570)
<!-- Reviewable:end -->
