### PR TITLE
Add route to show per-host volumes

### DIFF
--- a/iml-gui/crate/src/components/tree.rs
+++ b/iml-gui/crate/src/components/tree.rs
@@ -5,6 +5,7 @@
 use crate::{
     components::{alert_indicator, font_awesome, paging, Placement},
     generated::css_classes::C,
+    route::RouteId,
     GMsg, Route,
 };
 use iml_wire_types::{
@@ -578,7 +579,7 @@ fn tree_host_item_view(cache: &ArcCache, model: &Model, host: &Host) -> Option<N
         ],
         alert_indicator(&cache.active_alert, &host, true, Placement::Bottom),
         if tree_node.open {
-            tree_volume_collection_view(cache, model, &address)
+            tree_volume_collection_view(cache, model, &address, &host)
         } else {
             empty![]
         }
@@ -714,11 +715,17 @@ fn tree_pools_collection_view(cache: &ArcCache, model: &Model, parent_address: &
     .unwrap_or(empty![])
 }
 
-fn tree_volume_collection_view(cache: &ArcCache, model: &Model, parent_address: &Address) -> Node<Msg> {
+fn tree_volume_collection_view(cache: &ArcCache, model: &Model, parent_address: &Address, host: &Host) -> Node<Msg> {
     tree_collection_view(
         model,
         parent_address.extend(Step::VolumeCollection),
-        |x| item_view("folder", &format!("Volumes ({})", x.paging.total()), Route::Volumes),
+        |x| {
+            item_view(
+                "folder",
+                &format!("Volumes ({})", x.paging.total()),
+                Route::ServerVolumes(RouteId::from(&host.id)),
+            )
+        },
         |x| {
             slice_page(&x.paging, &x.items)
                 .filter_map(|x| cache.volume_node.get(x))

--- a/iml-gui/crate/src/components/tree.rs
+++ b/iml-gui/crate/src/components/tree.rs
@@ -579,7 +579,7 @@ fn tree_host_item_view(cache: &ArcCache, model: &Model, host: &Host) -> Option<N
         ],
         alert_indicator(&cache.active_alert, &host, true, Placement::Bottom),
         if tree_node.open {
-            tree_volume_collection_view(cache, model, &address, &host)
+            tree_volume_collection_view(cache, model, &address, host)
         } else {
             empty![]
         }

--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -1002,6 +1002,7 @@ fn view(model: &Model) -> Vec<Node<Msg>> {
         Page::Users => main_panels(model, page::users::view(&model.records).els().map_msg(page::Msg::Users)).els(),
         Page::User(x) => main_panels(model, page::user::view(x).els().map_msg(page::Msg::User)).els(),
         Page::Volumes(x) => main_panels(model, page::volumes::view(x).els().map_msg(page::Msg::Volumes)).els(),
+        Page::ServerVolumes(x) => main_panels(model, page::volumes::view(x).els().map_msg(page::Msg::Volumes)).els(),
         Page::Volume(x) => main_panels(model, page::volume::view(x).els().map_msg(page::Msg::Volume)).els(),
     };
 

--- a/iml-gui/crate/src/route.rs
+++ b/iml-gui/crate/src/route.rs
@@ -63,6 +63,7 @@ pub enum Route<'a> {
     Users,
     User(RouteId<'a>),
     Volumes,
+    ServerVolumes(RouteId<'a>),
     Volume(RouteId<'a>),
 }
 
@@ -90,6 +91,7 @@ impl<'a> Route<'a> {
             Self::Users => vec!["users"],
             Self::User(id) => vec!["users", id],
             Self::Volumes => vec!["volumes"],
+            Self::ServerVolumes(id) => vec!["servers", id, "volumes"],
             Self::Volume(id) => vec!["volumes", id],
         };
 
@@ -150,7 +152,11 @@ impl<'a> From<Url> for Route<'a> {
             Some("power_control") => Self::PowerControl,
             Some("servers") => match path.next() {
                 None => Self::Servers,
-                Some(id) => Self::Server(RouteId::from(id)),
+                Some(id) => match path.next().as_deref() {
+                    Some("volumes") => Self::ServerVolumes(RouteId::from(id)),
+                    None => Self::Server(RouteId::from(id)),
+                    _ => Self::NotFound,
+                },
             },
             Some("targets") => match path.next() {
                 None => Self::Targets,


### PR DESCRIPTION
The route is `/servers/<server-id>/volumes`.
It opens a page listing the volumes on the specified server.

Closes #1688.

![server-volumes](https://user-images.githubusercontent.com/131844/77354656-dc0c7480-6d4b-11ea-9ca9-b4510ffdca5f.png)


Signed-off-by: Igor Pashev <pashev.igor@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1713)
<!-- Reviewable:end -->
