### PR TITLE
Fix grafana charts

### DIFF
--- a/iml-gui/crate/src/components/dashboard/mod.rs
+++ b/iml-gui/crate/src/components/dashboard/mod.rs
@@ -39,7 +39,7 @@ pub(crate) fn performance_container(
         grafana_chart::view(
             IML_METRICS_DASHBOARD_ID,
             IML_METRICS_DASHBOARD_NAME,
-            create_chart_params(bw_id, vars.clone()),
+            create_chart_params(bw_id, "10s", vars.clone()),
             "38%",
         ),
         div![
@@ -59,7 +59,7 @@ pub(crate) fn performance_container(
         grafana_chart::view(
             IML_METRICS_DASHBOARD_ID,
             IML_METRICS_DASHBOARD_NAME,
-            create_chart_params(iops_id, vars),
+            create_chart_params(iops_id, "10s", vars),
             "38%",
         ),
         datepicker::view(model),

--- a/iml-gui/crate/src/components/grafana_chart.rs
+++ b/iml-gui/crate/src/components/grafana_chart.rs
@@ -18,10 +18,11 @@ pub(crate) struct GrafanaChartData<'a> {
     pub vars: BTreeMap<String, String>,
 }
 
-pub(crate) fn create_chart_params<'a>(
+pub(crate) fn create_chart_params(
     panel_id: u16,
+    refresh: &str,
     vars: impl IntoIterator<Item = (impl ToString, impl ToString)>,
-) -> GrafanaChartData<'a> {
+) -> GrafanaChartData {
     let hm: BTreeMap<String, String> = vars
         .into_iter()
         .map(|(x, y)| {
@@ -34,9 +35,10 @@ pub(crate) fn create_chart_params<'a>(
             (key, y.to_string())
         })
         .collect();
+
     GrafanaChartData {
         org_id: 1,
-        refresh: "10s",
+        refresh,
         panel_id,
         vars: hm,
     }

--- a/iml-gui/crate/src/components/stratagem/mod.rs
+++ b/iml-gui/crate/src/components/stratagem/mod.rs
@@ -394,22 +394,12 @@ pub(crate) fn view(model: &Model, all_locks: &Locks) -> Node<Msg> {
                 caption_wrapper(
                     "inode Usage Distribution",
                     Some(&last_scan),
-                    stratagem_chart(grafana_chart::GrafanaChartData {
-                        org_id: 1,
-                        refresh: "1m",
-                        panel_id: 2,
-                        vars: config.grafana_vars.clone()
-                    })
+                    stratagem_chart(grafana_chart::create_chart_params(2, "1m", config.grafana_vars.clone()))
                 ),
                 caption_wrapper(
                     "Space Usage Distribution",
                     Some(&last_scan),
-                    stratagem_chart(grafana_chart::GrafanaChartData {
-                        org_id: 1,
-                        refresh: "1m",
-                        panel_id: 3,
-                        vars: config.grafana_vars.clone()
-                    })
+                    stratagem_chart(grafana_chart::create_chart_params(3, "1m", config.grafana_vars.clone()))
                 ),
                 stratagem_config(config, locked)
             ]

--- a/iml-gui/crate/src/page/dashboard.rs
+++ b/iml-gui/crate/src/page/dashboard.rs
@@ -64,7 +64,7 @@ pub fn view(model: &Model) -> Node<Msg> {
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
-                        create_chart_params(26, no_vars()),
+                        create_chart_params(26, "10s", no_vars()),
                         "90%",
                     )
                 ]
@@ -78,6 +78,7 @@ pub fn view(model: &Model) -> Node<Msg> {
                         IML_METRICS_DASHBOARD_NAME,
                         create_chart_params(
                             34,
+                            "10s",
                             vec![
                                 ("from", &model.lnet_date_picker.from),
                                 ("to", &model.lnet_date_picker.to)

--- a/iml-gui/crate/src/page/fs_dashboard.rs
+++ b/iml-gui/crate/src/page/fs_dashboard.rs
@@ -71,6 +71,7 @@ pub fn view(model: &Model) -> Node<Msg> {
                         IML_METRICS_DASHBOARD_NAME,
                         create_chart_params(
                             31,
+                            "10s",
                             vec![
                                 ("fs_name", &model.fs_name),
                                 ("from", &model.fs_usage_date_picker.from),
@@ -89,7 +90,7 @@ pub fn view(model: &Model) -> Node<Msg> {
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
-                        create_chart_params(35, vec![("fs_name", &model.fs_name)]),
+                        create_chart_params(35, "10s", vec![("fs_name", &model.fs_name)]),
                         "90%",
                     ),
                 ],
@@ -103,6 +104,7 @@ pub fn view(model: &Model) -> Node<Msg> {
                         IML_METRICS_DASHBOARD_NAME,
                         create_chart_params(
                             32,
+                            "10s",
                             vec![
                                 ("fs_name", &model.fs_name),
                                 ("from", &model.mdt_usage_date_picker.from),

--- a/iml-gui/crate/src/page/server_dashboard.rs
+++ b/iml-gui/crate/src/page/server_dashboard.rs
@@ -27,7 +27,7 @@ pub fn view(_: &ArcCache, model: &Model) -> impl View<Msg> {
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
-                        create_chart_params(6, vec![("host_name", &model.host_name)]),
+                        create_chart_params(6, "10s", vec![("host_name", &model.host_name)]),
                         "90%",
                     ),
                 ],
@@ -39,7 +39,7 @@ pub fn view(_: &ArcCache, model: &Model) -> impl View<Msg> {
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
-                        create_chart_params(10, vec![("host_name", &model.host_name)]),
+                        create_chart_params(10, "10s", vec![("host_name", &model.host_name)]),
                         "90%",
                     ),
                 ],
@@ -51,7 +51,7 @@ pub fn view(_: &ArcCache, model: &Model) -> impl View<Msg> {
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
-                        create_chart_params(8, vec![("host_name", &model.host_name)]),
+                        create_chart_params(8, "10s", vec![("host_name", &model.host_name)]),
                         "90%",
                     ),
                 ],
@@ -63,7 +63,7 @@ pub fn view(_: &ArcCache, model: &Model) -> impl View<Msg> {
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
-                        create_chart_params(36, vec![("host_name", &model.host_name)]),
+                        create_chart_params(36, "10s", vec![("host_name", &model.host_name)]),
                         "90%",
                     ),
                 ],

--- a/iml-gui/crate/src/page/target_dashboard.rs
+++ b/iml-gui/crate/src/page/target_dashboard.rs
@@ -58,7 +58,7 @@ pub fn view(_: &ArcCache, model: &Model) -> Node<Msg> {
                         grafana_chart::view(
                             IML_METRICS_DASHBOARD_ID,
                             IML_METRICS_DASHBOARD_NAME,
-                            create_chart_params(37, vec![("target_name", &model.target_name)]),
+                            create_chart_params(37, "10s", vec![("target_name", &model.target_name)]),
                             "90%",
                         ),
                     ],
@@ -70,7 +70,7 @@ pub fn view(_: &ArcCache, model: &Model) -> Node<Msg> {
                         grafana_chart::view(
                             IML_METRICS_DASHBOARD_ID,
                             IML_METRICS_DASHBOARD_NAME,
-                            create_chart_params(14, vec![("target_name", &model.target_name)]),
+                            create_chart_params(14, "10s", vec![("target_name", &model.target_name)]),
                             "90%",
                         ),
                     ],
@@ -82,7 +82,7 @@ pub fn view(_: &ArcCache, model: &Model) -> Node<Msg> {
                         grafana_chart::view(
                             IML_METRICS_DASHBOARD_ID,
                             IML_METRICS_DASHBOARD_NAME,
-                            create_chart_params(16, vec![("target_name", &model.target_name)]),
+                            create_chart_params(16, "10s", vec![("target_name", &model.target_name)]),
                             "90%",
                         ),
                     ],
@@ -110,7 +110,7 @@ pub fn view(_: &ArcCache, model: &Model) -> Node<Msg> {
                         grafana_chart::view(
                             IML_METRICS_DASHBOARD_ID,
                             IML_METRICS_DASHBOARD_NAME,
-                            create_chart_params(14, vec![("target_name", &model.target_name)]),
+                            create_chart_params(14, "10s", vec![("target_name", &model.target_name)]),
                             "90%",
                         ),
                     ],
@@ -122,7 +122,7 @@ pub fn view(_: &ArcCache, model: &Model) -> Node<Msg> {
                         grafana_chart::view(
                             IML_METRICS_DASHBOARD_ID,
                             IML_METRICS_DASHBOARD_NAME,
-                            create_chart_params(16, vec![("target_name", &model.target_name)]),
+                            create_chart_params(16, "10s", vec![("target_name", &model.target_name)]),
                             "90%",
                         ),
                     ],


### PR DESCRIPTION
The grafana charts are not updating. This is because the `var-` prefix
that was being automatically injected by serde was removed (to allow for
    the `from` and `to` parameters). This patch updates the stratagem
charts to use the `create_chart_params` function instead of passing a
struct.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1706)
<!-- Reviewable:end -->
