### PR TITLE
Show page details in title and in breadcrumbs

### DIFF
--- a/iml-gui/crate/src/components/breadcrumbs.rs
+++ b/iml-gui/crate/src/components/breadcrumbs.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2020 DDN. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
-
-use crate::{generated::css_classes::C, route::Route, Msg};
+use crate::{generated::css_classes::C, Msg};
 use seed::{prelude::*, *};
 use std::{cmp::PartialEq, collections::LinkedList};
 
@@ -46,22 +45,18 @@ impl<Crumb: PartialEq> BreadCrumbs<Crumb> {
     }
 }
 
-pub fn view(bc: &BreadCrumbs<Route>) -> impl View<Msg> {
+pub fn view(bc: &BreadCrumbs<(String, String)>) -> impl View<Msg> {
     let mut ol = ol![class![C.justify_center, C.truncate, C.mx_4, C.rtl]];
 
     // XXX the list has "direction: rtl" to put ellipsis to the left on overflow,
     // XXX need to reverse the crumbs to show them in the correct left-to-right order:
-    for (n, p) in bc.iter().rev().enumerate() {
+    for (n, (href, title)) in bc.iter().rev().enumerate() {
         let mut cr = li![
             class![C.inline],
-            a![
-                class![C.hover__underline],
-                attrs! {At::Href => p.to_href()},
-                p.to_string(),
-            ]
+            a![class![C.hover__underline], attrs! {At::Href => href}, title,]
         ];
         if n == 0 {
-            cr.add_class(C.font_bold);
+            cr.add_class(C.text_blue_500);
         } else {
             ol.add_child(i!["/", class![C.px_2]]);
         }

--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -131,7 +131,7 @@ impl Loading {
 pub struct Model {
     activity_health: ActivityHealth,
     auth: auth::Model,
-    breadcrumbs: BreadCrumbs<Route<'static>>,
+    breadcrumbs: BreadCrumbs<(String, String)>,
     breakpoint_size: breakpoints::Size,
     command_modal: command_modal::Model,
     conf: Conf,
@@ -308,8 +308,6 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
         Msg::RouteChanged(url) => {
             model.route = Route::from(url);
 
-            orders.send_msg(Msg::UpdatePageTitle);
-
             if model.route == Route::Login {
                 orders.send_msg(Msg::Logout);
             }
@@ -318,13 +316,10 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
                 model.breadcrumbs.clear();
             }
 
-            model.breadcrumbs.push(model.route.clone());
-
             orders.send_msg(Msg::LoadPage);
         }
         Msg::UpdatePageTitle => {
-            let title = format!("{} - {}", model.route.to_string(), TITLE_SUFFIX);
-
+            let title = format!("{} - {}", model.page.title(), TITLE_SUFFIX);
             document().set_title(&title);
         }
         Msg::EventSourceConnect(_) => {
@@ -352,6 +347,8 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
         Msg::LoadPage => {
             if model.loading.loaded() && !model.page.is_active(&model.route) {
                 model.page = (&model.records, &model.route).into();
+                model.breadcrumbs.push((model.route.to_href(), model.page.title()));
+                orders.send_msg(Msg::UpdatePageTitle);
                 model.page.init(&model.records, &mut orders.proxy(Msg::Page));
             } else {
                 orders.skip();

--- a/iml-gui/crate/src/page/mod.rs
+++ b/iml-gui/crate/src/page/mod.rs
@@ -72,6 +72,36 @@ pub(crate) enum Page {
     Volume(volume::Model),
 }
 
+impl Page {
+    pub(crate) fn title(self: &Self) -> String {
+        match self {
+            Self::About => "About".into(),
+            Self::AppLoading => "Loading...".into(),
+            Self::Filesystems(_) => "Filesystems".into(),
+            Self::Filesystem(m) => format!("Filesystem: {}", &m.fs.name),
+            Self::Dashboard(_) => "Dashboard".into(),
+            Self::FsDashboard(m) => format!("{} Filesystem Dashboard", &m.fs_name),
+            Self::ServerDashboard(m) => format!("{} Server Dashboard", &m.host_name),
+            Self::TargetDashboard(m) => format!("{} Target Dashboard", &m.target_name),
+            Self::Jobstats => "Jobstats".into(),
+            Self::Login(_) => "Login".into(),
+            Self::Mgts(_) => "MGTs".into(),
+            Self::NotFound => "Page not found".into(),
+            Self::OstPools => "OST Pools".into(),
+            Self::OstPool(m) => format!("OST Pool: {}", &m.id),
+            Self::PowerControl => "Power Control".into(),
+            Self::Servers(_) => "Servers".into(),
+            Self::Server(m) => format!("Server: {}", &m.server.fqdn),
+            Self::Targets => "Targets".into(),
+            Self::Target(m) => format!("Target: {}", &m.target.name),
+            Self::Users => "Users".into(),
+            Self::User(m) => format!("User: {}", &m.user.username),
+            Self::Volumes(_) => "Volumes".into(),
+            Self::Volume(m) => format!("Volume: {}", &m.id),
+        }
+    }
+}
+
 impl RecordChange<Msg> for Page {
     fn update_record(&mut self, record: ArcRecord, cache: &ArcCache, orders: &mut impl Orders<Msg, GMsg>) {
         if let Self::Volumes(x) = self {

--- a/iml-gui/crate/src/page/partial/header.rs
+++ b/iml-gui/crate/src/page/partial/header.rs
@@ -52,31 +52,31 @@ fn nav_manage_dropdown(open: bool) -> Node<Msg> {
         ul![
             li![a![
                 &cls,
-                Route::Servers.to_string(),
+                "Servers",
                 attrs! {
                     At::Href => Route::Servers.to_href(),
                 },
             ]],
             li![
-                a![&cls, Route::Filesystems.to_string()],
+                a![&cls, "Filesystems"],
                 attrs! {
                     At::Href => Route::Filesystems.to_href(),
                 },
             ],
             li![
-                a![&cls, Route::Volumes.to_string()],
+                a![&cls, "Volumes"],
                 attrs! {
                     At::Href => Route::Volumes.to_href(),
                 },
             ],
             li![
-                a![&cls, Route::Mgt.to_string()],
+                a![&cls, "MGTs"],
                 attrs! {
                     At::Href => Route::Mgt.to_href(),
                 },
             ],
             li![
-                a![&cls, Route::Users.to_string()],
+                a![&cls, "Users"],
                 attrs! {
                     At::Href => Route::Users.to_href(),
                 },
@@ -117,7 +117,7 @@ fn main_menu_items(model: &Model) -> Node<Msg> {
                 menu_icon("tachometer-alt"),
                 span![
                     class![C.group_hover__text_active, C.text_active => model.route == Route::Dashboard],
-                    Route::Dashboard.to_string(),
+                    "Dashboard",
                 ],
             ]
         ],

--- a/iml-gui/crate/src/route.rs
+++ b/iml-gui/crate/src/route.rs
@@ -105,35 +105,6 @@ impl<'a> Route<'a> {
     }
 }
 
-impl<'a> ToString for Route<'a> {
-    fn to_string(&self) -> String {
-        match self {
-            Self::About => "About".into(),
-            Self::Dashboard => "Dashboard".into(),
-            Self::FsDashboard(_) => "Fs Dashboard".into(),
-            Self::ServerDashboard(_) => "Server Dashboard".into(),
-            Self::TargetDashboard(_) => "Target Dashboard".into(),
-            Self::Filesystems => "Filesystems".into(),
-            Self::Filesystem(_) => "Filesystem Detail".into(),
-            Self::Jobstats => "Jobstats".into(),
-            Self::Login => "Login".into(),
-            Self::Mgt => "MGTs".into(),
-            Self::NotFound => "404".into(),
-            Self::OstPools => "OST Pool".into(),
-            Self::OstPool(_) => "OST Pool Detail".into(),
-            Self::PowerControl => "Power Control".into(),
-            Self::Servers => "Servers".into(),
-            Self::Server(_) => "Server Detail".into(),
-            Self::Targets => "Target".into(),
-            Self::Target(_) => "Target Detail".into(),
-            Self::Users => "Users".into(),
-            Self::User(_) => "User".into(),
-            Self::Volumes => "Volumes".into(),
-            Self::Volume(_) => "Volume Detail".into(),
-        }
-    }
-}
-
 impl<'a> From<Route<'a>> for Url {
     fn from(route: Route<'a>) -> Self {
         route.path().into()


### PR DESCRIPTION
Derive page title from the page's model rather
than from the route. Closes #1577.

Signed-off-by: Igor Pashev <pashev.igor@gmail.com>
![title](https://user-images.githubusercontent.com/131844/77173204-d4d53480-6ac7-11ea-8819-4bce67f7bb3e.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1707)
<!-- Reviewable:end -->
