### PR TITLE
Api config

### DIFF
--- a/chroma_core/management/commands/print-settings.py
+++ b/chroma_core/management/commands/print-settings.py
@@ -1,10 +1,11 @@
-# Copyright (c) 2018 DDN. All rights reserved.
+# Copyright (c) 2020 DDN. All rights reserved.
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
 import settings
 import glob
 import json
+import os
 from django.db import connection
 from django.core.management.commands.runserver import Command as BaseCommand
 
@@ -16,6 +17,18 @@ class Command(BaseCommand):
 
     help = """Prints out selected settings in env variable format"""
 
+    def _load_config(self, config_file):
+        config = {}
+        if os.path.exists(config_file):
+            with open(config_file) as file:
+                content = file.read()
+
+                for line in content.splitlines():
+                    key_val = line.split("=", 1)
+                    config[key_val[0]] = key_val[1]
+
+        return config
+
     def handle(self, *args, **kwargs):
         cursor = connection.cursor()
         cursor.execute("SELECT * from api_key()")
@@ -25,46 +38,51 @@ class Command(BaseCommand):
         source_map_paths = glob.glob("/usr/share/iml-manager/iml-gui/main*.map")
         SOURCE_MAP_PATH = next(iter(source_map_paths), None)
 
+        overrides = self._load_config(os.path.join("/var/lib/chroma-setup", "config"))
+
         DB = settings.DATABASES.get("default")
-        xs = map(
-            lambda x: "{0}={1}".format(x[0], x[1]),
-            [
-                ("REALTIME_PORT", settings.REALTIME_PORT),
-                ("VIEW_SERVER_PORT", settings.VIEW_SERVER_PORT),
-                ("WARP_DRIVE_PORT", settings.WARP_DRIVE_PORT),
-                ("MAILBOX_PORT", settings.MAILBOX_PORT),
-                ("DEVICE_AGGREGATOR_PORT", settings.DEVICE_AGGREGATOR_PORT),
-                ("HTTP_AGENT2_PORT", settings.HTTP_AGENT2_PORT),
-                ("HTTP_AGENT2_PROXY_PASS", settings.HTTP_AGENT2_PROXY_PASS),
-                ("IML_API_PORT", settings.IML_API_PORT),
-                ("IML_API_PROXY_PASS", settings.IML_API_PROXY_PASS),
-                ("ALLOW_ANONYMOUS_READ", json.dumps(settings.ALLOW_ANONYMOUS_READ)),
-                ("BUILD", settings.BUILD),
-                ("IS_RELEASE", json.dumps(settings.IS_RELEASE)),
-                ("LOG_PATH", settings.LOG_PATH),
-                ("SERVER_HTTP_URL", settings.SERVER_HTTP_URL),
-                ("SITE_ROOT", settings.SITE_ROOT),
-                ("VERSION", settings.VERSION),
-                ("API_USER", API_USER),
-                ("API_KEY", API_KEY),
-                ("SOURCE_MAP_PATH", SOURCE_MAP_PATH),
-                ("MAILBOX_PATH", settings.MAILBOX_PATH),
-                ("PROXY_HOST", settings.PROXY_HOST),
-                ("INFLUXDB_IML_DB", settings.INFLUXDB_IML_DB),
-                ("INFLUXDB_STRATAGEM_SCAN_DB", settings.INFLUXDB_STRATAGEM_SCAN_DB),
-                ("INFLUXDB_IML_STATS_DB", settings.INFLUXDB_IML_STATS_DB),
-                ("INFLUXDB_PORT", settings.INFLUXDB_PORT),
-                ("DB_HOST", DB.get("HOST")),
-                ("DB_NAME", DB.get("NAME")),
-                ("DB_USER", DB.get("USER")),
-                ("DB_PASSWORD", DB.get("PASSWORD")),
-                ("AMQP_BROKER_USER", settings.AMQP_BROKER_USER),
-                ("AMQP_BROKER_PASSWORD", settings.AMQP_BROKER_PASSWORD),
-                ("AMQP_BROKER_VHOST", settings.AMQP_BROKER_VHOST),
-                ("AMQP_BROKER_HOST", settings.AMQP_BROKER_HOST),
-                ("AMQP_BROKER_PORT", settings.AMQP_BROKER_PORT),
-                ("AMQP_BROKER_URL", settings.BROKER_URL),
-            ],
-        )
+
+        config = {
+            "REALTIME_PORT": settings.REALTIME_PORT,
+            "VIEW_SERVER_PORT": settings.VIEW_SERVER_PORT,
+            "WARP_DRIVE_PORT": settings.WARP_DRIVE_PORT,
+            "MAILBOX_PORT": settings.MAILBOX_PORT,
+            "DEVICE_AGGREGATOR_PORT": settings.DEVICE_AGGREGATOR_PORT,
+            "HTTP_AGENT2_PORT": settings.HTTP_AGENT2_PORT,
+            "HTTP_AGENT2_PROXY_PASS": settings.HTTP_AGENT2_PROXY_PASS,
+            "IML_API_PORT": settings.IML_API_PORT,
+            "IML_API_PROXY_PASS": settings.IML_API_PROXY_PASS,
+            "ALLOW_ANONYMOUS_READ": json.dumps(settings.ALLOW_ANONYMOUS_READ),
+            "BUILD": settings.BUILD,
+            "IS_RELEASE": json.dumps(settings.IS_RELEASE),
+            "LOG_PATH": settings.LOG_PATH,
+            "SERVER_HTTP_URL": settings.SERVER_HTTP_URL,
+            "SITE_ROOT": settings.SITE_ROOT,
+            "VERSION": settings.VERSION,
+            "API_USER": API_USER,
+            "API_KEY": API_KEY,
+            "SOURCE_MAP_PATH": SOURCE_MAP_PATH,
+            "MAILBOX_PATH": settings.MAILBOX_PATH,
+            "PROXY_HOST": settings.PROXY_HOST,
+            "INFLUXDB_IML_DB": settings.INFLUXDB_IML_DB,
+            "INFLUXDB_STRATAGEM_SCAN_DB": settings.INFLUXDB_STRATAGEM_SCAN_DB,
+            "INFLUXDB_IML_STATS_DB": settings.INFLUXDB_IML_STATS_DB,
+            "INFLUXDB_PORT": settings.INFLUXDB_PORT,
+            "DB_HOST": DB.get("HOST"),
+            "DB_NAME": DB.get("NAME"),
+            "DB_USER": DB.get("USER"),
+            "DB_PASSWORD": DB.get("PASSWORD"),
+            "AMQP_BROKER_USER": settings.AMQP_BROKER_USER,
+            "AMQP_BROKER_PASSWORD": settings.AMQP_BROKER_PASSWORD,
+            "AMQP_BROKER_VHOST": settings.AMQP_BROKER_VHOST,
+            "AMQP_BROKER_HOST": settings.AMQP_BROKER_HOST,
+            "AMQP_BROKER_PORT": settings.AMQP_BROKER_PORT,
+            "AMQP_BROKER_URL": settings.BROKER_URL,
+            "BRANDING": settings.BRANDING,
+            "USE_STRATAGEM": json.dumps(settings.USE_STRATAGEM),
+        }
+
+        config.update(overrides)
+        xs = map(lambda x: "{0}={1}".format(x[0], x[1]), config.items())
 
         print("\n".join(xs))

--- a/iml-api/src/main.rs
+++ b/iml-api/src/main.rs
@@ -6,7 +6,7 @@ mod action;
 mod error;
 
 use iml_rabbit::{self, create_connection_filter};
-use iml_wire_types::Conf;
+use iml_wire_types::{Conf};
 use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::Filter;
 
@@ -19,6 +19,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         build: iml_manager_env::get_build(),
         version: iml_manager_env::get_version(),
         is_release: iml_manager_env::get_is_release(),
+        branding: iml_manager_env::get_branding().into(),
+        use_stratagem: iml_manager_env::get_use_stratagem(),
     };
 
     let subscriber = Subscriber::builder()

--- a/iml-api/src/main.rs
+++ b/iml-api/src/main.rs
@@ -6,7 +6,7 @@ mod action;
 mod error;
 
 use iml_rabbit::{self, create_connection_filter};
-use iml_wire_types::{Conf};
+use iml_wire_types::Conf;
 use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::Filter;
 

--- a/iml-gui/crate/src/page/filesystem.rs
+++ b/iml-gui/crate/src/page/filesystem.rs
@@ -166,10 +166,22 @@ fn paging_view(pager: &paging::Model) -> Node<paging::Msg> {
     ]
 }
 
-pub(crate) fn view(cache: &ArcCache, model: &Model, all_locks: &Locks, session: Option<&Session>) -> Node<Msg> {
+pub(crate) fn view(
+    cache: &ArcCache,
+    model: &Model,
+    all_locks: &Locks,
+    session: Option<&Session>,
+    use_stratagem: bool,
+) -> Node<Msg> {
+    let stratagem_content = if use_stratagem {
+        stratagem::view(&model.stratagem, all_locks).map_msg(Msg::Stratagem)
+    } else {
+        empty![]
+    };
+
     div![
         details_table(cache, all_locks, model),
-        stratagem::view(&model.stratagem, all_locks).map_msg(Msg::Stratagem),
+        stratagem_content,
         targets(
             "Management Target",
             cache,

--- a/iml-gui/crate/src/page/login.rs
+++ b/iml-gui/crate/src/page/login.rs
@@ -1,5 +1,10 @@
-use crate::{auth, components::ddn_logo, generated::css_classes::C, FailReasonExt, GMsg, MergeAttrs, Route};
-use iml_wire_types::Session;
+use crate::{
+    auth,
+    components::{ddn_logo, whamcloud_logo},
+    generated::css_classes::C,
+    FailReasonExt, GMsg, MergeAttrs, Route,
+};
+use iml_wire_types::{Branding, Session};
 use seed::{browser::service::fetch, prelude::*, *};
 
 #[derive(Clone, Default, serde::Serialize)]
@@ -101,7 +106,7 @@ fn err_item<T>(x: &str) -> Node<T> {
     p![class![C.text_red_500, C.text_xs, C.italic,], x]
 }
 
-pub fn view(model: &Model) -> impl View<Msg> {
+pub fn view(model: &Model, branding: Branding) -> impl View<Msg> {
     let input_cls = class![
         C.appearance_none,
         C.focus__outline_none,
@@ -116,6 +121,18 @@ pub fn view(model: &Model) -> impl View<Msg> {
     let errs = Errors::default();
 
     let errs = model.errors.as_ref().unwrap_or_else(|| &errs);
+    let (border_color, text_color, logo) = match branding {
+        Branding::Whamcloud => (
+            C.border_teal_500,
+            C.text_teal_500,
+            whamcloud_logo().merge_attrs(class![C.h_16, C.w_16]),
+        ),
+        Branding::Ddn | Branding::DdnAi400 => (
+            C.border_red_700,
+            C.text_red_700,
+            ddn_logo().merge_attrs(class![C.h_16, C.w_32]),
+        ),
+    };
 
     div![
         class![
@@ -127,15 +144,12 @@ pub fn view(model: &Model) -> impl View<Msg> {
             C.min_h_screen,
         ],
         form![
-            class![C.bg_white, C.shadow_md, C.px_16, C.py_8, C.border_b_8, C.border_red_700],
+            class![C.bg_white, C.shadow_md, C.px_16, C.py_8, C.border_b_8, border_color],
             ev(Ev::Submit, move |event| {
                 event.prevent_default();
                 Msg::Submit
             }),
-            div![
-                class![C.text_red_700, C.flex, C.justify_center, C.mb_6],
-                ddn_logo().merge_attrs(class![C.h_16, C.w_32])
-            ],
+            div![class![text_color, C.flex, C.justify_center, C.mb_6], logo],
             match errs.__all__.as_ref() {
                 Some(x) => err_item(x),
                 None => empty![],

--- a/iml-gui/crate/src/page/partial/header.rs
+++ b/iml-gui/crate/src/page/partial/header.rs
@@ -1,11 +1,11 @@
 use crate::{
     auth, breakpoints,
-    components::{breadcrumbs, ddn_logo, font_awesome, restrict},
+    components::{breadcrumbs, ddn_logo, font_awesome, restrict, whamcloud_logo},
     generated::css_classes::C,
     MergeAttrs, Model, Msg, Route, SessionExt,
     Visibility::*,
 };
-use iml_wire_types::GroupType;
+use iml_wire_types::{Branding, GroupType};
 use seed::{prelude::*, *};
 
 fn menu_icon<T>(icon_name: &str) -> Node<T> {
@@ -174,7 +174,17 @@ fn toggle_nav_view() -> Node<Msg> {
 }
 
 /// The navbar logo
-fn logo_nav_view<T>() -> Node<T> {
+fn logo_nav_view<T>(branding: Branding) -> Node<T> {
+    let (logo, txt, color) = match branding {
+        Branding::Whamcloud => (whamcloud_logo(), empty![], C.text_white),
+        Branding::Ddn => (ddn_logo(), empty![], C.text_red_600),
+        Branding::DdnAi400 => (
+            ddn_logo(),
+            span![class![C.font_semibold, C.text_3xl, C.tracking_tight], "AI400"],
+            C.text_red_600,
+        ),
+    };
+
     div![
         class![
             C.flex_shrink_0,
@@ -185,11 +195,11 @@ fn logo_nav_view<T>() -> Node<T> {
             C.lg__my_0,
             C.ml_6,
             C.my_2,
-            C.text_red_600,
+            color,
             C.xl__mr_12
         ],
-        ddn_logo().merge_attrs(class![C.h_12, C.w_24, C.mr_3]),
-        span![class![C.font_semibold, C.text_3xl, C.tracking_tight], "AI400"],
+        logo.merge_attrs(class![C.h_12, C.w_24, C.mr_3]),
+        txt,
     ]
 }
 
@@ -206,7 +216,7 @@ fn nav(model: &Model) -> Node<Msg> {
             C.justify_between,
             C.flex_wrap
         ],
-        logo_nav_view(),
+        logo_nav_view(model.conf.branding),
         toggle_nav_view(),
         if model.menu_visibility == Visible || model.breakpoint_size >= breakpoints::Size::LG {
             div![

--- a/iml-manager-env/src/lib.rs
+++ b/iml-manager-env/src/lib.rs
@@ -201,6 +201,14 @@ pub fn get_db_password() -> Option<String> {
     empty_str_to_none(get_var("DB_PASSWORD"))
 }
 
+pub fn get_branding() -> String {
+    get_var("BRANDING")
+}
+
+pub fn get_use_stratagem() -> bool {
+    string_to_bool(get_var("USE_STRATAGEM"))
+}
+
 /// Gets a connection string from the IML env
 pub fn get_db_conn_string() -> String {
     let mut xs = vec![format!("user={}", get_db_user())];

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -1540,10 +1540,10 @@ impl Default for Branding {
 impl From<String> for Branding {
     fn from(x: String) -> Self {
         match x.to_lowercase().as_str() {
-            "whamcloud" => Branding::Whamcloud,
-            "ddn" => Branding::Ddn,
-            "ddnai400" => Branding::DdnAi400,
-            _ => Branding::Whamcloud,
+            "whamcloud" => Self::Whamcloud,
+            "ddn" => Self::Ddn,
+            "ddnai400" => Self::DdnAi400,
+            _ => Self::Whamcloud,
         }
     }
 }

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -416,12 +416,27 @@ impl<T> ApiList<T> {
     }
 }
 
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Conf {
     pub allow_anonymous_read: bool,
     pub build: String,
     pub version: String,
     pub is_release: bool,
+    pub branding: Branding,
+    pub use_stratagem: bool,
+}
+
+impl Default for Conf {
+    fn default() -> Self {
+        Self {
+            allow_anonymous_read: true,
+            build: "Not Loaded".into(),
+            version: "0".into(),
+            is_release: false,
+            branding: Branding::default(),
+            use_stratagem: false,
+        }
+    }
 }
 
 impl EndpointName for Conf {
@@ -1506,6 +1521,30 @@ impl PartialOrd for OstPool {
 impl PartialEq for OstPool {
     fn eq(&self, other: &Self) -> bool {
         self.filesystem == other.filesystem && self.name == other.name
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub enum Branding {
+    Whamcloud,
+    Ddn,
+    DdnAi400,
+}
+
+impl Default for Branding {
+    fn default() -> Self {
+        Self::Whamcloud
+    }
+}
+
+impl From<String> for Branding {
+    fn from(x: String) -> Self {
+        match x.to_lowercase().as_str() {
+            "whamcloud" => Branding::Whamcloud,
+            "ddn" => Branding::Ddn,
+            "ddnai400" => Branding::DdnAi400,
+            _ => Branding::Whamcloud,
+        }
     }
 }
 

--- a/settings.py
+++ b/settings.py
@@ -96,6 +96,10 @@ TIMER_PROXY_PASS = "http://{}:{}".format(PROXY_HOST, TIMER_PORT)
 
 INCLUDES = ""
 
+BRANDING = "Whamcloud"
+
+USE_STRATAGEM = False
+
 ALLOWED_HOSTS = ["*"]
 
 ADMINS = (


### PR DESCRIPTION
Add ability to include a config file in `/etc/iml-docker/setup/config`. This config should (at least for now) allow the installer to include: `BRANDING` and `STRATRAGEM_ENABLED`. These values will be loaded into environment variables along with the rest of the variables specified in `print-settings.py`. The gui app will additionally wait for these values to be loaded before the gui is loaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1687)
<!-- Reviewable:end -->
