### PR TITLE
Refactor number-formatter to use integers

### DIFF
--- a/iml-gui/crate/src/components/tree.rs
+++ b/iml-gui/crate/src/components/tree.rs
@@ -700,7 +700,7 @@ fn tree_volume_collection_view(cache: &ArcCache, model: &Model, parent_address: 
                     let v = cache.volume.values().find(|v| v.id == x.volume_id).unwrap();
 
                     let size = match v.size {
-                        Some(x) => format!(" ({})", number_formatter::format_bytes(x as f64, None)),
+                        Some(x) => format!(" ({})", number_formatter::format_bytes(x as u64, None)),
                         None => "".into(),
                     };
 

--- a/iml-gui/crate/src/page/filesystem.rs
+++ b/iml-gui/crate/src/page/filesystem.rs
@@ -158,9 +158,9 @@ pub(crate) fn size_view<I>(f: &Filesystem) -> Node<I> {
         span![
             class![C.whitespace_no_wrap],
             pie_chart(u / t).merge_attrs(class![C.h_8, C.inline, C.mx_2]),
-            NF::format_bytes(u, None),
+            NF::format_bytes(u as u64, None),
             " / ",
-            NF::format_bytes(t, None)
+            NF::format_bytes(t as u64, None)
         ]
     } else {
         plain!("N/A")
@@ -169,13 +169,12 @@ pub(crate) fn size_view<I>(f: &Filesystem) -> Node<I> {
 
 fn files_view<I>(fs: &Filesystem) -> Node<I> {
     if let Some((u, t)) = fs.files_total.and_then(|t| fs.files_free.map(|f| (t - f, t))) {
-        log!("used: {}, total: {}", u, t);
         span![
             class![C.whitespace_no_wrap],
             pie_chart(u / t).merge_attrs(class![C.h_8, C.inline, C.mx_2]),
-            NF::format_number(u, None),
+            NF::format_number(u as u64, None),
             " / ",
-            NF::format_number(t, None)
+            NF::format_number(t as u64, None)
         ]
     } else {
         plain!("N/A")
@@ -214,7 +213,7 @@ fn volume_link<I>(cache: &ArcCache, t: &Target<TargetConfParam>) -> Node<I> {
             .volume
             .arc_values()
             .find(|v| v.id == vol_id)
-            .map(|v| format!("({})", number_formatter::format_bytes(v.size.unwrap() as f64, None)))
+            .map(|v| format!("({})", number_formatter::format_bytes(v.size.unwrap() as u64, None)))
             .unwrap();
         a![
             class![C.whitespace_no_wrap, C.text_blue_500, C.hover__underline, C.block],

--- a/iml-manager-cli/src/filesystem.rs
+++ b/iml-manager-cli/src/filesystem.rs
@@ -36,15 +36,15 @@ pub enum FilesystemCommand {
 fn usage(
     free: Option<f64>,
     total: Option<f64>,
-    formatter: fn(f64, Option<usize>) -> String,
+    formatter: fn(u64, Option<usize>) -> String,
 ) -> String {
     match (free, total) {
-        (Some(free), Some(total)) => format!(
+        (Some(free), Some(total)) if total >= free => format!(
             "{} / {}",
-            formatter(total - free, Some(0)),
-            formatter(total, Some(0))
+            formatter((total - free) as u64, Some(0)),
+            formatter(total as u64, Some(0))
         ),
-        (None, Some(total)) => format!("Calculating ... / {}", formatter(total, Some(0))),
+        (None, Some(total)) => format!("Calculating ... / {}", formatter(total as u64, Some(0))),
         _ => "Calculating ...".to_string(),
     }
 }
@@ -67,7 +67,7 @@ pub async fn filesystem_cli(command: FilesystemCommand) -> Result<(), ImlManager
                         f.state,
                         usage(f.bytes_free, f.bytes_total, format_bytes),
                         usage(f.files_free, f.files_total, format_number),
-                        format_number(f.client_count.unwrap_or(0.0), Some(0)),
+                        format_number(f.client_count.unwrap_or(0.0) as u64, Some(0)),
                         f.mdts.len().to_string(),
                         f.osts.len().to_string(),
                     ]

--- a/iml-wasm-components/iml-fs/src/lib.rs
+++ b/iml-wasm-components/iml-fs/src/lib.rs
@@ -40,10 +40,10 @@ fn mgt_link<T>(mgt: Option<&Target<TargetConfParam>>) -> Node<T> {
 fn usage<T>(
     used: Option<f64>,
     total: Option<f64>,
-    formatter: fn(f64, Option<usize>) -> String,
+    formatter: fn(u64, Option<usize>) -> String,
 ) -> Node<T> {
     div![match (used, total) {
-        (Some(used), Some(total)) => {
+        (Some(used), Some(total)) if total >= used => {
             let mut pc = pie_chart(used, total, "#aec7e8", "#1f77b4");
             pc.add_style("width", px(18))
                 .add_style("height", px(18))
@@ -51,9 +51,9 @@ fn usage<T>(
                 .add_style("margin-right", px(3));
             div![
                 pc,
-                formatter(used, Some(1)),
+                formatter(used as u64, Some(1)),
                 " / ",
-                formatter(total, Some(1)),
+                formatter(total as u64, Some(1)),
             ]
         }
         _ => Node::new_text("Calculating..."),

--- a/iml-wasm-components/iml-stratagem/src/inode_table.rs
+++ b/iml-wasm-components/iml-stratagem/src/inode_table.rs
@@ -173,7 +173,7 @@ fn get_inode_elements<T>(inodes: &Vec<INodeCount>) -> Vec<Node<T>> {
             tr![
                 td![x.uid],
                 td![x.count.to_string()],
-                td![format_bytes(x.size as f64, None)]
+                td![format_bytes(x.size as u64, None)]
             ]
         })
         .collect()

--- a/number-formatter/src/lib.rs
+++ b/number-formatter/src/lib.rs
@@ -1,47 +1,33 @@
-// Copyright (c) 2019 DDN. All rights reserved.
+// Copyright (c) 2019-2020 DDN. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use std::cmp;
+static PREFIXES: [&str; 9] = ["", "K", "M", "G", "T", "P", "E", "Z", "Y"];
 
-/// Format number given a precision, suffix and either 1000 or 1024 based Kilo
-///
-pub fn format(num: f64, precision: Option<usize>, suffix: &str, order2: bool) -> String {
-    let units = ["", "K", "M", "G", "T", "P", "E", "Z", "Y"];
-
-    let denominator = if order2 { 1024_f64 } else { 1000_f64 };
-    let precision = precision.unwrap_or(1);
-
-    let sign = if num < 0_f64 { "-" } else { "" };
-    let num = num.abs();
-
-    let pwr = (num.ln() / denominator.ln()).floor() as i32;
-    let pwr = cmp::min(pwr, (units.len() - 1) as i32);
-    let pwr = cmp::max(pwr, 0);
-
-    let num = num / denominator.powi(pwr);
-
-    let unit = units[pwr as usize];
-
-    if !suffix.is_empty() {
-        if order2 && !unit.is_empty() {
-            format!("{}{:.*} {}i{}", sign, precision, num, unit, suffix)
-        } else {
-            format!("{}{:.*} {}{}", sign, precision, num, unit, suffix)
-        }
-    } else if !unit.is_empty() {
-        format!("{}{:.*}{}", sign, precision, num, unit)
+pub fn format_bytes(bytes: u64, precision: Option<usize>) -> String {
+    let (s, exp) = normalize(bytes, precision, 1024);
+    if exp > 0 {
+        format!("{} {}iB", s, PREFIXES[exp as usize])
     } else {
-        format!("{}{:.*}", sign, precision, num)
+        format!("{} B", s)
     }
 }
 
-pub fn format_bytes(bytes: f64, precision: Option<usize>) -> String {
-    format(bytes, precision, "B", true)
+pub fn format_number(num: u64, precision: Option<usize>) -> String {
+    let (s, exp) = normalize(num, precision, 1000);
+    if exp > 0 {
+        format!("{}{}", s, PREFIXES[exp as usize])
+    } else {
+        s
+    }
 }
 
-pub fn format_number(num: f64, precision: Option<usize>) -> String {
-    format(num, precision, "", false)
+fn normalize(num: u64, precision: Option<usize>, base: u64) -> (String, u32) {
+    let exp = ((num as f64).ln() / (base as f64).ln()).floor() as u32;
+    let significand = num as f64 / base.pow(exp) as f64;
+
+    let prcsn = if exp > 0 { precision.unwrap_or(1) } else { 0 };
+    (format!("{:.*}", prcsn, significand), exp)
 }
 
 #[cfg(test)]
@@ -49,42 +35,38 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_format_bytes_success() {
-        assert_eq!(format_bytes(320.0, Some(0)), "320 B");
-        assert_eq!(format_bytes(200_000.0, Some(1)), "195.3 KiB");
-        assert_eq!(format_bytes(3_124_352.0, Some(3)), "2.980 MiB");
-        assert_eq!(format_bytes(432_303_020_202.0, Some(3)), "402.614 GiB");
-        assert_eq!(format_bytes(5_323_330_102_372.0, Some(2)), "4.84 TiB");
-        assert_eq!(format_bytes(1000.0, Some(0)), "1000 B");
-        assert_eq!(format_bytes(1024.0, Some(3)), "1.000 KiB");
-        assert_eq!(format_bytes(4326.0, Some(4)), "4.2246 KiB");
-        assert_eq!(format_bytes(3_045_827_469.0, Some(3)), "2.837 GiB");
-        assert_eq!(format_bytes(84_567_942_345_572_238.0, Some(2)), "75.11 PiB");
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(1000, Some(0)), "1000 B");
+        assert_eq!(format_bytes(1024, Some(3)), "1.000 KiB");
+        assert_eq!(format_bytes(139_083_776, Some(1)), "132.6 MiB");
+        assert_eq!(format_bytes(200_000, Some(1)), "195.3 KiB");
+        assert_eq!(format_bytes(3_045_827_469, Some(3)), "2.837 GiB");
+        assert_eq!(format_bytes(3_124_352, Some(3)), "2.980 MiB");
+        assert_eq!(format_bytes(4326, Some(4)), "4.2246 KiB");
+        assert_eq!(format_bytes(432_303_020_202, Some(3)), "402.614 GiB");
         assert_eq!(
-            format_bytes(5_213_456_204_567_832_146_028.0, Some(3)),
-            "4.416 ZiB"
+            format_bytes(5_213_456_204_567_832_028, Some(3)),
+            "4.522 EiB"
         );
-        assert_eq!(format_bytes(139_083_776.0, Some(1)), "132.6 MiB");
+        assert_eq!(format_bytes(5_323_330_102_372, Some(2)), "4.84 TiB");
+        assert_eq!(format_bytes(84_567_942_345_572_238, Some(2)), "75.11 PiB");
     }
 
     #[test]
-    fn test_format_number_success() {
-        assert_eq!(format_number(22.0, Some(10)), "22.0000000000");
-        assert_eq!(format_number(22.3, Some(10)), "22.3000000000");
-        assert_eq!(format_number(22.3, Some(2)), "22.30");
-        assert_eq!(format_number(22.3, Some(1)), "22.3");
-        assert_eq!(format_number(0.023, Some(5)), "0.02300");
-        assert_eq!(format_number(0.023, Some(1)), "0.0");
-        assert_eq!(format_number(8007.0, Some(5)), "8.00700K");
-        assert_eq!(format_number(8007.0, Some(3)), "8.007K");
-        assert_eq!(format_number(8007.0, Some(2)), "8.01K");
-        assert_eq!(format_number(8_007_000.0, Some(5)), "8.00700M");
-        assert_eq!(format_number(8_007_000_000.0, Some(1)), "8.0G");
-        assert_eq!(format_number(8_007_000_000_000.0, Some(1)), "8.0T");
-        assert_eq!(format_number(800_700.0, Some(5)), "800.70000K");
-        assert_eq!(format_number(8200.0, Some(5)), "8.20000K");
-        assert_eq!(format_number(8200.0, Some(3)), "8.200K");
-        assert_eq!(format_number(8200.0, Some(1)), "8.2K");
-        assert_eq!(format_number(8200.0, Some(0)), "8K");
+    fn test_format_number() {
+        // TODO: assert_eq!(format_number(999999, Some(0)), "1M");
+        assert_eq!(format_number(123, Some(0)), "123");
+        assert_eq!(format_number(123, Some(3)), "123");
+        assert_eq!(format_number(8007, Some(2)), "8.01K");
+        assert_eq!(format_number(8007, Some(3)), "8.007K");
+        assert_eq!(format_number(8007, Some(5)), "8.00700K");
+        assert_eq!(format_number(800_700, Some(5)), "800.70000K");
+        assert_eq!(format_number(8200, Some(0)), "8K");
+        assert_eq!(format_number(8200, Some(1)), "8.2K");
+        assert_eq!(format_number(8200, Some(3)), "8.200K");
+        assert_eq!(format_number(8200, Some(5)), "8.20000K");
+        assert_eq!(format_number(8_007_000, Some(5)), "8.00700M");
+        assert_eq!(format_number(8_007_000_000, Some(1)), "8.0G");
+        assert_eq!(format_number(8_007_000_000_000, Some(3)), "8.007T");
     }
 }


### PR DESCRIPTION
Make it print precise numbers if they are small enough.

![number-formatter](https://user-images.githubusercontent.com/131844/75259211-518a3100-57f0-11ea-9e40-045d0e1b1f6e.png)

Closes #1567.