### PR TITLE
Fixup wasm-pack install

### DIFF
--- a/.github/workflows/iml-gui.yml
+++ b/.github/workflows/iml-gui.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - run: cargo install wasm-pack
+      - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: wasm-pack test iml-gui/crate --headless --firefox
 
   check_rpm_build:

--- a/docker/iml-gui.dockerfile
+++ b/docker/iml-gui.dockerfile
@@ -7,7 +7,7 @@ RUN cd /build/iml-gui && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y yarn nodejs && \
     rustup target add wasm32-unknown-unknown && \
-    cargo install wasm-pack && \
+    curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh && \
     yarn install && \
     yarn build:release;
 


### PR DESCRIPTION
Due to breaking change in a patch bump of the `quote` crate,
wasm-pack doesn't compile.

Switch to using precompiled binaries.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1655)
<!-- Reviewable:end -->
