### PR TITLE
Always generate identity.pfx on rust agent startup

### DIFF
--- a/iml-agent/src/env.rs
+++ b/iml-agent/src/env.rs
@@ -69,25 +69,23 @@ lazy_static! {
 
         let pfx_path = get_pfx_path();
 
-        if !path_exists(&pfx_path) {
-            Command::new("openssl")
-                .args(&[
-                    "pkcs12",
-                    "-export",
-                    "-out",
-                    &pfx_path,
-                    "-inkey",
-                    &private_pem_path,
-                    "-in",
-                    &cert_path,
-                    "-certfile",
-                    &authority_cert_path,
-                    "-passout",
-                    "pass:",
-                ])
-                .status()
-                .expect("Error creating pfx");
-        }
+        Command::new("openssl")
+            .args(&[
+                "pkcs12",
+                "-export",
+                "-out",
+                &pfx_path,
+                "-inkey",
+                &private_pem_path,
+                "-in",
+                &cert_path,
+                "-certfile",
+                &authority_cert_path,
+                "-passout",
+                "pass:",
+            ])
+            .status()
+            .expect("Error creating pfx");
 
         std::fs::read(&pfx_path).expect("Could not read pfx")
     };


### PR DESCRIPTION
Ensure we always generate the identity.pfx on rust agent startup to
avoid stale auth.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1730)
<!-- Reviewable:end -->
