### PR TITLE
Have nginx pass proxied gzip data from grafana and influx

### DIFF
--- a/chroma-manager.conf.template
+++ b/chroma-manager.conf.template
@@ -155,17 +155,7 @@ server {
         expires 1y;
         add_header Cache-Control $cache_control;
 
-        gzip on;
-        gzip_types
-            application/javascript
-            application/json
-            application/manifest+json
-            application/wasm
-            application/x-javascript
-            application/x-web-app-manifest+json
-            image/*
-            text/css
-            text/javascript;
+        gzip_proxied any;
     }
 
     location /influx {
@@ -177,6 +167,8 @@ server {
         proxy_set_header X-Forwarded-Server $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass {{INFLUXDB_PROXY_PASS}}/query;
+
+        gzip_proxied any;
     }
 
     location /api/conf {

--- a/grafana/grafana-iml.ini
+++ b/grafana/grafana-iml.ini
@@ -1,5 +1,6 @@
 [server]
 root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
+enable_gzip = true
 
 [database]
 type = postgres


### PR DESCRIPTION
Let influx and grafana gzip their own data and pass that
through nginx.

Issue #1589

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1698)
<!-- Reviewable:end -->
