### PR TITLE
detect_scan: Only request certain targets if non-empty

### DIFF
--- a/chroma_core/models/host.py
+++ b/chroma_core/models/host.py
@@ -959,7 +959,10 @@ class DetectTargetsStep(Step):
         return True
 
     def detect_scan(self, host, host_data, target_devices):
-        host_data[host] = self.invoke_agent(host, "detect_scan", {"target_devices": target_devices})
+        opts = {}
+        if target_devices:
+            opts["target_devices"] = target_devices
+        host_data[host] = self.invoke_agent(host, "detect_scan", opts)
 
     def detect_ha(self, host, ha_data):
         ha_list = self.invoke_rust_agent_expect_result(host.fqdn, "get_ha_resource_list", args=None)


### PR DESCRIPTION
Only pass target_devices to detect_scan on agent if list is non-empty

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1729)
<!-- Reviewable:end -->
