### PR TITLE
wait_for_cmds fn does not return final command

### DIFF
--- a/iml-manager-cli/src/filesystem.rs
+++ b/iml-manager-cli/src/filesystem.rs
@@ -102,7 +102,7 @@ async fn detect_filesystem(hosts: Option<String>) -> Result<(), ImlManagerCliErr
     };
     let cmd = wrap_fut("Detecting filesystems...", create_command(cmd)).await?;
 
-    wait_for_cmds_success(vec![cmd]).await?;
+    wait_for_cmds_success(&[cmd]).await?;
     Ok(())
 }
 

--- a/iml-manager-cli/src/ostpool.rs
+++ b/iml-manager-cli/src/ostpool.rs
@@ -176,7 +176,7 @@ async fn ostpool_destroy(
     let resp = delete(&pool.resource_uri, "").await?;
     term.write_line(&format!("{} ost pool...", style("Destroying").green()))?;
     let objs: ObjCommands = resp.json().await?;
-    wait_for_cmds_success(objs.commands).await?;
+    wait_for_cmds_success(&objs.commands).await?;
 
     Ok(())
 }
@@ -204,7 +204,7 @@ pub async fn ostpool_cli(command: OstPoolCommand) -> Result<(), ImlManagerCliErr
 
             term.write_line(&format!("{} ost pool...", style("Creating").green()))?;
             let objs: ObjCommand = resp.json().await?;
-            wait_for_cmds_success(vec![objs.command]).await?;
+            wait_for_cmds_success(&[objs.command]).await?;
         }
         OstPoolCommand::Destroy { fsname, poolname } => {
             ostpool_destroy(&term, fsname, poolname).await?;
@@ -226,7 +226,7 @@ pub async fn ostpool_cli(command: OstPoolCommand) -> Result<(), ImlManagerCliErr
             let uri = pool.resource_uri.clone();
             let resp = put(&uri, pool).await?;
             let objs: ObjCommand = resp.json().await?;
-            wait_for_cmds_success(vec![objs.command]).await?;
+            wait_for_cmds_success(&[objs.command]).await?;
         }
         OstPoolCommand::Shrink {
             fsname,
@@ -243,7 +243,7 @@ pub async fn ostpool_cli(command: OstPoolCommand) -> Result<(), ImlManagerCliErr
             let resp = put(&uri, pool).await?;
 
             let objs: ObjCommand = resp.json().await?;
-            wait_for_cmds_success(vec![objs.command]).await?;
+            wait_for_cmds_success(&[objs.command]).await?;
         }
     };
 

--- a/iml-manager-cli/src/server.rs
+++ b/iml-manager-cli/src/server.rs
@@ -575,7 +575,7 @@ async fn get_test_host_commands_and_jobs(
 
     term.write_line(&format!("{} preflight checks...", style("Running").green()))?;
 
-    let cmds = wait_for_cmds(cmds).await?;
+    let cmds = wait_for_cmds(&cmds).await?;
 
     let jobs = get_jobs_from_commands(cmds);
 
@@ -605,7 +605,7 @@ async fn deploy_agents(
 
     term.write_line(&format!("{} agents...", style("Deploying").green()))?;
 
-    wait_for_cmds_success(commands).await?;
+    wait_for_cmds_success(&commands).await?;
 
     wrap_fut(
         "Waiting for agents to restart...",
@@ -679,7 +679,7 @@ async fn add_server(config: AddHosts) -> Result<(), ImlManagerCliError> {
 
     let cmds = handle_profiles(&term, &config, &hosts, &server_profile).await?;
 
-    wait_for_cmds_success(cmds).await?;
+    wait_for_cmds_success(&cmds).await?;
 
     Ok(())
 }
@@ -781,7 +781,7 @@ pub async fn server_cli(command: ServerCommand) -> Result<(), ImlManagerCliError
             let commands: Vec<Command> =
                 wrap_fut("Removing Servers...", future::try_join_all(xs)).await?;
 
-            wait_for_cmds_success(commands).await?;
+            wait_for_cmds_success(&commands).await?;
         }
         ServerCommand::Profile => {
             let profiles: ApiList<ServerProfile> =

--- a/iml-manager-cli/src/update_repo_file.rs
+++ b/iml-manager-cli/src/update_repo_file.rs
@@ -73,7 +73,7 @@ pub async fn update_repo_file_cli(config: UpdateRepoFileHosts) -> Result<(), Iml
 
     let cmd = wrap_fut("Updating Repo files...", create_command(cmd)).await?;
 
-    wait_for_cmds_success(vec![cmd]).await?;
+    wait_for_cmds_success(&[cmd]).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #1720.

The wait_for_cmds fn does not return the final command fetched, but
instead returns the original list of commands back.

When checking for final command state, we need the list generated on the
final tick.

Return the final command state from the fn.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1721)
<!-- Reviewable:end -->
