### PR TITLE
Remove volume links and other tree-view links that do not need to be shown

### DIFF
--- a/iml-gui/crate/src/components/resource_links.rs
+++ b/iml-gui/crate/src/components/resource_links.rs
@@ -1,6 +1,6 @@
 use crate::{extensions::MergeAttrs as _, generated::css_classes::C, route::RouteId, Route};
 use iml_api_utils::extract_id;
-use iml_wire_types::{Filesystem, Target, TargetConfParam, VolumeOrResourceUri};
+use iml_wire_types::{Filesystem, Target, TargetConfParam};
 use seed::{prelude::*, *};
 
 pub fn href_view<T>(x: &str, route: Route) -> Node<T> {
@@ -9,6 +9,10 @@ pub fn href_view<T>(x: &str, route: Route) -> Node<T> {
         attrs! {At::Href => route.to_href()},
         x
     ]
+}
+
+pub fn label_view<T>(x: &str, _: Route) -> Node<T> {
+    span![x]
 }
 
 pub fn server_link<T>(uri: Option<&String>, txt: &str) -> Node<T> {
@@ -22,12 +26,13 @@ pub fn server_link<T>(uri: Option<&String>, txt: &str) -> Node<T> {
 }
 
 pub fn volume_link<T>(t: &Target<TargetConfParam>) -> Node<T> {
-    let vol_id = match &t.volume {
-        VolumeOrResourceUri::ResourceUri(url) => extract_id(url).unwrap().parse::<u32>().unwrap(),
-        VolumeOrResourceUri::Volume(v) => v.id,
-    };
+    // let vol_id = match &t.volume {
+    //     VolumeOrResourceUri::ResourceUri(url) => extract_id(url).unwrap().parse::<u32>().unwrap(),
+    //     VolumeOrResourceUri::Volume(v) => v.id,
+    // };
 
-    href_view(&t.volume_name, Route::Volume(RouteId::from(vol_id))).merge_attrs(class![C.break_all])
+    // href_view(&t.volume_name, Route::Volume(RouteId::from(vol_id))).merge_attrs(class![C.break_all])
+    span![&t.volume_name].merge_attrs(class![C.break_all])
 }
 
 pub fn fs_link<T>(x: &Filesystem) -> Node<T> {

--- a/iml-gui/crate/src/components/tree.rs
+++ b/iml-gui/crate/src/components/tree.rs
@@ -548,6 +548,14 @@ fn item_view(icon: &str, label: &str, route: Route) -> Node<Msg> {
     ]
 }
 
+fn item_label_view(icon: &str, label: &str, _: Route) -> Node<Msg> {
+    span![
+        class![C.mr_1, C.break_all],
+        font_awesome(class![C.w_5, C.h_4, C.inline, C.mr_1, C._mt_1], icon),
+        label
+    ]
+}
+
 fn tree_host_item_view(cache: &ArcCache, model: &Model, host: &Host) -> Option<Node<Msg>> {
     let address = Address::new(vec![Step::HostCollection, Step::Host(host.id)]);
 
@@ -581,7 +589,7 @@ fn tree_pool_item_view(cache: &ArcCache, model: &Model, address: &Address, pool:
     Some(li![
         class![C.py_1],
         toggle_view(address.clone(), tree_node.open),
-        item_view("swimming-pool", pool.label(), Route::OstPool(pool.id.into())),
+        item_label_view("swimming-pool", pool.label(), Route::OstPool(pool.id.into())),
         if tree_node.open {
             tree_target_collection_view(cache, model, &address, TargetKind::Ost)
         } else {
@@ -691,7 +699,7 @@ fn tree_pools_collection_view(cache: &ArcCache, model: &Model, parent_address: &
     tree_collection_view(
         model,
         addr.clone(),
-        |x| item_view("folder", &format!("OST Pools ({})", x.paging.total()), Route::OstPools),
+        |x| item_label_view("folder", &format!("OST Pools ({})", x.paging.total()), Route::OstPools),
         |x| {
             slice_page(&x.paging, &x.items)
                 .filter_map(|x| cache.ost_pool.get(x))
@@ -720,7 +728,7 @@ fn tree_volume_collection_view(cache: &ArcCache, model: &Model, parent_address: 
 
                     li![
                         class![C.py_1],
-                        item_view("hdd", &format!("{}{}", x.label(), size), Route::Volume(v.id.into())),
+                        item_label_view("hdd", &format!("{}{}", x.label(), size), Route::Volume(v.id.into())),
                     ]
                 })
                 .collect()
@@ -744,7 +752,13 @@ fn tree_target_collection_view(
     tree_collection_view(
         model,
         parent_address.extend(kind),
-        |x| item_view("folder", &format!("{} ({})", label, x.paging.total()), Route::Targets),
+        |x| {
+            if kind == TargetKind::Mgt {
+                item_view("folder", &format!("{} ({})", label, x.paging.total()), Route::Mgt)
+            } else {
+                item_label_view("folder", &format!("{} ({})", label, x.paging.total()), Route::Targets)
+            }
+        },
         |x| {
             slice_page(&x.paging, &x.items)
                 .filter_map(|x| cache.target.get(x))

--- a/iml-gui/crate/src/page/volumes.rs
+++ b/iml-gui/crate/src/page/volumes.rs
@@ -156,7 +156,7 @@ pub fn view(model: &Model) -> impl View<Msg> {
                 ]),
                 tbody![model.rows[model.pager.range()].iter().map(|(v, vns, hs)| {
                     tr![
-                        table::td_center(resource_links::href_view(
+                        table::td_center(resource_links::label_view(
                             &vns[0].path,
                             Route::Volume(RouteId::from(v.id))
                         )),


### PR DESCRIPTION
- remove link from volumes on filesystem detail, mgt, individual volumes in tree view
- Remove OST pools parent link in tree view
- Remove Target parent links (except MGT)

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1693)
<!-- Reviewable:end -->
