### PR TITLE
Prevent mixing _topdir from host and adm

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -113,6 +113,7 @@ Vagrant.configure('2') do |config|
                            '/integrated-manager-for-lustre/',
                            type: 'rsync',
                            rsync__exclude: [
+                              '_topdir',
                               '.cargo/',
                               '.git/',
                               'iml-gui/crate/.cargo/',

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -115,12 +115,12 @@ Vagrant.configure('2') do |config|
                            rsync__exclude: [
                               '.cargo/',
                               '.git/',
-                              'target/',
                               'iml-gui/crate/.cargo/',
                               'iml-gui/crate/target/',
                               'iml-gui/node_modules/',
                               'iml-wasm-components/.cargo/',
                               'iml-wasm-components/target/',
+                              'target/',
                               'vagrant/'
                            ]
 


### PR DESCRIPTION
Caused errors where incorrect SRPMs would be processed during `install-iml-local`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1594)
<!-- Reviewable:end -->
