### PR TITLE
Clean yum cache

### DIFF
--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+yum clean all
+
 yum copr enable -y managerforlustre/manager-for-lustre-devel
 # Get latest rpmdevtools
 yum install -y https://copr-be.cloud.fedoraproject.org/results/managerforlustre/buildtools/epel-8-x86_64/01152137-rpmdevtools/rpmdevtools-8.10-7.el8.noarch.rpm


### PR DESCRIPTION
Prevent usage of older repo metadata files (`repomd.xml`) which could
happen when VM has time not synchonized with the host
(i.e. after recovery from snapshot)

Signed-off-by: Michael Pankov <work@michaelpankov.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1593)
<!-- Reviewable:end -->
