### PR TITLE
Fixup iml-gui deploy

### DIFF
--- a/.github/workflows/devel-release.yml
+++ b/.github/workflows/devel-release.yml
@@ -56,6 +56,7 @@ jobs:
           PROJECT: manager-for-lustre-devel
           PACKAGE: rust-iml-gui
           SPEC: iml-gui/rust-iml-gui.spec
+          SRPM_TASK: iml-gui-srpm
           WORKSPACE: ${{ github.workspace }}
           KEY: ${{ secrets.key }}
           IV: ${{ secrets.iv }}


### PR DESCRIPTION
The rust-iml-gui deploy job is missing the correct `SRPM_TASK`.

Add it in.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1611)
<!-- Reviewable:end -->
