### PR TITLE
Update page title & breadcrumb with user

### DIFF
--- a/iml-gui/crate/src/components/breadcrumbs.rs
+++ b/iml-gui/crate/src/components/breadcrumbs.rs
@@ -5,7 +5,6 @@ use crate::{generated::css_classes::C, Msg};
 use seed::{prelude::*, *};
 use std::{cmp::PartialEq, collections::LinkedList};
 
-#[derive(Debug)]
 pub struct BreadCrumbs<Crumb> {
     crumbs: LinkedList<Crumb>,
 }
@@ -16,6 +15,11 @@ impl<Crumb> Default for BreadCrumbs<Crumb> {
             crumbs: LinkedList::new(),
         }
     }
+}
+
+pub trait BreadCrumb {
+    fn title(&self) -> &str;
+    fn href(&self) -> &str;
 }
 
 impl<Crumb: PartialEq> BreadCrumbs<Crumb> {
@@ -45,15 +49,15 @@ impl<Crumb: PartialEq> BreadCrumbs<Crumb> {
     }
 }
 
-pub fn view(bc: &BreadCrumbs<(String, String)>) -> impl View<Msg> {
+pub fn view<Crumb: BreadCrumb + PartialEq>(bc: &BreadCrumbs<Crumb>) -> impl View<Msg> {
     let mut ol = ol![class![C.justify_center, C.truncate, C.mx_4, C.rtl]];
 
     // XXX the list has "direction: rtl" to put ellipsis to the left on overflow,
     // XXX need to reverse the crumbs to show them in the correct left-to-right order:
-    for (n, (href, title)) in bc.iter().rev().enumerate() {
+    for (n, c) in bc.iter().rev().enumerate() {
         let mut cr = li![
             class![C.inline],
-            a![class![C.hover__underline], attrs! {At::Href => href}, title,]
+            a![class![C.hover__underline], attrs! {At::Href => c.href()}, c.title()]
         ];
         if n == 0 {
             cr.add_class(C.text_blue_500);

--- a/iml-gui/crate/src/page/mod.rs
+++ b/iml-gui/crate/src/page/mod.rs
@@ -75,7 +75,6 @@ pub(crate) enum Page {
 
 impl Page {
     pub(crate) fn title(self: &Self) -> String {
-        // FIXME: delegate to a model where possible, e. g. Self::User(m) => m.title()?
         match self {
             Self::About => "About".into(),
             Self::AppLoading => "Loading...".into(),
@@ -97,7 +96,7 @@ impl Page {
             Self::Targets => "Targets".into(),
             Self::Target(m) => format!("Target: {}", &m.target.name),
             Self::Users => "Users".into(),
-            Self::User(m) => format!("User: {}", &m.user.username),
+            Self::User(m) => format!("User: {}", m.title()),
             Self::Volumes(_) => "Volumes".into(),
             Self::ServerVolumes(m) => format!("Volumes on {}", &m.host.as_ref().unwrap().fqdn),
             Self::Volume(m) => format!("Volume: {}", &m.id),

--- a/iml-gui/crate/src/page/user.rs
+++ b/iml-gui/crate/src/page/user.rs
@@ -46,6 +46,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
             match x.response() {
                 Ok(_) => {
                     model.toast = Some(toast::Model::Success(format!("{} updated", model.user.username)));
+                    orders.send_g_msg(GMsg::UpdatePageTitle);
                 }
                 Err(e) => {
                     error!("An error has occurred {:?}", e);
@@ -65,6 +66,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
         Msg::SetUser(user) => {
             model.edited_user = (*user).clone();
             model.user = user;
+            orders.send_g_msg(GMsg::UpdatePageTitle);
         }
         Msg::UsernameChange(x) => model.edited_user.username = x,
         Msg::FirstNameChange(x) => model.edited_user.first_name = x,
@@ -81,6 +83,14 @@ pub struct Model {
 }
 
 impl Model {
+    pub fn title(&self) -> String {
+        match (self.user.first_name.as_str(), self.user.last_name.as_str()) {
+            ("", "") => self.user.username.clone(),
+            ("", l) => l.into(),
+            (f, "") => f.into(),
+            (f, l) => format!("{} {}", f, l),
+        }
+    }
     pub fn new(user: Arc<AuthUserRecord>) -> Self {
         Self {
             edited_user: (*user).clone(),


### PR DESCRIPTION
In general: update the current breadcrumb whenever the current page's title
changes.

In particular: when the user is updated, update the user page's title

Closes: #1734.

![user](https://user-images.githubusercontent.com/131844/77751941-4add1c80-702f-11ea-8a09-f5bc6ae74cf4.gif)


Signed-off-by: Igor Pashev <pashev.igor@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1739)
<!-- Reviewable:end -->
