### PR TITLE
Change `MGTs` to `MDTs` on filesystem page

### DIFF
--- a/iml-gui/crate/src/page/filesystem.rs
+++ b/iml-gui/crate/src/page/filesystem.rs
@@ -365,7 +365,7 @@ fn details_table(cache: &ArcCache, all_locks: &Locks, model: &Model) -> Node<Msg
             ],
             tr![t::th_left(plain!("MGS")), t::td_view(mgs(&model.mgt, &model.fs)),],
             tr![
-                t::th_left(plain!("Number of MGTs")),
+                t::th_left(plain!("Number of MDTs")),
                 t::td_view(plain!(model.mdts.len().to_string()))
             ],
             tr![


### PR DESCRIPTION
- Update filesystem page to use correct label.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1747)
<!-- Reviewable:end -->
