### PR TITLE
Address immediate GUI visual bugs

### DIFF
--- a/iml-gui/crate/src/page/filesystem.rs
+++ b/iml-gui/crate/src/page/filesystem.rs
@@ -412,7 +412,7 @@ fn targets(
             h3![class![C.py_4, C.font_normal, C.text_lg], title]
         ],
         table![
-            class![C.table_fixed, C.w_full],
+            class![C.table_auto, C.w_full],
             style! {
                 St::BorderSpacing => px(10),
                 St::BorderCollapse => "initial"
@@ -421,8 +421,8 @@ fn targets(
                 t::thead_view(vec![
                     t::th_left(plain!["Name"]).merge_attrs(class![C.w_32]),
                     t::th_left(plain!["Volume"]),
-                    t::th_left(plain!["Primary Server"]).merge_attrs(class![C.w_48]),
-                    t::th_left(plain!["Failover Server"]).merge_attrs(class![C.w_48]),
+                    t::th_left(plain!["Primary Server"]).merge_attrs(class![C.w_48, C.hidden, C.md__table_cell]),
+                    t::th_left(plain!["Failover Server"]).merge_attrs(class![C.w_48, C.hidden, C.md__table_cell]),
                     t::th_left(plain!["Started on"]).merge_attrs(class![C.w_48]),
                     th![class![C.w_48]]
                 ]),
@@ -443,11 +443,13 @@ fn targets(
                         t::td_view(resource_links::server_link(
                             Some(&x.primary_server),
                             &x.primary_server_name
-                        )),
+                        ))
+                        .merge_attrs(class![C.hidden, C.md__table_cell]),
                         t::td_view(resource_links::server_link(
                             x.failover_servers.first(),
                             &x.failover_server_name
-                        )),
+                        ))
+                        .merge_attrs(class![C.hidden, C.md__table_cell]),
                         t::td_view(resource_links::server_link(x.active_host.as_ref(), &x.active_host_name)),
                         td![
                             class![C.p_3, C.text_center],

--- a/iml-gui/crate/src/status_section.rs
+++ b/iml-gui/crate/src/status_section.rs
@@ -131,8 +131,9 @@ pub fn view(
                 C.bg_blue_1000,
                 C.lg__w_24,
                 C.lg__h_main_content,
-                C.grid,
-                C.grid_rows_4,
+                C.hidden,
+                C.lg__grid,
+                C.lg__grid_rows_4,
             ],
             toggle_section(model),
             side_panel_buttons(route, activity_health).merge_attrs(class![C.row_span_2])


### PR DESCRIPTION
Fixes #1708.

Description:
There are a couple of gui bugs that need immediate fixing:

 - The right panel does not display properly in reponsive mode. For now, we should remove the right panel unless we are in a large view.
 - The volume table cell is rendering as a single column of text when the window is scaled down. We should fix the volume cell and also remove both the primary and failover server columns unless the browser is open in a medium view or larger.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1709)
<!-- Reviewable:end -->
