### PR TITLE
Do not load docker images in RPM %post block

### DIFF
--- a/iml-docker.service
+++ b/iml-docker.service
@@ -9,6 +9,7 @@ RemainAfterExit=yes
 StandardError=journal
 StandardOutput=journal
 WorkingDirectory=/etc/iml-docker
+ExecStartPre=-/usr/bin/docker load -i /var/tmp/iml-images.tgz
 ExecStart=/usr/bin/docker stack deploy -c docker-compose.yml -c docker-compose.overrides.yml iml --resolve-image=never
 ExecStop=/usr/bin/docker stack rm iml
 ExecStop=/bin/bash -c 'while /usr/bin/docker stack ps iml > /dev/null 2>&1; do sleep 1; done'

--- a/iml-docker.spec
+++ b/iml-docker.spec
@@ -40,9 +40,6 @@ mv iml-docker.service %{buildroot}%{_unitdir}
 
 %post
 systemctl preset iml-docker.service
-systemctl enable --now docker
-docker load -i %{_tmppath}/iml-images.tgz
-
 
 %preun
 %systemd_preun iml-docker.service


### PR DESCRIPTION
Instead, attempt to load them when starting the iml-docker.service.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1602)
<!-- Reviewable:end -->
