### PR TITLE
Vagrant: Add ldiskfs-lvm-fs provisioners

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -75,6 +75,19 @@ From here you can decide what type of setup to run.
 
   1. https://whamcloud.github.io/Online-Help/docs/Contributor_Docs/cd_Managed_ZFS.html
 
+- Monitored Ldiskfs with LVM Metadata:
+
+  ```sh
+	vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-network,create-ldiskfs-lvm-fs,mount-ldiskfs-lvm-fs
+	```
+
+- Monitored Ldiskfs with LVM Metadata and HA:
+
+  ```sh
+	vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-network,create-ldiskfs-lvm-fs,ha-ldiskfs-lvm-fs-step1
+	vagrant provision --provision-with=ha-ldiskfs-lvm-fs-step2
+	```
+
 ### Windows
 
 This is tested on Windows 10 1909.

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -85,7 +85,7 @@ From here you can decide what type of setup to run.
 
   ```sh
 	vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-network,create-ldiskfs-lvm-fs,ha-ldiskfs-lvm-fs-prep
-	VBOX_PASSWD=lustre
+	VBOX_PASSWD=<ROOT_PW_HERE>
 	vagrant provision --provision-with=ha-ldiskfs-lvm-fs-setup
 	```
 

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -84,8 +84,9 @@ From here you can decide what type of setup to run.
 - Monitored Ldiskfs with LVM Metadata and HA:
 
   ```sh
-	vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-network,create-ldiskfs-lvm-fs,ha-ldiskfs-lvm-fs-step1
-	vagrant provision --provision-with=ha-ldiskfs-lvm-fs-step2
+	vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-network,create-ldiskfs-lvm-fs,ha-ldiskfs-lvm-fs-prep
+	VBOX_PASSWD=lustre
+	vagrant provision --provision-with=ha-ldiskfs-lvm-fs-setup
 	```
 
 ### Windows

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -253,11 +253,11 @@ Vagrant.configure('2') do |config|
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
-                           mkfs.lustre --failover 10.73.20.12@tcp --mgs --backfstype=zfs mgt/mgt
+                           mkfs.lustre --servicenode 10.73.20.11@tcp:10.73.20.12@tcp --mgs --backfstype=zfs mgt/mgt
                            mkdir -p /lustre/zfsmo/mgs
                            mount -t lustre mgt/mgt /lustre/zfsmo/mgs
 
-                           mkfs.lustre --reformat --failover 10.73.20.12@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=0 --mgsnode=10.73.20.11@tcp mdt0/mdt0
+                           mkfs.lustre --reformat --failover 10.73.20.12@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=0 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp mdt0/mdt0
                            mkdir -p /lustre/zfsmo/mdt0
                            mount -t lustre mdt0/mdt0 /lustre/zfsmo/mdt0
                          SHELL
@@ -267,7 +267,7 @@ Vagrant.configure('2') do |config|
                          run: 'never',
                          inline: <<-SHELL
                               mkfs.lustre --mgs --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp /dev/mapper/mpatha
-                              mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=0 --mgsnode=10.73.20.11@tcp --fsname=fs /dev/mapper/mpathb
+                              mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=0 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp --fsname=fs /dev/mapper/mpathb
                          SHELL
 
         mds.vm.provision 'mount-ldiskfs-fs',
@@ -280,6 +280,36 @@ Vagrant.configure('2') do |config|
                            mount -t lustre /dev/mapper/mpathb /mnt/mdt0
                          SHELL
 
+        mds.vm.provision 'create-ldiskfs-lvm-fs',
+                         type: 'shell',
+                         run: 'never',
+                         path: 'scripts/create_ldiskfs_lvm_fs.sh',
+                         args: ['fs', '/dev/mapper/mpathb', 0, '/dev/mapper/mpatha']
+
+        mds.vm.provision 'mount-ldiskfs-lvm-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           mkdir -p /mnt/mgs
+                           mkdir -p /mnt/mdt0
+                           mount -t lustre /dev/mapper/mgt_vg-mgt /mnt/mgs
+                           mount -t lustre /dev/mapper/mdt0_vg-mdt /mnt/mdt0
+                         SHELL
+
+         mds.vm.provision 'ha-ldiskfs-lvm-fs-step2',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           pcs cluster auth mds1.local mds2.local -u hacluster -p lustre
+                           pcs cluster setup --start --name mds-cluster mds1.local mds2.local --enable --token 17000
+                           pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 login=root passwd=lustre
+                           pcs resource create mgs-vg ocf:heartbeat:LVM volgrpname=mgt_vg exclusive=true op start timeout=120 op stop timeout=120 --group mgs-grp
+                           pcs resource create mgs ocf:lustre:Lustre target=/dev/mapper/mgt_vg-mgt mountpoint=/mnt/mgs op start timeout=900 op stop timeout=120 --group mgs-grp
+                           pcs resource create mdt0-vg ocf:heartbeat:LVM volgrpname=mdt0_vg exclusive=true op start timeout=120 op stop timeout=120 --group mdt0-grp
+                           pcs resource create mdt0 ocf:lustre:Lustre target=/dev/mapper/mdt0_vg-mdt mountpoint=/mnt/mdt0 op start timeout=900 op stop timeout=120 --group mdt0-grp
+                           pcs resource create mdt1-vg ocf:heartbeat:LVM volgrpname=mdt1_vg exclusive=true op start timeout=120 op stop timeout=120 --group mdt1-grp
+                           pcs resource create mdt1 ocf:lustre:Lustre target=/dev/mapper/mdt1_vg-mdt mountpoint=/mnt/mdt1 op start timeout=900 op stop timeout=120 --group mdt1-grp
+                         SHELL
       else
         mds.vm.provision 'create-pools',
                          type: 'shell',
@@ -289,7 +319,7 @@ Vagrant.configure('2') do |config|
                            zpool create mdt1 -o multihost=on /dev/mapper/mpathc
                          SHELL
 
-      mds.vm.provision 'import-pools',
+        mds.vm.provision 'import-pools',
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
@@ -305,7 +335,7 @@ Vagrant.configure('2') do |config|
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
-                           mkfs.lustre --failover 10.73.20.11@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=1 --mgsnode=10.73.20.11@tcp mdt1/mdt1
+                           mkfs.lustre --failover 10.73.20.11@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=1 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp mdt1/mdt1
                            mkdir -p /lustre/zfsmo/mdt1
                            mount -t lustre mdt1/mdt1 /lustre/zfsmo/mdt1
                          SHELL
@@ -314,14 +344,14 @@ Vagrant.configure('2') do |config|
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
-                            mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=1 --mgsnode=10.73.20.11@tcp --fsname=fs /dev/mapper/mpathc
+                            mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=1 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp --fsname=fs /dev/mapper/mpathc
                          SHELL
 
         mds.vm.provision 'create-ldiskfs-fs2',
                             type: 'shell',
                             run: 'never',
                             inline: <<-SHELL
-                              mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=0 --mgsnode=10.73.20.11@tcp --fsname=fs2 /dev/mapper/mpathd
+                              mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=0 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp --fsname=fs2 /dev/mapper/mpathd
                             SHELL
 
         mds.vm.provision 'mount-ldiskfs-fs',
@@ -339,7 +369,34 @@ Vagrant.configure('2') do |config|
                            mkdir -p /mnt/mdt2
                            mount -t lustre /dev/mapper/mpathd /mnt/mdt2
                          SHELL
+
+        mds.vm.provision 'create-ldiskfs-lvm-fs',
+                         type: 'shell',
+                         run: 'never',
+                         path: 'scripts/create_ldiskfs_lvm_fs.sh',
+                         args: ['fs', '/dev/mapper/mpathc', 1, '']
+
+        mds.vm.provision 'mount-ldiskfs-lvm-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           mkdir -p /mnt/mdt1
+                           mount -t lustre /dev/mapper/mdt1_vg-mdt /mnt/mdt1
+                         SHELL
+
       end
+
+      mds.vm.provision 'ha-ldiskfs-lvm-fs-step1',
+                       type: 'shell',
+                       run: 'never',
+                       inline: <<-SHELL
+                         yum -y  --nogpgcheck install pcs lustre-resource-agents
+                         echo -n lustre | passwd --stdin hacluster
+                         systemctl enable --now pcsd
+                         mkdir -p /mnt/mgs
+                         mkdir -p /mnt/mdt{0,1}
+                       SHELL
+
     end
   end
 
@@ -441,16 +498,16 @@ Vagrant.configure('2') do |config|
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
-                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=0 --mgsnode=10.73.20.11@tcp ost0/ost0
-                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=1 --mgsnode=10.73.20.11@tcp ost1/ost1
-                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=2 --mgsnode=10.73.20.11@tcp ost2/ost2
-                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=3 --mgsnode=10.73.20.11@tcp ost3/ost3
-                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=4 --mgsnode=10.73.20.11@tcp ost4/ost4
-                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=5 --mgsnode=10.73.20.11@tcp ost5/ost5
-                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=6 --mgsnode=10.73.20.11@tcp ost6/ost6
-                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=7 --mgsnode=10.73.20.11@tcp ost7/ost7
-                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=8 --mgsnode=10.73.20.11@tcp ost8/ost8
-                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=9 --mgsnode=10.73.20.11@tcp ost9/ost9
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=0 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost0/ost0
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=1 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost1/ost1
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=2 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost2/ost2
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=3 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost3/ost3
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=4 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost4/ost4
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=5 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost5/ost5
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=6 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost6/ost6
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=7 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost7/ost7
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=8 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost8/ost8
+                              mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=9 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost9/ost9
                               mkdir -p /lustre/zfsmo/ost{0..9}
                               mount -t lustre ost0/ost0 /lustre/zfsmo/ost0
                               mount -t lustre ost1/ost1 /lustre/zfsmo/ost1
@@ -500,6 +557,38 @@ Vagrant.configure('2') do |config|
                           mount -t lustre /dev/mapper/mpathj /mnt/ost2-4
                          SHELL
 
+        oss.vm.provision 'create-ldiskfs-lvm-fs',
+                         type: 'shell',
+                         run: 'never',
+                         path: 'scripts/create_ldiskfs_fs_osts.sh',
+                         args: ['a', 'e', 0, 'fs']
+
+        oss.vm.provision 'mount-ldiskfs-lvm-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                          mkdir -p /mnt/ost{0,1,2,3,4}
+                          mount -t lustre /dev/mapper/mpatha /mnt/ost0
+                          mount -t lustre /dev/mapper/mpathb /mnt/ost1
+                          mount -t lustre /dev/mapper/mpathc /mnt/ost2
+                          mount -t lustre /dev/mapper/mpathd /mnt/ost3
+                          mount -t lustre /dev/mapper/mpathe /mnt/ost4
+                         SHELL
+
+        oss.vm.provision 'ha-ldiskfs-lvm-fs-step2',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           pcs cluster auth oss1.local oss2.local -u hacluster -p lustre
+                           pcs cluster setup --start --name mds-cluster oss1.local oss2.local --enable --token 17000
+                           pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 login=root passwd=lustre
+                           IDX=0
+                           for x in {a..e} {k..o}; do
+                             pcs resource create ost$IDX ocf:lustre:Lustre target=/dev/mapper/mpath$x mountpoint=/mnt/ost$IDX op start timeout=900 op stop timeout=120
+                             ((IDX++))
+                           done
+                         SHELL
+
       else
         oss.vm.provision 'create-pools',
                          type: 'shell',
@@ -543,16 +632,16 @@ Vagrant.configure('2') do |config|
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
-                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=10 --mgsnode=10.73.20.11@tcp ost10/ost10
-                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=11 --mgsnode=10.73.20.11@tcp ost11/ost11
-                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=12 --mgsnode=10.73.20.11@tcp ost12/ost12
-                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=13 --mgsnode=10.73.20.11@tcp ost13/ost13
-                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=14 --mgsnode=10.73.20.11@tcp ost14/ost14
-                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=15 --mgsnode=10.73.20.11@tcp ost15/ost15
-                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=16 --mgsnode=10.73.20.11@tcp ost16/ost16
-                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=17 --mgsnode=10.73.20.11@tcp ost17/ost17
-                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=18 --mgsnode=10.73.20.11@tcp ost18/ost18
-                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=19 --mgsnode=10.73.20.11@tcp ost19/ost19
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=10 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost10/ost10
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=11 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost11/ost11
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=12 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost12/ost12
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=13 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost13/ost13
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=14 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost14/ost14
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=15 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost15/ost15
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=16 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost16/ost16
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=17 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost17/ost17
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=18 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost18/ost18
+                              mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=19 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost19/ost19
                               mkdir -p /lustre/zfsmo/ost{10..19}
                               mount -t lustre ost10/ost10 /lustre/zfsmo/ost10
                               mount -t lustre ost11/ost11 /lustre/zfsmo/ost11
@@ -601,7 +690,37 @@ Vagrant.configure('2') do |config|
                              mount -t lustre /dev/mapper/mpaths /mnt/ost2-8
                              mount -t lustre /dev/mapper/mpatht /mnt/ost2-9
                          SHELL
+
+        oss.vm.provision 'create-ldiskfs-lvm-fs',
+                         type: 'shell',
+                         run: 'never',
+                         path: 'scripts/create_ldiskfs_fs_osts.sh',
+                         args: ['k', 'o', 5, 'fs']
+
+        oss.vm.provision 'mount-ldiskfs-lvm-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                             mkdir -p /mnt/ost{5,6,7,8,9}
+                             mount -t lustre /dev/mapper/mpathk /mnt/ost5
+                             mount -t lustre /dev/mapper/mpathl /mnt/ost6
+                             mount -t lustre /dev/mapper/mpathm /mnt/ost7
+                             mount -t lustre /dev/mapper/mpathn /mnt/ost8
+                             mount -t lustre /dev/mapper/mpatho /mnt/ost9
+                         SHELL
+
       end
+
+      oss.vm.provision 'ha-ldiskfs-lvm-fs-step1',
+                       type: 'shell',
+                       run: 'never',
+                       inline: <<-SHELL
+                         yum -y --nogpgcheck install pcs lustre-resource-agents
+                         echo -n lustre | passwd --stdin hacluster
+                         systemctl enable --now pcsd
+                         mkdir -p /mnt/ost{0..9}
+                       SHELL
+
     end
   end
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -11,6 +11,10 @@ ISCSI_MEM = (ENV['ISCSI_MEM'] || 1024).freeze
 # Num CPUs allocated to the iSCSI server VM
 ISCSI_CPU = (ENV['ISCSI_CPU'] || 4).freeze
 
+VBOX_USER   = (ENV['VBOX_USER']   || "").freeze
+VBOX_PASSWD = (ENV['VBOX_PASSWD'] || "").freeze
+VBOX_SSHKEY = (ENV['VBOX_SSHKEY'] || "").freeze
+
 require 'open3'
 require 'fileutils'
 
@@ -296,20 +300,11 @@ Vagrant.configure('2') do |config|
                            mount -t lustre /dev/mapper/mdt0_vg-mdt /mnt/mdt0
                          SHELL
 
-         mds.vm.provision 'ha-ldiskfs-lvm-fs-step2',
+         mds.vm.provision 'ha-ldiskfs-lvm-fs-setup',
                          type: 'shell',
                          run: 'never',
-                         inline: <<-SHELL
-                           pcs cluster auth mds1.local mds2.local -u hacluster -p lustre
-                           pcs cluster setup --start --name mds-cluster mds1.local mds2.local --enable --token 17000
-                           pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 login=root passwd=lustre
-                           pcs resource create mgs-vg ocf:heartbeat:LVM volgrpname=mgt_vg exclusive=true op start timeout=120 op stop timeout=120 --group mgs-grp
-                           pcs resource create mgs ocf:lustre:Lustre target=/dev/mapper/mgt_vg-mgt mountpoint=/mnt/mgs op start timeout=900 op stop timeout=120 --group mgs-grp
-                           pcs resource create mdt0-vg ocf:heartbeat:LVM volgrpname=mdt0_vg exclusive=true op start timeout=120 op stop timeout=120 --group mdt0-grp
-                           pcs resource create mdt0 ocf:lustre:Lustre target=/dev/mapper/mdt0_vg-mdt mountpoint=/mnt/mdt0 op start timeout=900 op stop timeout=120 --group mdt0-grp
-                           pcs resource create mdt1-vg ocf:heartbeat:LVM volgrpname=mdt1_vg exclusive=true op start timeout=120 op stop timeout=120 --group mdt1-grp
-                           pcs resource create mdt1 ocf:lustre:Lustre target=/dev/mapper/mdt1_vg-mdt mountpoint=/mnt/mdt1 op start timeout=900 op stop timeout=120 --group mdt1-grp
-                         SHELL
+                         path: 'scripts/create_ldiskfs_lvm_mds_ha_setup.sh',
+                         args: [ VBOX_USER, VBOX_PASSWD, VBOX_SSHKEY ]
       else
         mds.vm.provision 'create-pools',
                          type: 'shell',
@@ -386,7 +381,7 @@ Vagrant.configure('2') do |config|
 
       end
 
-      mds.vm.provision 'ha-ldiskfs-lvm-fs-step1',
+      mds.vm.provision 'ha-ldiskfs-lvm-fs-prep',
                        type: 'shell',
                        run: 'never',
                        inline: <<-SHELL
@@ -575,20 +570,12 @@ Vagrant.configure('2') do |config|
                           mount -t lustre /dev/mapper/mpathe /mnt/ost4
                          SHELL
 
-        oss.vm.provision 'ha-ldiskfs-lvm-fs-step2',
+        oss.vm.provision 'ha-ldiskfs-lvm-fs-setup',
                          type: 'shell',
                          run: 'never',
-                         inline: <<-SHELL
-                           pcs cluster auth oss1.local oss2.local -u hacluster -p lustre
-                           pcs cluster setup --start --name mds-cluster oss1.local oss2.local --enable --token 17000
-                           pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 login=root passwd=lustre
-                           IDX=0
-                           for x in {a..e} {k..o}; do
-                             pcs resource create ost$IDX ocf:lustre:Lustre target=/dev/mapper/mpath$x mountpoint=/mnt/ost$IDX op start timeout=900 op stop timeout=120
-                             ((IDX++))
-                           done
-                         SHELL
-
+                         path: 'scripts/create_ldiskfs_lvm_mds_ha_setup.sh',
+                         args: [ "{a..e} {k..o}", 0, VBOX_USER, VBOX_PASSWD, VBOX_SSHKEY ]
+                         
       else
         oss.vm.provision 'create-pools',
                          type: 'shell',
@@ -711,7 +698,7 @@ Vagrant.configure('2') do |config|
 
       end
 
-      oss.vm.provision 'ha-ldiskfs-lvm-fs-step1',
+      oss.vm.provision 'ha-ldiskfs-lvm-fs-prep',
                        type: 'shell',
                        run: 'never',
                        inline: <<-SHELL

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -11,7 +11,9 @@ ISCSI_MEM = (ENV['ISCSI_MEM'] || 1024).freeze
 # Num CPUs allocated to the iSCSI server VM
 ISCSI_CPU = (ENV['ISCSI_CPU'] || 4).freeze
 
-VBOX_USER   = (ENV['VBOX_USER']   || "").freeze
+# User is required (default to root)
+# need either password or sshkey (or will assume sshkey)
+VBOX_USER   = (ENV['VBOX_USER']   || "root").freeze
 VBOX_PASSWD = (ENV['VBOX_PASSWD'] || "").freeze
 VBOX_SSHKEY = (ENV['VBOX_SSHKEY'] || "").freeze
 
@@ -573,7 +575,7 @@ Vagrant.configure('2') do |config|
         oss.vm.provision 'ha-ldiskfs-lvm-fs-setup',
                          type: 'shell',
                          run: 'never',
-                         path: 'scripts/create_ldiskfs_lvm_mds_ha_setup.sh',
+                         path: 'scripts/create_ldiskfs_lvm_oss_ha_setup.sh',
                          args: [ "{a..e} {k..o}", 0, VBOX_USER, VBOX_PASSWD, VBOX_SSHKEY ]
                          
       else

--- a/vagrant/scripts/create_ldiskfs_fs_osts.sh
+++ b/vagrant/scripts/create_ldiskfs_fs_osts.sh
@@ -6,6 +6,6 @@ IDX=$3
 FSNAME=$4
 
 for x in $(eval echo "{$START..$END}"); do
-     mkfs.lustre --ost --reformat --servicenode=10.73.20.21@tcp --servicenode=10.73.20.22@tcp --index=$IDX --mgsnode=10.73.20.11@tcp:10.73.20.11@tcp --fsname=$FSNAME /dev/mapper/mpath$x
+     mkfs.lustre --ost --reformat --servicenode=10.73.20.21@tcp --servicenode=10.73.20.22@tcp --index=$IDX --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp --fsname=$FSNAME /dev/mapper/mpath$x
      ((IDX++))
 done

--- a/vagrant/scripts/create_ldiskfs_fs_osts.sh
+++ b/vagrant/scripts/create_ldiskfs_fs_osts.sh
@@ -6,6 +6,6 @@ IDX=$3
 FSNAME=$4
 
 for x in $(eval echo "{$START..$END}"); do
-     mkfs.lustre --ost --reformat --servicenode=10.73.20.21@tcp --servicenode=10.73.20.22@tcp --index=$IDX --mgsnode=10.73.20.11@tcp --fsname=$FSNAME /dev/mapper/mpath$x
+     mkfs.lustre --ost --reformat --servicenode=10.73.20.21@tcp --servicenode=10.73.20.22@tcp --index=$IDX --mgsnode=10.73.20.11@tcp:10.73.20.11@tcp --fsname=$FSNAME /dev/mapper/mpath$x
      ((IDX++))
 done

--- a/vagrant/scripts/create_ldiskfs_lvm_fs.sh
+++ b/vagrant/scripts/create_ldiskfs_lvm_fs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+yum -y install lvm2
+systemctl disable --now lvm2-lvmetad.service lvm2-lvmetad.socket
+sed -i -e 's/use_lvmetad = 1/use_lvmetad = 0/' /etc/lvm/lvm.conf
+
+FSNAME=$1
+MDT=$2
+IDX=$3
+MGT=$4
+
+# if doing mdt0 also do mgt
+if [ -n "$MGT" ]; then
+    pvcreate $MGT
+    vgcreate mgt_vg $MGT
+    lvcreate -n mgt -l 100%FREE --addtag pacemaker mgt_vg
+    mkfs.lustre --mgs --reformat --servicenode=10.73.20.11@tcp:10.73.20.12@tcp /dev/mapper/mgt_vg-mgt
+fi
+
+pvcreate $MDT
+vgcreate mdt${IDX}_vg $MDT
+lvcreate -n mdt -l 100%FREE --addtag pacemaker mdt${IDX}_vg
+mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp:10.73.20.12@tcp --index=$IDX --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp --fsname=$FSNAME /dev/mapper/mdt${IDX}_vg-mdt
+
+sed -i -e '/^activation/a\ \tvolume_list = []\n\tauto_activation_volume_list = []' /etc/lvm/lvm.conf

--- a/vagrant/scripts/create_ldiskfs_lvm_mds_ha_setup.sh
+++ b/vagrant/scripts/create_ldiskfs_lvm_mds_ha_setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# ARGS: VBOX_USER VBOX_PASSWD VBOX_SSHKEY
+#
+USER=$1
+PASSWD=$2
+SSHKEY=$3
+
+pcs cluster auth mds1.local mds2.local -u hacluster -p lustre
+pcs cluster setup --start --name mds-cluster mds1.local mds2.local --enable --token 17000
+pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 ${VBOX_USER:+login=${USER}} ${PASSWD:+passwd=${PASSWD}} ${SSHKEY:+identity_file=${SSHKEY}}
+pcs resource create mgs-vg ocf:heartbeat:LVM volgrpname=mgt_vg exclusive=true op start timeout=120 op stop timeout=120 --group mgs-grp
+pcs resource create mgs ocf:lustre:Lustre target=/dev/mapper/mgt_vg-mgt mountpoint=/mnt/mgs op start timeout=900 op stop timeout=120 --group mgs-grp
+pcs resource create mdt0-vg ocf:heartbeat:LVM volgrpname=mdt0_vg exclusive=true op start timeout=120 op stop timeout=120 --group mdt0-grp
+pcs resource create mdt0 ocf:lustre:Lustre target=/dev/mapper/mdt0_vg-mdt mountpoint=/mnt/mdt0 op start timeout=900 op stop timeout=120 --group mdt0-grp
+pcs resource create mdt1-vg ocf:heartbeat:LVM volgrpname=mdt1_vg exclusive=true op start timeout=120 op stop timeout=120 --group mdt1-grp
+pcs resource create mdt1 ocf:lustre:Lustre target=/dev/mapper/mdt1_vg-mdt mountpoint=/mnt/mdt1 op start timeout=900 op stop timeout=120 --group mdt1-grp

--- a/vagrant/scripts/create_ldiskfs_lvm_mds_ha_setup.sh
+++ b/vagrant/scripts/create_ldiskfs_lvm_mds_ha_setup.sh
@@ -8,7 +8,7 @@ SSHKEY=$3
 
 pcs cluster auth mds1.local mds2.local -u hacluster -p lustre
 pcs cluster setup --start --name mds-cluster mds1.local mds2.local --enable --token 17000
-pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 ${VBOX_USER:+login=${USER}} ${PASSWD:+passwd=${PASSWD}} ${SSHKEY:+identity_file=${SSHKEY}}
+pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 login=${USER} ${PASSWD:+passwd=${PASSWD}} ${SSHKEY:+identity_file=${SSHKEY}}
 pcs resource create mgs-vg ocf:heartbeat:LVM volgrpname=mgt_vg exclusive=true op start timeout=120 op stop timeout=120 --group mgs-grp
 pcs resource create mgs ocf:lustre:Lustre target=/dev/mapper/mgt_vg-mgt mountpoint=/mnt/mgs op start timeout=900 op stop timeout=120 --group mgs-grp
 pcs resource create mdt0-vg ocf:heartbeat:LVM volgrpname=mdt0_vg exclusive=true op start timeout=120 op stop timeout=120 --group mdt0-grp

--- a/vagrant/scripts/create_ldiskfs_lvm_oss_ha_setup.sh
+++ b/vagrant/scripts/create_ldiskfs_lvm_oss_ha_setup.sh
@@ -11,7 +11,7 @@ SSHKEY=$5
 
 pcs cluster auth oss1.local oss2.local -u hacluster -p lustre
 pcs cluster setup --start --name oss-cluster oss1.local oss2.local --enable --token 17000
-pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 ${VBOX_USER:+login=${USER}} ${PASSWD:+passwd=${PASSWD}} ${SSHKEY:+identity_file=${SSHKEY}}
+pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 login=${USER} ${PASSWD:+passwd=${PASSWD}} ${SSHKEY:+identity_file=${SSHKEY}}
 
 for x in (eval "echo $LIST"); do
     pcs resource create ost$IDX ocf:lustre:Lustre target=/dev/mapper/mpath$x mountpoint=/mnt/ost$IDX op start timeout=900 op stop timeout=120

--- a/vagrant/scripts/create_ldiskfs_lvm_oss_ha_setup.sh
+++ b/vagrant/scripts/create_ldiskfs_lvm_oss_ha_setup.sh
@@ -13,7 +13,7 @@ pcs cluster auth oss1.local oss2.local -u hacluster -p lustre
 pcs cluster setup --start --name oss-cluster oss1.local oss2.local --enable --token 17000
 pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 login=${USER} ${PASSWD:+passwd=${PASSWD}} ${SSHKEY:+identity_file=${SSHKEY}}
 
-for x in (eval "echo $LIST"); do
+for x in $(eval "echo $LIST"); do
     pcs resource create ost$IDX ocf:lustre:Lustre target=/dev/mapper/mpath$x mountpoint=/mnt/ost$IDX op start timeout=900 op stop timeout=120
     ((IDX++))
 done

--- a/vagrant/scripts/create_ldiskfs_lvm_oss_ha_setup.sh
+++ b/vagrant/scripts/create_ldiskfs_lvm_oss_ha_setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# ARGS: MPATH_LIST IDX VBOX_USER VBOX_PASSWD VBOX_SSHKEY
+#
+LIST=$1
+IDX=$2
+
+USER=$3
+PASSWD=$4
+SSHKEY=$5
+
+pcs cluster auth oss1.local oss2.local -u hacluster -p lustre
+pcs cluster setup --start --name oss-cluster oss1.local oss2.local --enable --token 17000
+pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 ${VBOX_USER:+login=${USER}} ${PASSWD:+passwd=${PASSWD}} ${SSHKEY:+identity_file=${SSHKEY}}
+
+for x in (eval "echo $LIST"); do
+    pcs resource create ost$IDX ocf:lustre:Lustre target=/dev/mapper/mpath$x mountpoint=/mnt/ost$IDX op start timeout=900 op stop timeout=120
+    ((IDX++))
+done

--- a/vagrant/scripts/install_ldiskfs_no_iml.sh
+++ b/vagrant/scripts/install_ldiskfs_no_iml.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-2.12.3/el7/patchless-ldiskfs-server/
+yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4/el7/patchless-ldiskfs-server/
 yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
 yum install -y --nogpgcheck lustre kmod-lustre-osd-ldiskfs


### PR DESCRIPTION
Add provisioners to create MDT and MGT on LVMs

To create an ES-like system provision with the following steps:
create-ldiskfs-lvm-fs
ha-ldiskfs-lvm-fs-step1
ha-ldiskfs-lvm-fs-step2

Set lustre version to 2.12.4

Add documentation to README.md

Fixes #1746

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1751)
<!-- Reviewable:end -->
