### PR TITLE
Make `Msg` debuggable

### DIFF
--- a/iml-gui/crate/src/auth.rs
+++ b/iml-gui/crate/src/auth.rs
@@ -34,7 +34,7 @@ impl Default for State {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Msg {
     Fetch,
     Fetched(fetch::ResponseDataResult<Session>),

--- a/iml-gui/crate/src/components/action_dropdown/confirm_action_modal.rs
+++ b/iml-gui/crate/src/components/action_dropdown/confirm_action_modal.rs
@@ -28,7 +28,7 @@ pub struct Model {
     pub modal: modal::Model,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Msg {
     SendJob(String, Arc<AvailableAction>),
     JobSent(Box<fetch::ResponseDataResult<Command>>),
@@ -97,7 +97,7 @@ pub(crate) fn view(action: &Action) -> Node<Msg> {
     };
 
     let confirm_msg2 = confirm_msg.clone();
-
+    log!("modal::bg_view");
     modal::bg_view(
         true,
         Msg::Modal,

--- a/iml-gui/crate/src/components/action_dropdown/mod.rs
+++ b/iml-gui/crate/src/components/action_dropdown/mod.rs
@@ -53,7 +53,7 @@ fn has_locks(locks: &Locks, composite_ids: &[CompositeId]) -> bool {
     locked_items(locks, composite_ids).next().is_some()
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IdMsg(pub u32, pub Msg);
 
 pub enum State {
@@ -116,7 +116,7 @@ impl Drop for Model {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Msg {
     StartFetch,
     SendFetch,

--- a/iml-gui/crate/src/components/modal.rs
+++ b/iml-gui/crate/src/components/modal.rs
@@ -8,7 +8,7 @@ pub struct Model {
 
 type ParentMsg<T> = fn(Msg) -> T;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum Msg {
     KeyDown(u32),
     Close,

--- a/iml-gui/crate/src/components/paging.rs
+++ b/iml-gui/crate/src/components/paging.rs
@@ -67,7 +67,7 @@ impl Model {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Msg {
     SetTotal(usize),
     SetOffset(usize),

--- a/iml-gui/crate/src/components/tree.rs
+++ b/iml-gui/crate/src/components/tree.rs
@@ -377,7 +377,7 @@ fn remove_item(
     Some(())
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Msg {
     Add(RecordId),
     Remove(RecordId),

--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -219,7 +219,7 @@ fn sink(g_msg: GMsg, _model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
 // ------ ------
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Msg {
     RouteChanged(Url),
     UpdatePageTitle,

--- a/iml-gui/crate/src/notification.rs
+++ b/iml-gui/crate/src/notification.rs
@@ -10,7 +10,7 @@ pub(crate) struct Model {
     svc: Option<ServiceWorkerRegistration>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Msg {
     Close,
     Display(String, String),

--- a/iml-gui/crate/src/page/login.rs
+++ b/iml-gui/crate/src/page/login.rs
@@ -1,4 +1,5 @@
 use crate::{auth, components::ddn_logo, generated::css_classes::C, FailReasonExt, GMsg, MergeAttrs, Route};
+use core::fmt;
 use iml_wire_types::Session;
 use seed::{browser::service::fetch, prelude::*, *};
 
@@ -37,6 +38,15 @@ pub enum Msg {
     Submit,
     GetSession,
     GotSession(fetch::ResponseDataResult<Session>),
+}
+
+impl fmt::Debug for Msg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PasswordChange(_) => f.write_str("*****"),
+            _ => write!(f, "{:?}", self),
+        }
+    }
 }
 
 async fn login(form: Form) -> Result<Msg, Msg> {

--- a/iml-gui/crate/src/page/servers.rs
+++ b/iml-gui/crate/src/page/servers.rs
@@ -36,7 +36,7 @@ pub struct Model {
     sort: (SortField, paging::Dir),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Msg {
     SetHosts(Vec<Host>, im::HashMap<u32, Arc<LnetConfigurationRecord>>),
     Page(paging::Msg),

--- a/iml-wire-types/src/warp_drive.rs
+++ b/iml-wire-types/src/warp_drive.rs
@@ -182,8 +182,8 @@ impl Cache {
 /// A `Record` with it's concrete type erased.
 /// The returned item implements the `Label` and `EndpointName`
 /// traits.
-pub trait ErasedRecord: Label + EndpointNameSelf + Id {}
-impl<T: Label + EndpointNameSelf + Id + ToCompositeId> ErasedRecord for T {}
+pub trait ErasedRecord: Label + EndpointNameSelf + Id + core::fmt::Debug {}
+impl<T: Label + EndpointNameSelf + Id + ToCompositeId + core::fmt::Debug> ErasedRecord for T {}
 
 fn erase(x: Arc<impl ErasedRecord + 'static>) -> Box<Arc<dyn ErasedRecord>> {
     Box::new(x)


### PR DESCRIPTION
The rationale: the `iml-gui` becomes more and more complex, and as the time goes it becomes harder to track the message flow within the application.
This PR adds Debug for messages for the components, so that if one adds `log!` call somewhere, e.g.:
```rust
pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
    log!("msg = {:?}", msg);  // <<< THIS
    match msg {
         ...
   }
}
```

He or she then can see in the console (and although this log output is pretty verbose, it makes easier to track the message flow)
```
"Starting app..."
"msg = {:?}" UpdatePageTitle
"msg = {:?}" Auth(
    Fetch,
)
"msg = {:?}" RouteChanged(
    Url {
        path: [
            "",
        ],
        search: None,
        hash: None,
        title: None,
    },
)
"msg = {:?}" UpdatePageTitle
"msg = {:?}" LoadPage
"App started."
"msg = {:?}" Notification(
    SetSVCWorker(
        JsValue(ServiceWorkerRegistration),
    ),
)
"msg = {:?}" EventSourceConnect(
    JsValue(Event),
)
"EventSource connected."
"msg = {:?}" EventSourceMessage(
    MessageEvent {
        obj: Event {
            obj: Object {
                obj: JsValue(MessageEvent),
            },
        },
    },
)
"msg = {:?}" Records(
    Cache {...}
"msg = {:?}" Notification(
    Nothing,
)
"msg = {:?}" ServersPage(
    SetHosts(
        [
            Host { ... },
            Host { ... },
        ],
    ),
)
"msg = {:?}" Tree(
    Reset,
)
"msg = {:?}" EventSourceMessage(
    MessageEvent {
        obj: Event {
            obj: Object {
                obj: JsValue(MessageEvent),
            },
        },
    },
)
"msg = {:?}" Locks(
    {},
)
"msg = {:?}" LoadPage
"msg = {:?}" Auth(
    Fetched(
        Ok(
            Session {
                read_enabled: true,
                resource_uri: "/api/session/",
                user: Some(
                    User {
                        alert_subscriptions: Some(
                            [],
                        ),
                        email: "",
                        first_name: "",
                        full_name: "",
                        groups: Some(
                            [
                                Group {
                                    id: 1,
                                    name: Superusers,
                                    resource_uri: "/api/group/1/",
                                },
                            ],
                        ),
                        id: 1,
                        is_superuser: true,
                        last_name: "",
                        new_password1: None,
                        new_password2: None,
                        password1: None,
                        password2: None,
                        resource_uri: "/api/user/1/",
                        username: "admin",
                    },
                ),
            },
        ),
    ),
)
"msg = {:?}" Auth(
    Loop,
)
"msg = {:?}" WindowResize
"msg = {:?}" Auth(
    Loop,
)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1604)
<!-- Reviewable:end -->
