### PR TITLE
Add repouri provisioner

### DIFF
--- a/iml-system-tests/Cargo.lock
+++ b/iml-system-tests/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "arc-swap"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
 
 [[package]]
 name = "bitflags"
@@ -183,9 +183,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
+checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
 name = "log"
@@ -291,26 +291,21 @@ checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.11"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
+checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 dependencies = [
  "unicode-xid",
 ]
@@ -348,9 +343,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "socket2"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
  "cfg-if",
  "libc",
@@ -360,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
+checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -78,7 +78,7 @@ From here you can decide what type of setup to run.
 - Monitored Ldiskfs with LVM Metadata:
 
   ```sh
-   vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-networkcreate-ldiskfs-lvm-fs,mount-ldiskfs-lvm-fs
+   vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-network,create-ldiskfs-lvm-fs,mount-ldiskfs-lvm-fs
   ```
 
 - Monitored Ldiskfs with LVM Metadata and HA:

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -73,21 +73,21 @@ From here you can decide what type of setup to run.
      vagrant provision --provision-with=deploy-managed-hosts adm
      ```
 
-  1. https://whamcloud.github.io/Online-Help/docs/Contributor_Docs/cd_Managed_ZFS.html
+  1. <https://whamcloud.github.io/Online-Help/docs/Contributor_Docs/cd_Managed_ZFS.html>
 
 - Monitored Ldiskfs with LVM Metadata:
 
   ```sh
-	vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-network,create-ldiskfs-lvm-fs,mount-ldiskfs-lvm-fs
-	```
+   vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-networkcreate-ldiskfs-lvm-fs,mount-ldiskfs-lvm-fs
+  ```
 
 - Monitored Ldiskfs with LVM Metadata and HA:
 
   ```sh
-	vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-network,create-ldiskfs-lvm-fs,ha-ldiskfs-lvm-fs-prep
-	VBOX_PASSWD=<ROOT_PW_HERE>
-	vagrant provision --provision-with=ha-ldiskfs-lvm-fs-setup
-	```
+   vagrant provision --provision-with=install-ldiskfs-no-iml,configure-lustre-network,create-ldiskfs-lvm-fs,ha-ldiskfs-lvm-fs-prep
+   VBOX_PASSWD=<ROOT_PW_HERE>
+   vagrant provision --provision-with=ha-ldiskfs-lvm-fs-setup
+  ```
 
 ### Windows
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -17,6 +17,8 @@ VBOX_USER   = (ENV['VBOX_USER']   || "root").freeze
 VBOX_PASSWD = (ENV['VBOX_PASSWD'] || "").freeze
 VBOX_SSHKEY = (ENV['VBOX_SSHKEY'] || "").freeze
 
+REPO_URI = (ENV['REPO_URI'] || '').freeze
+
 require 'open3'
 require 'fileutils'
 
@@ -128,6 +130,15 @@ Vagrant.configure('2') do |config|
                               'target/',
                               'vagrant/'
                            ]
+
+    # Install IML onto the admin node
+    # Using a given repouri
+    adm.vm.provision 'install-iml-repouri',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/install_iml_repouri.sh',
+                     env: {"REPO_URI" => REPO_URI}
+
 
     # Install IML onto the admin node
     # Using the mfl devel repo

--- a/vagrant/scripts/install_iml_repouri.sh
+++ b/vagrant/scripts/install_iml_repouri.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+if [[ -z $REPO_URI ]];
+then
+    echo "REPO_URI must be set to use this provisioner"
+    exit 1
+fi
+
+cat <<EOF > /etc/yum.repos.d/manager-for-lustre.repo
+[manager-for-lustre]
+name=manager-for-lustre
+baseurl=$REPO_URI
+enabled=1
+gpgcheck=0
+
+[managerforlustre-manager-for-lustre-devel]
+name=Copr repo for manager-for-lustre-devel owned by managerforlustre
+baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/epel-7-\$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+
+[influxdb]
+name = InfluxDB Repository - RHEL 7
+baseurl = https://repos.influxdata.com/centos/7/\$basearch/stable
+enabled = 1
+gpgcheck = 1
+gpgkey = https://repos.influxdata.com/influxdb.key
+
+[grafana]
+name=grafana
+baseurl=https://packages.grafana.com/oss/rpm
+repo_gpgcheck=1
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.grafana.com/gpg.key
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+EOF
+
+yum install -y python2-iml-manager
+
+cat <<EOF > /usr/share/chroma-manager/base.repo
+[manager-for-lustre]
+name=manager-for-lustre
+baseurl=$REPO_URI
+enabled=1
+gpgcheck=0
+
+[managerforlustre-manager-for-lustre-devel]
+name=Copr repo for manager-for-lustre-devel owned by managerforlustre
+baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/epel-7-\$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+EOF
+
+chroma-config setup admin lustre localhost --no-dbspace-check


### PR DESCRIPTION
Add a new provisioner that will allow provisioning via a passed in
REPO_URI environment variable.

`vagrant provision --provision-with=install-iml-repouri`

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1753)
<!-- Reviewable:end -->
