### PR TITLE
Allow NTP to use the `stratagem_existing_client`

### DIFF
--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -155,7 +155,7 @@ def validate_mdt_profile(bundle):
 
 
 def validate_client_profile(bundle):
-    if not ManagedHost.objects.filter(server_profile_id="stratagem_client").exists():
+    if not ManagedHost.objects.filter(server_profile_id__in=["stratagem_client", "stratagem_existing_client"]).exists():
         return {
             "code": "stratagem_client_profile_not_installed",
             "message": "A client must be added with the 'Stratagem Client' profile to run this command.",

--- a/chroma_core/models/stratagem.py
+++ b/chroma_core/models/stratagem.py
@@ -9,7 +9,7 @@ from os import path
 from toolz.functoolz import pipe, partial, flip
 from settings import MAILBOX_PATH, SERVER_HTTP_URL
 from django.db import models
-from django.db.models import CASCADE
+from django.db.models import CASCADE, Q
 from chroma_core.lib.cache import ObjectCache
 from chroma_core.models.jobs import StatefulObject
 from chroma_core.models.utils import DeletableMetaclass
@@ -678,7 +678,9 @@ class SendStratagemResultsToClientJob(Job):
         return "Sending stratagem results to client"
 
     def get_steps(self):
-        client_host = ManagedHost.objects.get(server_profile_id="stratagem_client")
+        client_host = ManagedHost.objects.get(
+            Q(server_profile_id="stratagem_client") | Q(server_profile_id="stratagem_existing_client")
+        )
         client_mount = LustreClientMount.objects.get(host_id=client_host.id, filesystem_id=self.filesystem.id)
 
         return [

--- a/chroma_core/services/job_scheduler/job_scheduler.py
+++ b/chroma_core/services/job_scheduler/job_scheduler.py
@@ -1910,7 +1910,9 @@ class JobScheduler(object):
             }
         )
 
-        client_host = ManagedHost.objects.get(server_profile_id="stratagem_client")
+        client_host = ManagedHost.objects.get(
+            Q(server_profile_id="stratagem_client") | Q(server_profile_id="stratagem_existing_client")
+        )
         client_mount_exists = LustreClientMount.objects.filter(host_id=client_host.id, filesystem_id=fs_id).exists()
 
         mountpoint = "/mnt/{}".format(filesystem.name)


### PR DESCRIPTION
Fixes #1743.

Description:
Currently, stratagem verifies that the stratagem_client profile is installed on the client. We also have the stratagem_existing_client profile, which is also valid. This code should be updated to allow for either client to be installed.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1744)
<!-- Reviewable:end -->
