### PR TITLE
Remove extra layer of boxing

### DIFF
--- a/iml-gui/crate/src/components/action_dropdown/mod.rs
+++ b/iml-gui/crate/src/components/action_dropdown/mod.rs
@@ -15,7 +15,7 @@ use seed::{prelude::*, *};
 use serde_json::json;
 use std::{collections::BTreeMap, iter, sync::Arc, time::Duration};
 
-type ActionMap = BTreeMap<String, Vec<(Arc<AvailableAction>, Box<Arc<dyn ErasedRecord>>)>>;
+type ActionMap = BTreeMap<String, Vec<(Arc<AvailableAction>, Arc<dyn ErasedRecord>)>>;
 
 type AvailableActions = ApiList<AvailableAction>;
 

--- a/iml-wire-types/src/warp_drive.rs
+++ b/iml-wire-types/src/warp_drive.rs
@@ -185,8 +185,8 @@ impl Cache {
 pub trait ErasedRecord: Label + EndpointNameSelf + Id {}
 impl<T: Label + EndpointNameSelf + Id + ToCompositeId> ErasedRecord for T {}
 
-fn erase(x: Arc<impl ErasedRecord + 'static>) -> Box<Arc<dyn ErasedRecord>> {
-    Box::new(x)
+fn erase(x: Arc<impl ErasedRecord + 'static>) -> Arc<dyn ErasedRecord> {
+    x
 }
 
 impl ArcCache {
@@ -253,7 +253,7 @@ impl ArcCache {
     pub fn get_erased_record(
         &self,
         composite_id: &CompositeId,
-    ) -> Option<Box<Arc<dyn ErasedRecord>>> {
+    ) -> Option<Arc<dyn ErasedRecord>> {
         let content_type = self.content_type.get(&composite_id.0)?;
 
         match content_type.model.as_ref() {

--- a/iml-wire-types/src/warp_drive.rs
+++ b/iml-wire-types/src/warp_drive.rs
@@ -250,10 +250,7 @@ impl ArcCache {
     }
     /// Given a `CompositeId`, returns an `ErasedRecord` if
     /// a matching one exists.
-    pub fn get_erased_record(
-        &self,
-        composite_id: &CompositeId,
-    ) -> Option<Arc<dyn ErasedRecord>> {
+    pub fn get_erased_record(&self, composite_id: &CompositeId) -> Option<Arc<dyn ErasedRecord>> {
         let content_type = self.content_type.get(&composite_id.0)?;
 
         match content_type.model.as_ref() {


### PR DESCRIPTION
`Arc` already allows storing unsized objects in it.

Remove additional boxing so we avoid extra allocation and indirection.

Signed-off-by: Michael Pankov <work@michaelpankov.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1615)
<!-- Reviewable:end -->
