### PR TITLE
Use lapin instead of lapin-futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0261eeb244071203cd9727151a3161b9f6b443001c265dd52e782db6a36aa4d0"
+checksum = "3249cfdac820c4df7c63fe6ae3b06d94f15fb294996e50f4a6d2da580337c966"
 dependencies = [
  "amq-protocol-codegen",
  "amq-protocol-tcp",
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-codegen"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804fc12efd85663a6ced824386dde4f9b255fc00dd3db96459e35165164828e5"
+checksum = "3e12e0b090bc6ebec18ecb38ebf0be22653702e7ed523361d195efa80c361b5d"
 dependencies = [
  "amq-protocol-types",
  "handlebars",
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-tcp"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7623ad8723830dd9c48372e1d5fde9973ce7c28636267dfcf506bed382e84150"
+checksum = "4221dcd6665e958d353485d28109fc7c4ed1d9cb06b9ba0a48c06847f03b4039"
 dependencies = [
  "amq-protocol-uri",
  "mio",
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-types"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13489ba9891aac7f217c80ef10ead9e0219422d9af826bceb13a84346f75d0f"
+checksum = "4ec472722ea67718835222ea608c0410c41fbde0dc033a11a14c94b6a0dd61d6"
 dependencies = [
  "cookie-factory",
  "nom 5.1.0",
@@ -60,11 +60,11 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-uri"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e68b30bc7968ba7a013083e52d43429b1f253261a2960de6eb0905169e10f4"
+checksum = "09cb1e049824f477dbaeff58faf55d865bf2ce3409b48eaf32cd9c5cfe13c91c"
 dependencies = [
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "url",
 ]
 
@@ -118,10 +118,11 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "assert-json-diff"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9881d306dee755eccf052d652b774a6b2861e86b4772f555262130e58e4f81d2"
+checksum = "9c356497fd3417158bcb318266ac83c391219ca3a5fa659049f42e0041ab57d6"
 dependencies = [
+ "extend",
  "serde",
  "serde_json",
 ]
@@ -720,6 +721,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
+name = "extend"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf29866f640a891350d1aa695e0bf254df007df909cbecb65f6db4ba593b70a8"
+dependencies = [
+ "proc-macro-error 0.3.4",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,12 +795,6 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "futures"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
@@ -867,7 +874,6 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
 dependencies = [
- "futures 0.1.29",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1152,7 +1158,7 @@ dependencies = [
 name = "iml-action-runner"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "iml-agent-comms",
  "iml-manager-env",
  "iml-rabbit",
@@ -1182,7 +1188,7 @@ dependencies = [
  "dotenv",
  "elementtree",
  "exitcode",
- "futures 0.3.4",
+ "futures",
  "futures-util",
  "http 0.2.0",
  "iml-cmd",
@@ -1211,7 +1217,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber 0.1.6",
+ "tracing-subscriber 0.2.1",
  "url",
  "uuid 0.7.4",
  "v_hist",
@@ -1222,7 +1228,7 @@ dependencies = [
 name = "iml-agent-comms"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "iml-manager-env",
  "iml-rabbit",
  "iml-wire-types",
@@ -1239,7 +1245,7 @@ dependencies = [
 name = "iml-api"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "iml-job-scheduler-rpc",
  "iml-manager-env",
  "iml-rabbit",
@@ -1256,7 +1262,7 @@ dependencies = [
 name = "iml-cmd"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "tokio",
  "tracing",
  "warp",
@@ -1267,7 +1273,7 @@ name = "iml-fs"
 version = "0.1.0"
 dependencies = [
  "bytes 0.5.4",
- "futures 0.3.4",
+ "futures",
  "pretty_assertions",
  "tempdir",
  "tempfile",
@@ -1279,7 +1285,7 @@ dependencies = [
 name = "iml-job-scheduler-rpc"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "iml-rabbit",
  "iml-wire-types",
  "serde",
@@ -1294,7 +1300,7 @@ name = "iml-mailbox"
 version = "0.1.0"
 dependencies = [
  "bytes 0.5.4",
- "futures 0.3.4",
+ "futures",
  "iml-fs",
  "iml-manager-env",
  "pretty_assertions",
@@ -1313,7 +1319,7 @@ dependencies = [
  "console",
  "dialoguer",
  "dotenv",
- "futures 0.3.4",
+ "futures",
  "hostlist-parser",
  "iml-manager-client",
  "iml-wire-types",
@@ -1364,7 +1370,7 @@ dependencies = [
 name = "iml-ostpool"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "futures-util",
  "iml-postgres",
  "iml-service-queue",
@@ -1378,7 +1384,7 @@ dependencies = [
 name = "iml-postgres"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "iml-manager-env",
  "tokio-postgres",
  "tracing",
@@ -1388,7 +1394,7 @@ dependencies = [
 name = "iml-postoffice"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "iml-rabbit",
  "iml-service-queue",
  "iml-wire-types",
@@ -1401,10 +1407,10 @@ dependencies = [
 name = "iml-rabbit"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "iml-manager-env",
  "iml-wire-types",
- "lapin-futures",
+ "lapin",
  "serde_json",
  "tokio",
  "tracing",
@@ -1415,7 +1421,7 @@ dependencies = [
 name = "iml-request-retry"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "http 0.2.0",
  "rand 0.7.3",
  "rand_xorshift 0.2.0",
@@ -1433,7 +1439,7 @@ dependencies = [
 name = "iml-service-queue"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "iml-rabbit",
  "iml-wire-types",
  "serde",
@@ -1445,7 +1451,7 @@ dependencies = [
 name = "iml-timer"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "iml-cmd",
  "iml-manager-client",
  "iml-manager-env",
@@ -1462,7 +1468,7 @@ dependencies = [
 name = "iml-util"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "iml-wire-types",
  "serde",
  "serde_json",
@@ -1474,7 +1480,7 @@ dependencies = [
 name = "iml-warp-drive"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "im",
  "iml-manager-client",
  "iml-manager-env",
@@ -1632,21 +1638,11 @@ dependencies = [
  "amq-protocol",
  "amq-protocol-codegen",
  "crossbeam-channel",
+ "futures-core",
  "log 0.4.8",
  "mio",
  "parking_lot 0.10.0",
  "serde_json",
-]
-
-[[package]]
-name = "lapin-futures"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b394ba17e07251555988f7a7fb8452e4e56833bdf2965d9b1e614bcf78a3db"
-dependencies = [
- "futures 0.1.29",
- "lapin",
- "log 0.4.8",
 ]
 
 [[package]]
@@ -1670,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 
 [[package]]
 name = "libloading"
@@ -1878,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "mockito"
-version = "0.22.0"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e524e85ea7c80559354217a6470c14abc2411802a9996aed1821559b9e28e3c"
+checksum = "ae82e6bad452dd42b0f4437414eae3c8c27b958a55dc6c198e351042c4e3024e"
 dependencies = [
  "assert-json-diff",
  "colored",
@@ -1888,7 +1884,7 @@ dependencies = [
  "httparse",
  "lazy_static",
  "log 0.4.8",
- "percent-encoding 1.0.1",
+ "percent-encoding",
  "rand 0.7.3",
  "regex",
  "serde_json",
@@ -2118,12 +2114,6 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-
-[[package]]
-name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
@@ -2345,11 +2335,35 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e202b6302b80433b759eb9314be63521361a6622f6c125fe0dc3f6196e2722"
+dependencies = [
+ "proc-macro-error-attr 0.3.4",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
+]
+
+[[package]]
+name = "proc-macro-error"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052b3c9af39c7e5e94245f820530487d19eb285faedcb40e0c3275132293f242"
 dependencies = [
- "proc-macro-error-attr",
+ "proc-macro-error-attr 0.4.9",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "rustversion",
+ "syn 1.0.14",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d140e22ca819b3aa3719d1aafbdea40544799e3f901886a4ee72c3ff710de7c9"
+dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
  "rustversion",
@@ -2708,7 +2722,7 @@ dependencies = [
  "mime 0.3.16",
  "mime_guess 2.0.1",
  "native-tls",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite",
  "serde",
  "serde_json",
@@ -3135,7 +3149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "095064aa1f5b94d14e635d0a5684cf140c43ae40a0fd990708d38f5d669e5f64"
 dependencies = [
  "heck",
- "proc-macro-error",
+ "proc-macro-error 0.4.9",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
  "syn 1.0.14",
@@ -3363,10 +3377,10 @@ dependencies = [
  "byteorder",
  "bytes 0.5.4",
  "fallible-iterator",
- "futures 0.3.4",
+ "futures",
  "log 0.4.8",
  "parking_lot 0.10.0",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "phf 0.8.0",
  "pin-project-lite",
  "postgres-protocol",
@@ -3379,7 +3393,7 @@ dependencies = [
 name = "tokio-runtime-shutdown"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures",
  "stream-cancel",
  "tokio",
  "tokio-test",
@@ -3634,7 +3648,7 @@ checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
  "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -3740,7 +3754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce153bc4ad61ed81c255cad4f1bf2474a1d284b482b20eecaefb152d0675fb1b"
 dependencies = [
  "bytes 0.5.4",
- "futures 0.3.4",
+ "futures",
  "headers",
  "http 0.2.0",
  "hyper",

--- a/iml-agent-comms/Cargo.toml
+++ b/iml-agent-comms/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3"
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
-iml-rabbit = { path = "../iml-rabbit", version = "0.1.0", features = ["client-filter"]}
+iml-rabbit = { path = "../iml-rabbit", version = "0.1.0", features = ["warp-filters"]}
 iml-manager-env = { path = "../iml-manager-env", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"

--- a/iml-agent-comms/src/messaging.rs
+++ b/iml-agent-comms/src/messaging.rs
@@ -4,7 +4,8 @@
 
 use futures::{Future, Stream};
 use iml_rabbit::{
-    basic_consume, declare_transient_queue, BasicConsumeOptions, Channel, Client, ImlRabbitError,
+    basic_consume, declare_transient_queue, BasicConsumeOptions, Channel, Connection,
+    ImlRabbitError,
 };
 use iml_wire_types::{Fqdn, Id, ManagerMessage, Message, PluginMessage, PluginName, Seq};
 
@@ -77,7 +78,7 @@ pub fn terminate_agent_session(
     plugin: PluginName,
     fqdn: Fqdn,
     session_id: Id,
-    client: Client,
+    client: Connection,
 ) -> impl Future<Output = Result<(), ImlRabbitError>> {
     iml_rabbit::send_message(
         client,

--- a/iml-agent/Cargo.toml
+++ b/iml-agent/Cargo.toml
@@ -39,7 +39,7 @@ structopt = "0.2"
 tokio = { version = "0.2", features = ["fs", "process", "macros", "net"] }
 tokio-util = { version = "0.2", features = ["codec"] }
 tracing = "0.1"
-tracing-subscriber = "0.1"
+tracing-subscriber = "0.2"
 url = "2.1"
 uuid = { version = "0.7", features = ["v4"] }
 v_hist = "0.1.2"
@@ -52,7 +52,7 @@ default-features = false
 features = ["std"]
 
 [dev-dependencies]
-mockito = "0.22.0"
+mockito = "0.23"
 pretty_assertions = "0.6.1"
 insta = "0.12"
 tempfile = "3.1.0"

--- a/iml-api/Cargo.toml
+++ b/iml-api/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 futures = "0.3"
 iml-job-scheduler-rpc = { path = "../iml-job-scheduler-rpc", version = "0.1" }
 iml-manager-env = { path = "../iml-manager-env", version = "0.1" }
-iml-rabbit = { path = "../iml-rabbit", version = "0.1.0", features = ["client-filter"] }
+iml-rabbit = { path = "../iml-rabbit", version = "0.1.0", features = ["warp-filters"] }
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"

--- a/iml-rabbit/Cargo.toml
+++ b/iml-rabbit/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["IML Team <iml@whamcloud.com>"]
 edition = "2018"
 
 [dependencies]
-futures = { version = "0.3", features = ["compat"] }
+futures = "0.3"
 iml-manager-env = { path = "../iml-manager-env", version = "0.1.0" }
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
-lapin-futures = "0.28.4"
+lapin = { version = "0.28.4", features = ["futures"] }
 serde_json = "1"
 tracing = "0.1"
 warp = { version = "0.2", optional = true }
@@ -17,4 +17,4 @@ warp = { version = "0.2", optional = true }
 tokio = { version = "0.2", features = ["macros"] }
 
 [features]
-client-filter = ["warp"]
+warp-filters = ["warp"]

--- a/iml-services/iml-action-runner/Cargo.toml
+++ b/iml-services/iml-action-runner/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 warp = "0.2"
 iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
-iml-rabbit = { path = "../../iml-rabbit", version = "0.1.0", features = ["client-filter"]}
+iml-rabbit = { path = "../../iml-rabbit", version = "0.1.0", features = ["warp-filters"]}
 iml-manager-env = { path = "../../iml-manager-env", version = "0.1.0" }
 iml-service-queue = { path = "../iml-service-queue", version = "0.1.0" }
 iml-util = { path = "../../iml-util", version = "0.1.0" }

--- a/iml-services/iml-action-runner/src/main.rs
+++ b/iml-services/iml-action-runner/src/main.rs
@@ -9,7 +9,7 @@ use iml_action_runner::{
     data::SessionToRpcs, local_actions::SharedLocalActionsInFlight, receiver::handle_agent_data,
     sender::sender, Sessions, Shared,
 };
-use iml_rabbit::create_client_filter;
+use iml_rabbit::create_connection_filter;
 use iml_service_queue::service_queue::{consume_service_queue, ImlServiceQueueError};
 use iml_util::tokio_utils::get_tcp_or_unix_listener;
 use std::{collections::HashMap, sync::Arc};
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let log = warp::log("iml_action_runner::sender");
 
-    let (fut, client_filter) = create_client_filter().await?;
+    let (fut, client_filter) = create_connection_filter().await?;
 
     tokio::spawn(fut);
 

--- a/iml-services/iml-action-runner/src/receiver.rs
+++ b/iml-services/iml-action-runner/src/receiver.rs
@@ -6,7 +6,7 @@ use crate::{
     data::{create_data_message, remove_action_in_flight, SessionToRpcs},
     Sessions, Shared,
 };
-use iml_rabbit::{send_message, Client};
+use iml_rabbit::{send_message, Connection};
 use iml_wire_types::{ActionResult, Fqdn, Id, PluginMessage};
 
 pub static AGENT_TX_RUST: &str = "agent_tx_rust";
@@ -27,7 +27,7 @@ fn terminate_session(fqdn: &Fqdn, sessions: &mut Sessions, session_to_rpcs: &mut
 }
 
 async fn create_session(
-    client: Client,
+    client: Connection,
     sessions: Shared<Sessions>,
     rpcs: Shared<SessionToRpcs>,
     fqdn: Fqdn,
@@ -113,7 +113,7 @@ async fn handle_data(
 }
 
 pub async fn handle_agent_data(
-    client: Client,
+    client: Connection,
     m: PluginMessage,
     sessions: Shared<Sessions>,
     rpcs: Shared<SessionToRpcs>,

--- a/iml-services/iml-action-runner/src/sender.rs
+++ b/iml-services/iml-action-runner/src/sender.rs
@@ -12,7 +12,7 @@ use crate::{
     ActionType, Sessions, Shared,
 };
 use futures::{channel::oneshot, TryFutureExt};
-use iml_rabbit::{send_message, Client};
+use iml_rabbit::{send_message, Connection};
 use iml_wire_types::{Action, ActionId, Id, ManagerMessage};
 use std::{sync::Arc, time::Duration};
 use warp::{self, Filter};
@@ -24,7 +24,7 @@ use warp::{self, Filter};
 ///
 /// If unsuccessful, this fn will keep the `ActionInFlight` within the rpcs.
 async fn cancel_running_action(
-    client: Client,
+    client: Connection,
     msg: ManagerMessage,
     queue_name: impl Into<String>,
     session_id: Id,
@@ -62,7 +62,7 @@ pub fn sender(
     sessions: Shared<Sessions>,
     session_to_rpcs: Shared<SessionToRpcs>,
     local_actions: SharedLocalActionsInFlight,
-    client_filter: impl Filter<Extract = (Client,), Error = warp::Rejection> + Clone + Send,
+    client_filter: impl Filter<Extract = (Connection,), Error = warp::Rejection> + Clone + Send,
 ) -> impl Filter<Extract = (Result<serde_json::Value, String>,), Error = warp::Rejection> + Clone {
     let queue_name = queue_name.into();
 
@@ -81,7 +81,7 @@ pub fn sender(
         move |shared_sessions: Shared<Sessions>,
               shared_session_to_rpcs: Shared<SessionToRpcs>,
               local_actions: SharedLocalActionsInFlight,
-              client: Client,
+              client: Connection,
               queue_name: String,
               action_type: ActionType| {
             async move {

--- a/iml-services/iml-service-queue/src/service_queue.rs
+++ b/iml-services/iml-service-queue/src/service_queue.rs
@@ -4,8 +4,8 @@
 
 use futures::{future, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use iml_rabbit::{
-    basic_consume, connect_to_queue, connect_to_rabbit, purge_queue, BasicConsumeOptions, Client,
-    ImlRabbitError,
+    basic_consume, connect_to_queue, connect_to_rabbit, purge_queue, BasicConsumeOptions,
+    Connection, ImlRabbitError,
 };
 use iml_wire_types::{Fqdn, PluginMessage};
 
@@ -51,7 +51,7 @@ impl From<serde_json::error::Error> for ImlServiceQueueError {
 ///
 /// This is expected to be called once during startup.
 pub fn consume_service_queue(
-    client: Client,
+    client: Connection,
     name: &'static str,
 ) -> impl Stream<Item = Result<PluginMessage, ImlServiceQueueError>> {
     let name2 = name.to_string();

--- a/iml-warp-drive/src/locks.rs
+++ b/iml-warp-drive/src/locks.rs
@@ -3,12 +3,12 @@
 // license that can be found in the LICENSE file.
 
 use crate::request::Request;
-use futures::Stream as Stream03;
+use futures::Stream;
 use im::{HashMap, HashSet};
 use iml_rabbit::{
     basic_consume, basic_publish, bind_queue, create_channel, declare_transient_exchange,
-    declare_transient_queue, message::Delivery, purge_queue, BasicConsumeOptions, Channel, Client,
-    ExchangeKind, ImlRabbitError, Queue,
+    declare_transient_queue, message::Delivery, purge_queue, BasicConsumeOptions, Channel,
+    Connection, ExchangeKind, ImlRabbitError, Queue,
 };
 use iml_wire_types::{LockAction, LockChange, ToCompositeId};
 
@@ -29,9 +29,9 @@ async fn declare_locks_queue(c: Channel) -> Result<(Channel, Queue), ImlRabbitEr
 ///
 /// This is expected to be called once during startup.
 pub async fn create_locks_consumer(
-    client: Client,
-) -> Result<impl Stream03<Item = Result<Delivery, ImlRabbitError>>, ImlRabbitError> {
-    let channel = create_channel(client).await?;
+    conn: Connection,
+) -> Result<impl Stream<Item = Result<Delivery, ImlRabbitError>>, ImlRabbitError> {
+    let channel = create_channel(&conn).await?;
     let channel = declare_rpc_exchange(channel).await?;
     let (channel, queue) = declare_locks_queue(channel).await?;
 


### PR DESCRIPTION
The lapin crate provides futures 03 compatibility behind a feature.

Switch to using lapin instead of lapin-futures which was futures 01 based
and need compatibility shims.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1601)
<!-- Reviewable:end -->
