### PR TITLE
Fix NaN case in progress circle

### DIFF
--- a/iml-gui/crate/src/components/progress_circle.rs
+++ b/iml-gui/crate/src/components/progress_circle.rs
@@ -9,11 +9,15 @@ static RADIUS: f64 = 90.0;
 static CIRCUMFERENCE: f64 = 2.0 * std::f64::consts::PI * RADIUS;
 
 pub fn used_to_color(used: f64) -> &'static str {
-    match (used.round() as i64) * 100 {
-        75..=100 => C.text_red_500,
-        50..=74 => C.text_yellow_500,
-        0..=49 => C.text_green_500,
-        _ => C.text_gray_500,
+    if used.is_nan() {
+        C.text_gray_500
+    } else {
+        match (used.round() as u64) * 100 {
+            75..=100 => C.text_red_500,
+            50..=74 => C.text_yellow_500,
+            0..=49 => C.text_green_500,
+            _ => C.text_gray_500,
+        }
     }
 }
 


### PR DESCRIPTION
If the progress circle receives a NaN value in `used_to_color` it will
crash the application. We should make sure the used value isn't NaN
before attempting to round the value.

![image](https://user-images.githubusercontent.com/1100657/76008610-ea4e3a00-5edd-11ea-9895-0408e7e92e6a.png)


Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1658)
<!-- Reviewable:end -->
