### PR TITLE
Add baseless profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
 
 [[package]]
 name = "arrayref"
@@ -1194,7 +1194,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "tokio",
- "tokio-util 0.3.0",
+ "tokio-util 0.3.1",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1265,7 +1265,7 @@ dependencies = [
  "tempdir",
  "tempfile",
  "tokio",
- "tokio-util 0.3.0",
+ "tokio-util 0.3.1",
 ]
 
 [[package]]
@@ -2238,7 +2238,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 dependencies = [
- "siphasher 0.3.1",
+ "siphasher 0.3.2",
 ]
 
 [[package]]
@@ -2784,9 +2784,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
+checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
 dependencies = [
  "lazy_static",
  "winapi 0.3.8",
@@ -2852,18 +2852,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
  "proc-macro2 1.0.9",
  "quote 1.0.3",
@@ -2973,9 +2973,9 @@ checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "siphasher"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83da420ee8d1a89e640d0948c646c1c088758d3a3c538f943bfa97bdac17929d"
+checksum = "8e88f89a550c01e4cd809f3df4f52dc9e939f3273a2017eabd5c6d12fd98bb23"
 
 [[package]]
 name = "sized-chunks"
@@ -3097,9 +3097,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe43617218c0805c6eb37160119dc3c548110a67786da7218d1c6555212f073"
+checksum = "c8faa2719539bbe9d77869bfb15d4ee769f99525e707931452c97b693b3f159d"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3108,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e79c80e0f4efd86ca960218d4e056249be189ff1c42824dcd9a7f51a56f0bd"
+checksum = "3f88b8e18c69496aad6f9ddf4630dd7d585bcaf765786cb415b9aec2fe5a0430"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -3339,7 +3339,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "tokio",
- "tokio-util 0.3.0",
+ "tokio-util 0.3.1",
 ]
 
 [[package]]
@@ -3402,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af67cdce2b40f8dffb0ee04c853a24217b5d0d3e358f0f5ccc0b5332174ed9a8"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
  "bytes",
  "futures-core",

--- a/agent-bootstrap-script.template
+++ b/agent-bootstrap-script.template
@@ -129,10 +129,10 @@ def reg_manager():
         raise
 
 
-def create_repo():
+def create_repo(contents):
     tmp = tempfile.NamedTemporaryFile()
     # this format needs to match chroma_agent.action_plugins.agent_setup.configure_repo
-    tmp.write(REPO_CONTENT.format(AUTHORITY_CERT, PRIVATE_KEY, AGENT_CERT))
+    tmp.write(contents)
 
     tmp.flush()
     launch_command("cp %s %s" % (tmp.name, REPO_PATH))
@@ -183,9 +183,12 @@ def main():
         setup_keys()
         registration_response = reg_manager()
 
-        # Now that we're registered, we can download packages
-        create_repo()
-        install_agent()
+        contents = REPO_CONTENT.format(AUTHORITY_CERT, PRIVATE_KEY, AGENT_CERT).strip()
+
+        if len(contents) > 0:
+            # Now that we're registered, we can download packages
+            create_repo(contents)
+            install_agent()
 
         # Persist the agent configuration file so that it can connect
         # to the manager

--- a/default_baseless.profile
+++ b/default_baseless.profile
@@ -1,0 +1,9 @@
+{
+  "ui_name": "Unconfigured Baseless Server",
+  "name": "default_baseless",
+  "ui_description": "An unconfigured server without a base.repo.",
+  "user_selectable": false,
+  "initial_state": "unconfigured",
+  "packages": [],
+  "repolist": []
+}

--- a/iml-manager-cli/src/api_utils.rs
+++ b/iml-manager-cli/src/api_utils.rs
@@ -157,7 +157,7 @@ pub async fn get_available_actions(
 pub fn first<T: EndpointName>(x: ApiList<T>) -> Result<T, ImlManagerCliError> {
     x.objects
         .into_iter()
-        .nth(0)
+        .next()
         .ok_or_else(|| ImlManagerCliError::DoesNotExist(T::endpoint_name()))
 }
 

--- a/iml-manager-cli/src/error.rs
+++ b/iml-manager-cli/src/error.rs
@@ -80,7 +80,7 @@ impl std::fmt::Display for ImlManagerCliError {
             ImlManagerCliError::DoesNotExist(ref err) => write!(f, "{} does not exist", err),
             ImlManagerCliError::FailedCommandError(ref xs) => {
                 let failed_msg = xs.iter().fold(
-                    String::from("The Following commands have failed:\n"),
+                    String::from("The following commands have failed:\n"),
                     |acc, x| format!("{}{}\n", acc, x.message),
                 );
 

--- a/iml-manager-cli/src/error.rs
+++ b/iml-manager-cli/src/error.rs
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+use iml_wire_types::Command;
+
 #[derive(Debug)]
 pub enum DurationParseError {
     NoUnit,
@@ -54,35 +56,44 @@ impl std::error::Error for DurationParseError {}
 
 #[derive(Debug)]
 pub enum ImlManagerCliError {
+    ApiError(String),
     ClientRequestError(iml_manager_client::ImlManagerClientError),
-    TokioTimerError(tokio::time::Error),
-    TokioJoinError(tokio::task::JoinError),
+    CombineEasyError(combine::stream::easy::Errors<char, &'static str, usize>),
+    DoesNotExist(&'static str),
+    FailedCommandError(Vec<Command>),
     IntParseError(std::num::ParseIntError),
+    IoError(std::io::Error),
     ParseDurationError(DurationParseError),
+    ReqwestError(reqwest::Error),
     RunStratagemValidationError(RunStratagemValidationError),
     SerdeJsonError(serde_json::error::Error),
-    DoesNotExist(&'static str),
-    ApiError(String),
-    IoError(std::io::Error),
-    CombineEasyError(combine::stream::easy::Errors<char, &'static str, usize>),
-    ReqwestError(reqwest::Error),
+    TokioJoinError(tokio::task::JoinError),
+    TokioTimerError(tokio::time::Error),
 }
 
 impl std::fmt::Display for ImlManagerCliError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
+            ImlManagerCliError::ApiError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::ClientRequestError(ref err) => write!(f, "{}", err),
-            ImlManagerCliError::TokioTimerError(ref err) => write!(f, "{}", err),
-            ImlManagerCliError::TokioJoinError(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::CombineEasyError(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::DoesNotExist(ref err) => write!(f, "{} does not exist", err),
+            ImlManagerCliError::FailedCommandError(ref xs) => {
+                let failed_msg = xs.iter().fold(
+                    String::from("The Following commands have failed:\n"),
+                    |acc, x| format!("{}{}\n", acc, x.message),
+                );
+
+                write!(f, "{}", failed_msg)
+            }
             ImlManagerCliError::IntParseError(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::IoError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::ParseDurationError(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::ReqwestError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::RunStratagemValidationError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::SerdeJsonError(ref err) => write!(f, "{}", err),
-            ImlManagerCliError::DoesNotExist(ref err) => write!(f, "{} does not exist", err),
-            ImlManagerCliError::ApiError(ref err) => write!(f, "{}", err),
-            ImlManagerCliError::IoError(ref err) => write!(f, "{}", err),
-            ImlManagerCliError::CombineEasyError(ref err) => write!(f, "{}", err),
-            ImlManagerCliError::ReqwestError(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::TokioJoinError(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::TokioTimerError(ref err) => write!(f, "{}", err),
         }
     }
 }
@@ -96,18 +107,19 @@ impl std::fmt::Display for RunStratagemValidationError {
 impl std::error::Error for ImlManagerCliError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
+            ImlManagerCliError::ApiError(_) => None,
             ImlManagerCliError::ClientRequestError(ref err) => Some(err),
-            ImlManagerCliError::TokioTimerError(ref err) => Some(err),
-            ImlManagerCliError::TokioJoinError(ref err) => Some(err),
+            ImlManagerCliError::CombineEasyError(ref err) => Some(err),
+            ImlManagerCliError::DoesNotExist(_) => None,
+            ImlManagerCliError::FailedCommandError(_) => None,
             ImlManagerCliError::IntParseError(ref err) => Some(err),
+            ImlManagerCliError::IoError(ref err) => Some(err),
             ImlManagerCliError::ParseDurationError(ref err) => Some(err),
+            ImlManagerCliError::ReqwestError(ref err) => Some(err),
             ImlManagerCliError::RunStratagemValidationError(ref err) => Some(err),
             ImlManagerCliError::SerdeJsonError(ref err) => Some(err),
-            ImlManagerCliError::DoesNotExist(_) => None,
-            ImlManagerCliError::ApiError(_) => None,
-            ImlManagerCliError::IoError(ref err) => Some(err),
-            ImlManagerCliError::CombineEasyError(ref err) => Some(err),
-            ImlManagerCliError::ReqwestError(ref err) => Some(err),
+            ImlManagerCliError::TokioJoinError(ref err) => Some(err),
+            ImlManagerCliError::TokioTimerError(ref err) => Some(err),
         }
     }
 }
@@ -169,6 +181,12 @@ impl From<std::io::Error> for ImlManagerCliError {
 impl From<combine::stream::easy::Errors<char, &str, usize>> for ImlManagerCliError {
     fn from(err: combine::stream::easy::Errors<char, &str, usize>) -> Self {
         ImlManagerCliError::CombineEasyError(err.map_range(|_| ""))
+    }
+}
+
+impl From<Vec<Command>> for ImlManagerCliError {
+    fn from(xs: Vec<Command>) -> Self {
+        ImlManagerCliError::FailedCommandError(xs)
     }
 }
 

--- a/iml-manager-cli/src/filesystem.rs
+++ b/iml-manager-cli/src/filesystem.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     api_utils::{
-        create_command, get, get_all, get_hosts, get_one, wait_for_cmds, SendCmd, SendJob,
+        create_command, get, get_all, get_hosts, get_one, wait_for_cmds_success, SendCmd, SendJob,
     },
     display_utils::{generate_table, wrap_fut},
     error::ImlManagerCliError,
@@ -102,7 +102,7 @@ async fn detect_filesystem(hosts: Option<String>) -> Result<(), ImlManagerCliErr
     };
     let cmd = wrap_fut("Detecting filesystems...", create_command(cmd)).await?;
 
-    wait_for_cmds(vec![cmd]).await?;
+    wait_for_cmds_success(vec![cmd]).await?;
     Ok(())
 }
 

--- a/iml-manager-cli/src/ostpool.rs
+++ b/iml-manager-cli/src/ostpool.rs
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 use crate::{
-    api_utils::{delete, get, get_all, get_one, post, put, wait_for_cmds},
+    api_utils::{delete, get, get_all, get_one, post, put, wait_for_cmds_success},
     display_utils::{generate_table, wrap_fut},
     error::ImlManagerCliError,
 };
@@ -176,7 +176,7 @@ async fn ostpool_destroy(
     let resp = delete(&pool.resource_uri, "").await?;
     term.write_line(&format!("{} ost pool...", style("Destroying").green()))?;
     let objs: ObjCommands = resp.json().await?;
-    wait_for_cmds(objs.commands).await?;
+    wait_for_cmds_success(objs.commands).await?;
 
     Ok(())
 }
@@ -204,7 +204,7 @@ pub async fn ostpool_cli(command: OstPoolCommand) -> Result<(), ImlManagerCliErr
 
             term.write_line(&format!("{} ost pool...", style("Creating").green()))?;
             let objs: ObjCommand = resp.json().await?;
-            wait_for_cmds(vec![objs.command]).await?;
+            wait_for_cmds_success(vec![objs.command]).await?;
         }
         OstPoolCommand::Destroy { fsname, poolname } => {
             ostpool_destroy(&term, fsname, poolname).await?;
@@ -226,7 +226,7 @@ pub async fn ostpool_cli(command: OstPoolCommand) -> Result<(), ImlManagerCliErr
             let uri = pool.resource_uri.clone();
             let resp = put(&uri, pool).await?;
             let objs: ObjCommand = resp.json().await?;
-            wait_for_cmds(vec![objs.command]).await?;
+            wait_for_cmds_success(vec![objs.command]).await?;
         }
         OstPoolCommand::Shrink {
             fsname,
@@ -243,7 +243,7 @@ pub async fn ostpool_cli(command: OstPoolCommand) -> Result<(), ImlManagerCliErr
             let resp = put(&uri, pool).await?;
 
             let objs: ObjCommand = resp.json().await?;
-            wait_for_cmds(vec![objs.command]).await?;
+            wait_for_cmds_success(vec![objs.command]).await?;
         }
     };
 

--- a/iml-manager-cli/src/server.rs
+++ b/iml-manager-cli/src/server.rs
@@ -298,7 +298,7 @@ fn list_server(hosts: ApiList<Host>) {
 
 fn get_profile_by_name<'a>(xs: &'a [ServerProfile], name: &str) -> Option<&'a ServerProfile> {
     let profile_opt = xs
-        .into_iter()
+        .iter()
         .filter(|x| x.user_selectable)
         .find(|x| x.name == name);
 
@@ -537,7 +537,7 @@ fn get_commands_from_wrapper(objects: Vec<HostProfileCmdWrapper>) -> Vec<Command
 
 async fn process_addhosts(
     config: &AddHosts,
-    api_hosts: &Vec<Host>,
+    api_hosts: &[Host],
     new_hosts: BTreeSet<String>,
 ) -> Result<(BTreeSet<String>, AuthType), ImlManagerCliError> {
     let (known_hosts, new_hosts) = filter_known_hosts(new_hosts, &api_hosts);
@@ -688,7 +688,7 @@ async fn add_server(config: AddHosts) -> Result<(), ImlManagerCliError> {
 /// figures out the profile that should be used to deploy the agents
 fn get_agent_profile<'a>(
     profile: &ServerProfile,
-    xs: &'a Vec<ServerProfile>,
+    xs: &'a [ServerProfile],
 ) -> Result<&'a ServerProfile, Error> {
     let name = if profile.repolist.is_empty() {
         "default_baseless"

--- a/iml-manager-cli/src/server.rs
+++ b/iml-manager-cli/src/server.rs
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 use crate::{
-    api_utils::{get, get_all, get_hosts, post, put, wait_for_cmds},
+    api_utils::{get, get_all, get_hosts, post, put, wait_for_cmds, wait_for_cmds_success},
     display_utils::{
         display_cancelled, display_error, format_error, format_success, generate_table, wrap_fut,
     },
@@ -71,6 +71,9 @@ pub enum ServerCommand {
     /// Remove servers from IML
     #[structopt(name = "remove")]
     Remove(RemoveHosts),
+    /// List all profiles
+    #[structopt(name = "profile")]
+    Profile,
 }
 
 #[derive(Debug)]
@@ -125,7 +128,7 @@ impl<'a> TestHostConfig<'a> {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 struct AgentConfig<'a> {
-    server_profile: String,
+    server_profile: &'a str,
     #[serde(flatten, borrow)]
     info: TestHostConfig<'a>,
 }
@@ -293,15 +296,14 @@ fn list_server(hosts: ApiList<Host>) {
     table.printstd();
 }
 
-fn get_profile(config: &AddHosts, profiles: ApiList<ServerProfile>) -> Option<ServerProfile> {
-    let profile_opt = profiles
-        .objects
+fn get_profile_by_name<'a>(xs: &'a [ServerProfile], name: &str) -> Option<&'a ServerProfile> {
+    let profile_opt = xs
         .into_iter()
         .filter(|x| x.user_selectable)
-        .find(|x| x.name == config.profile);
+        .find(|x| x.name == name);
 
     if profile_opt.is_none() {
-        display_error(format!("Unknown profile {}", config.profile));
+        display_error(format!("Unknown profile {}", name));
     }
 
     profile_opt
@@ -406,13 +408,14 @@ fn handle_test_host_failure(all_passed: bool, config: &AddHosts) -> Result<(), I
 
 fn get_agent_config_objects<'a>(
     new_hosts: &'a BTreeSet<String>,
+    agent_profile: &'a ServerProfile,
     auth: &AuthType,
 ) -> Vec<AgentConfig<'a>> {
     new_hosts
         .iter()
         .map(|address| AgentConfig {
             info: TestHostConfig::new(&address, &auth),
-            server_profile: "/api/server_profile/default/".into(),
+            server_profile: &agent_profile.resource_uri,
         })
         .collect()
 }
@@ -534,20 +537,10 @@ fn get_commands_from_wrapper(objects: Vec<HostProfileCmdWrapper>) -> Vec<Command
 
 async fn process_addhosts(
     config: &AddHosts,
+    api_hosts: &Vec<Host>,
     new_hosts: BTreeSet<String>,
-) -> Result<(ServerProfile, BTreeSet<String>, AuthType), ImlManagerCliError> {
-    let (profiles, api_hosts): (ApiList<ServerProfile>, ApiList<Host>) =
-        future::try_join(get_all(), get_all()).await?;
-
-    let profile_name = config.profile.clone();
-    let profile = get_profile(&config, profiles).ok_or_else(|| {
-        Error::new(
-            ErrorKind::NotFound,
-            format!("{} profile not found.", profile_name),
-        )
-    })?;
-
-    let (known_hosts, new_hosts) = filter_known_hosts(new_hosts, &api_hosts.objects);
+) -> Result<(BTreeSet<String>, AuthType), ImlManagerCliError> {
+    let (known_hosts, new_hosts) = filter_known_hosts(new_hosts, &api_hosts);
 
     show_known_host_messages(known_hosts);
 
@@ -560,15 +553,11 @@ async fn process_addhosts(
         }
         "password" => AuthType::Password(config.password.clone().unwrap_or_default()),
         bad => {
-            return Err(Error::new(
-                ErrorKind::NotFound,
-                format!("{} not a valid auth type", bad),
-            )
-            .into());
+            return Err(not_found_err(format!("{} not a valid auth type", bad)));
         }
     };
 
-    Ok((profile, new_hosts, auth))
+    Ok((new_hosts, auth))
 }
 
 async fn get_test_host_commands_and_jobs(
@@ -599,13 +588,14 @@ async fn get_test_host_commands_and_jobs(
     Ok(all_passed)
 }
 
-async fn handle_agents(
+async fn deploy_agents(
     term: &Term,
     new_hosts: &BTreeSet<String>,
-    profile: &ServerProfile,
+    agent_profile: &ServerProfile,
+    server_profile: &ServerProfile,
     auth: &AuthType,
 ) -> Result<Vec<Host>, ImlManagerCliError> {
-    let objects = get_agent_config_objects(new_hosts, auth);
+    let objects = get_agent_config_objects(new_hosts, agent_profile, auth);
 
     let Objects { objects }: Objects<CommandAndHostWrapper> = post_command_to_host(objects).await?;
 
@@ -615,11 +605,11 @@ async fn handle_agents(
 
     term.write_line(&format!("{} agents...", style("Deploying").green()))?;
 
-    wait_for_cmds(commands).await?;
+    wait_for_cmds_success(commands).await?;
 
     wrap_fut(
         "Waiting for agents to restart...",
-        wait_till_agent_starts(&hosts, &profile.name),
+        wait_till_agent_starts(&hosts, &server_profile.name),
     )
     .await?;
 
@@ -665,10 +655,18 @@ async fn add_server(config: AddHosts) -> Result<(), ImlManagerCliError> {
 
     tracing::debug!("Parsed hosts {:?}", new_hosts);
 
-    let (profile, new_hosts, auth) = process_addhosts(&config, new_hosts).await?;
+    let (profiles, api_hosts): (ApiList<ServerProfile>, ApiList<Host>) =
+        future::try_join(get_all(), get_all()).await?;
+
+    let server_profile = get_profile_by_name(&profiles.objects, &config.profile)
+        .ok_or_else(|| not_found_err(format!("{} profile not found.", &config.profile)))?;
+
+    let agent_profile = get_agent_profile(server_profile, &profiles.objects)?;
+
+    let (new_hosts, auth) = process_addhosts(&config, &api_hosts.objects, new_hosts).await?;
 
     if new_hosts.is_empty() {
-        return Ok(());
+        return Err(not_found_err("No new hosts found"));
     }
 
     tracing::debug!("AUTH: {:?}", auth);
@@ -677,12 +675,33 @@ async fn add_server(config: AddHosts) -> Result<(), ImlManagerCliError> {
 
     handle_test_host_failure(all_passed, &config)?;
 
-    let hosts = handle_agents(&term, &new_hosts, &profile, &auth).await?;
+    let hosts = deploy_agents(&term, &new_hosts, &agent_profile, &server_profile, &auth).await?;
 
-    let cmds = handle_profiles(&term, &config, &hosts, &profile).await?;
+    let cmds = handle_profiles(&term, &config, &hosts, &server_profile).await?;
 
-    wait_for_cmds(cmds).await?;
+    wait_for_cmds_success(cmds).await?;
+
     Ok(())
+}
+
+/// Given a server_profile to deploy,
+/// figures out the profile that should be used to deploy the agents
+fn get_agent_profile<'a>(
+    profile: &ServerProfile,
+    xs: &'a Vec<ServerProfile>,
+) -> Result<&'a ServerProfile, Error> {
+    let name = if profile.repolist.is_empty() {
+        "default_baseless"
+    } else {
+        "default"
+    };
+
+    let x = xs
+        .into_iter()
+        .find(|x| x.name == name)
+        .ok_or_else(|| Error::new(ErrorKind::NotFound, format!("{} profile not found.", name)))?;
+
+    Ok(x)
 }
 
 pub async fn server_cli(command: ServerCommand) -> Result<(), ImlManagerCliError> {
@@ -762,9 +781,30 @@ pub async fn server_cli(command: ServerCommand) -> Result<(), ImlManagerCliError
             let commands: Vec<Command> =
                 wrap_fut("Removing Servers...", future::try_join_all(xs)).await?;
 
-            wait_for_cmds(commands).await?;
+            wait_for_cmds_success(commands).await?;
+        }
+        ServerCommand::Profile => {
+            let profiles: ApiList<ServerProfile> =
+                wrap_fut("Fetching profiles...", get_all()).await?;
+
+            tracing::debug!("profiles: {:?}", profiles);
+
+            let table = generate_table(
+                &["Profile", "Name", "Description"],
+                profiles
+                    .objects
+                    .into_iter()
+                    .filter(|x| x.user_selectable)
+                    .map(|x| vec![x.name, x.ui_name, x.ui_description]),
+            );
+
+            table.printstd();
         }
     };
 
     Ok(())
+}
+
+fn not_found_err(x: impl Into<String>) -> ImlManagerCliError {
+    Error::new(ErrorKind::NotFound, x.into()).into()
 }

--- a/iml-manager-cli/src/update_repo_file.rs
+++ b/iml-manager-cli/src/update_repo_file.rs
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 use crate::{
-    api_utils::{create_command, get_hosts, wait_for_cmds, SendCmd, SendJob},
+    api_utils::{create_command, get_hosts, wait_for_cmds_success, SendCmd, SendJob},
     display_utils::{display_cancelled, display_error, wrap_fut},
     error::ImlManagerCliError,
 };
@@ -73,7 +73,7 @@ pub async fn update_repo_file_cli(config: UpdateRepoFileHosts) -> Result<(), Iml
 
     let cmd = wrap_fut("Updating Repo files...", create_command(cmd)).await?;
 
-    wait_for_cmds(vec![cmd]).await?;
+    wait_for_cmds_success(vec![cmd]).await?;
 
     Ok(())
 }

--- a/iml-warp-drive/src/cache.rs
+++ b/iml-warp-drive/src/cache.rs
@@ -337,6 +337,8 @@ pub async fn populate_from_db(
     ])
     .await?;
 
+    tracing::debug!("Built initial db statements");
+
     let fut1 = future::try_join5(
         into_row(client.query_raw(&stmts[0], iter::empty()).await?),
         into_row(client.query_raw(&stmts[1], iter::empty()).await?),

--- a/iml-warp-drive/src/main.rs
+++ b/iml-warp-drive/src/main.rs
@@ -167,8 +167,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .with(warp::log("iml-warp-drive::api"));
 
+    let addr = iml_manager_env::get_warp_drive_addr();
+
+    tracing::info!("Listening on {}", addr);
+
     let (_, fut) = warp::serve(routes).bind_with_graceful_shutdown(
-        iml_manager_env::get_warp_drive_addr(),
+        addr,
         tokio_runtime_shutdown::when_finished(&valve)
             .then(move |_| users::disconnect_all_users(user_state3)),
     );


### PR DESCRIPTION
Fixes #1710

Add a new default (phase 1) profile called default_baseless.

It has no base repos and is used iff the server_profile (phase 2)
has no base repos as well.

In addition add a list endpoint for server profiles.

  - Add `default_baseless.profile`
  - Update bootstrap to not create repo or install agent if generated
repofile is empty
  - Ensure iml cli returns correct error codes when commands fail.
  - Ensure iml cli returns error when there are no hosts to add.
  - Add some more debug to warp-drive.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1711)
<!-- Reviewable:end -->
