### PR TITLE
Implement device-aggregator as iml daemon plugin

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -37,13 +37,14 @@ srpm:
 	mkdir -p ${TMPDIR}/_topdir/{SOURCES,SPECS}
 	mkdir -p ${TMPDIR}/release/rust-iml
 	cargo build --release
-	cp target/release/iml-{action-runner,agent,agent-comms,agent-daemon,api,mailbox,ostpool,postoffice,stats,warp-drive} \
+	cp target/release/iml-{action-runner,agent,agent-comms,agent-daemon,api,mailbox,ostpool,postoffice,stats,device,warp-drive} \
 		iml-agent-comms.service \
 		iml-mailbox.service \
 		iml-postoffice.service \
 		iml-ostpool.service \
 		iml-api.service \
 		iml-rust-stats.service \
+		iml-device.service \
 		iml-action-runner.service \
 		iml-action-runner.socket \
 		iml-agent/systemd-units/* \
@@ -94,7 +95,6 @@ iml-srpm: iml-deps substs
 		${BUILDROOT}/iml-manager.target \
 		${BUILDROOT}/chroma-config.1 \
 		${BUILDROOT}/logrotate.cfg \
-		${BUILDROOT}/10-device-aggregator.service.conf \
 		${TMPDIR}/configuration
 
 	tar -czvf ${TMPDIR}/_topdir/SOURCES/configuration.tar.gz -C ${TMPDIR}/configuration .

--- a/10-device-aggregator.service.conf
+++ b/10-device-aggregator.service.conf
@@ -1,3 +1,0 @@
-[Unit]
-Before=iml-plugin-runner.service
-Before=nginx.service

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "device-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a837a40ad42813d6c811d407d8386d8a46ad9110d9b3f4b90dc6b05fc45bfa"
+dependencies = [
+ "im 13.0.0",
+ "libzfs-types",
+ "log 0.4.8",
+ "serde",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1127,18 @@ dependencies = [
 
 [[package]]
 name = "im"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8db49f8bc08d5cc4e2bb0f7d25a6d1db2c79bc6f7d7c86c96c657eb3d214125f"
+dependencies = [
+ "rustc_version",
+ "serde",
+ "sized-chunks 0.3.1",
+ "typenum",
+]
+
+[[package]]
+name = "im"
 version = "14.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "696059c87b83c5a258817ecd67c3af915e3ed141891fc35a1e79908801cf0ce7"
@@ -1123,7 +1147,7 @@ dependencies = [
  "rand_core 0.5.1",
  "rand_xoshiro",
  "serde",
- "sized-chunks",
+ "sized-chunks 0.5.3",
  "typenum",
  "version_check 0.9.1",
 ]
@@ -1248,6 +1272,27 @@ dependencies = [
  "futures",
  "tokio",
  "tracing",
+ "warp",
+]
+
+[[package]]
+name = "iml-device"
+version = "0.2.0"
+dependencies = [
+ "device-types",
+ "futures",
+ "iml-manager-env",
+ "iml-rabbit",
+ "iml-service-queue",
+ "iml-wire-types",
+ "insta",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
  "warp",
 ]
 
@@ -1480,7 +1525,7 @@ name = "iml-warp-drive"
 version = "0.2.0"
 dependencies = [
  "futures",
- "im",
+ "im 14.3.0",
  "iml-manager-client",
  "iml-manager-env",
  "iml-postgres",
@@ -1501,7 +1546,7 @@ name = "iml-wire-types"
 version = "0.2.0"
 dependencies = [
  "bytes",
- "im",
+ "im 14.3.0",
  "iml-api-utils",
  "postgres-types",
  "serde",
@@ -1712,6 +1757,16 @@ version = "0.2.0"
 dependencies = [
  "bindgen",
  "libc",
+]
+
+[[package]]
+name = "libzfs-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781e3a0e71718873e3fb34ba980a2ff855079c2685d36c78c3df5586a9379bca"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2869,18 +2924,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
+checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
+checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -2993,6 +3048,15 @@ name = "siphasher"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e88f89a550c01e4cd809f3df4f52dc9e939f3273a2017eabd5c6d12fd98bb23"
+
+[[package]]
+name = "sized-chunks"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f01db57d7ee89c8e053245deb77040a6cc8508311f381c88749c33d4b9b78785"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "sized-chunks"
@@ -3284,6 +3348,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn 1.0.17",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3305,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619cdb2245c40c42d563089b72e80c5df659513d667a017598439ef7a7b1ffe1"
+checksum = "ee5a0dd887e37d37390c13ff8ac830f992307fe30a1fff0ab8427af67211ba28"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     'iml-rabbit',
     'iml-request-retry',
     'iml-services/iml-action-runner',
+    'iml-services/iml-device',
     'iml-services/iml-ostpool',
     'iml-services/iml-postoffice',
     'iml-services/iml-service-queue',

--- a/chroma-manager.conf.template
+++ b/chroma-manager.conf.template
@@ -336,22 +336,6 @@ server {
         alias {{REPO_PATH}}/lustre-client/;
     }
 
-    location /iml-device-aggregator {
-        if ($ssl_client_verify != SUCCESS) {
-            return 401;
-        }
-
-        proxy_set_header X-SSL-Client-On $ssl_client_verify;
-        proxy_set_header X-SSL-Client-Name $ssl_client_s_dn_cn;
-        proxy_set_header X-SSL-Client-Serial $ssl_client_serial;
-
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Server $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Http-Host $http_host;
-        proxy_pass {{DEVICE_AGGREGATOR_PROXY_PASS}};
-    }
-
     location /iml_has_package_updates {
         if ($ssl_client_verify != SUCCESS) {
             return 401;

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@ build: clean
 	COMPOSE_DOCKER_CLI_BUILD=1 docker-compose build
 
 save: build
-	COMPOSE_DOCKER_CLI_BUILD=1 docker-compose pull postgres rabbit device-aggregator update-handler
+	COMPOSE_DOCKER_CLI_BUILD=1 docker-compose pull postgres rabbit update-handler
 	docker save -o iml-images.tar $(COMPOSE_IMAGES)
 	gzip -9 < iml-images.tar > iml-images.tgz
 

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -12,7 +12,7 @@ services:
     restart: on-failure
   update-handler:
     restart: on-failure
-  device-aggregator:
+  device:
     restart: on-failure
   corosync:
     restart: on-failure

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -102,13 +102,16 @@ services:
       - "manager-config:/var/lib/chroma"
     environment:
       - "IML_CA_PATH=/var/lib/chroma/authority.crt"
-  device-aggregator:
-    image: "imlteam/device-aggregator:latest"
-    hostname: "device-aggregator"
+  device:
+    image: "imlteam/device:6.1.0-dev"
+    hostname: "device"
+    build:
+      context: ../
+      dockerfile: ./docker/iml-device.dockerfile
     deploy: *default-deploy
     environment:
       - DEVICE_AGGREGATOR_PORT=8008
-      - PROXY_HOST=device-aggregator
+      - PROXY_HOST=device
       - RUST_LOG=info
     volumes:
       - "manager-config:/var/lib/chroma"
@@ -190,7 +193,7 @@ services:
     volumes:
       - "manager-config:/var/lib/chroma"
     environment:
-      - DEVICE_AGGREGATOR_URL=http://device-aggregator:8008
+      - DEVICE_AGGREGATOR_URL=http://device:8008
   power-control:
     image: "imlteam/manager-power-control:6.1.0-dev"
     hostname: "power-control"

--- a/docker/iml-device.dockerfile
+++ b/docker/iml-device.dockerfile
@@ -1,0 +1,8 @@
+FROM rust-iml-base as builder
+FROM imlteam/rust-service-base:6.1.0-dev
+
+COPY --from=builder /build/target/release/iml-device /usr/local/bin
+COPY docker/wait-for-dependencies.sh /usr/local/bin
+
+ENTRYPOINT [ "wait-for-dependencies.sh" ]
+CMD ["iml-device"]

--- a/docker/setup-nginx
+++ b/docker/setup-nginx
@@ -9,7 +9,7 @@ vars = {
     "HTTP_AGENT_PROXY_PASS": "http://http-agent:8002",
     "HTTP_AGENT2_PROXY_PASS": "http://iml-agent-comms:8003",
     "REPO_PATH": "/var/lib/chroma/repo",
-    "DEVICE_AGGREGATOR_PROXY_PASS": "http://device-aggregator:8008",
+    "DEVICE_AGGREGATOR_PROXY_PASS": "http://device:8008",
     "UPDATE_HANDLER_PROXY_PASS": "http://update-handler:8080",
     "WARP_DRIVE_PROXY_PASS": "http://iml-warp-drive:8890",
     "MAILBOX_PATH": "/var/spool/iml/mailbox",
@@ -29,11 +29,6 @@ with open(conf_template, "r") as f:
     config = re.sub(
         r"proxy_read_timeout (.+);",
         r"proxy_read_timeout \g<1>;\n    resolver 127.0.0.11 ipv6=off valid=5s;\n    resolver_timeout 5s;",
-        config,
-    )
-    config = re.sub(
-        r"location /iml-device-aggregator {",
-        r"location /iml-device-aggregator {\n\n         client_body_buffer_size 1m;\n        client_max_body_size 8m;\n",
         config,
     )
 

--- a/iml-agent/src/daemon_plugins/daemon_plugin.rs
+++ b/iml-agent/src/daemon_plugins/daemon_plugin.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     agent_error::{NoPluginError, Result},
-    daemon_plugins::{action_runner, ostpool, postoffice, stats},
+    daemon_plugins::{action_runner, device, ostpool, postoffice, stats},
 };
 use futures::{future, Future, FutureExt};
 use iml_wire_types::{AgentResult, PluginName};
@@ -70,6 +70,7 @@ pub fn plugin_registry() -> DaemonPlugins {
         ("ostpool".into(), mk_callback(ostpool::create)),
         ("postoffice".into(), mk_callback(postoffice::create)),
         ("stats".into(), mk_callback(stats::create)),
+        ("device".into(), mk_callback(device::create)),
     ]
     .into_iter()
     .collect();

--- a/iml-agent/src/daemon_plugins/device.rs
+++ b/iml-agent/src/daemon_plugins/device.rs
@@ -1,0 +1,118 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{
+    agent_error::ImlAgentError,
+    daemon_plugins::{DaemonPlugin, Output},
+};
+use futures::{
+    channel::oneshot, future, lock::Mutex, Future, FutureExt, Stream, StreamExt, TryFutureExt,
+    TryStreamExt,
+};
+use std::{pin::Pin, sync::Arc};
+use stream_cancel::{StreamExt as _, Trigger, Tripwire};
+use tokio::{io::AsyncWriteExt, net::UnixStream};
+use tokio_util::codec::{FramedRead, LinesCodec};
+
+/// Opens a persistent stream to device scanner.
+fn device_stream() -> impl Stream<Item = Result<String, ImlAgentError>> {
+    UnixStream::connect("/var/run/device-scanner.sock")
+        .err_into()
+        .and_then(|mut conn| async {
+            conn.write_all(b"\"Stream\"\n")
+                .err_into::<ImlAgentError>()
+                .await?;
+
+            Ok(conn)
+        })
+        .map_ok(|c| FramedRead::new(c, LinesCodec::new()).err_into())
+        .try_flatten_stream()
+}
+
+pub fn create() -> impl DaemonPlugin {
+    Devices {
+        trigger: None,
+        state: Arc::new(Mutex::new((None, None))),
+    }
+}
+
+#[derive(Debug)]
+pub struct Devices {
+    trigger: Option<Trigger>,
+    state: Arc<Mutex<(Output, Output)>>,
+}
+
+impl DaemonPlugin for Devices {
+    fn start_session(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Output, ImlAgentError>> + Send>> {
+        let (trigger, tripwire) = Tripwire::new();
+        let (tx, rx) = oneshot::channel();
+
+        self.trigger = Some(trigger);
+
+        let state = Arc::clone(&self.state);
+
+        tokio::spawn(
+            device_stream()
+                .boxed()
+                .and_then(|x| future::ready(serde_json::from_str(&x).map_err(|e| e.into())))
+                .into_future()
+                .then(|(x, s)| {
+                    let x = if let Some(x) = x {
+                        x.map(move |y| {
+                            let _ = tx.send(y);
+                            s
+                        })
+                    } else {
+                        Ok(s)
+                    };
+
+                    future::ready(x)
+                })
+                .try_flatten_stream()
+                .take_until(tripwire)
+                .try_for_each(move |x| {
+                    let state = Arc::clone(&state);
+
+                    async move {
+                        let mut s = state.lock().await;
+
+                        s.0 = s.1.take();
+                        s.1 = x;
+
+                        Ok(())
+                    }
+                })
+                .map(|x| {
+                    if let Err(e) = x {
+                        tracing::error!("Error processing device output: {}", e);
+                    }
+                }),
+        );
+
+        Box::pin(rx.err_into())
+    }
+    fn update_session(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Output, ImlAgentError>> + Send>> {
+        let state = Arc::clone(&self.state);
+
+        async move {
+            let s = state.lock().await.clone();
+
+            if s.0 != s.1 {
+                Ok(s.1)
+            } else {
+                Ok(None)
+            }
+        }
+        .boxed()
+    }
+    fn teardown(&mut self) -> Result<(), ImlAgentError> {
+        self.trigger.take();
+
+        Ok(())
+    }
+}

--- a/iml-agent/src/daemon_plugins/mod.rs
+++ b/iml-agent/src/daemon_plugins/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod action_runner;
 pub mod daemon_plugin;
+pub mod device;
 pub mod ostpool;
 pub mod postoffice;
 pub mod stats;

--- a/iml-device.service
+++ b/iml-device.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=IML Device Service
+PartOf=iml-manager.target
+Before=iml-plugin-runner.service
+Before=nginx.service
+After=rabbitmq-server.service
+After=iml-settings-populator.service
+Requires=iml-settings-populator.service
+
+
+[Service]
+Type=simple
+Environment=RUST_LOG=info
+EnvironmentFile=/var/lib/chroma/iml-settings.conf
+ExecStart=/bin/iml-device
+Restart=always
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=iml-manager.target

--- a/iml-manager-env/src/lib.rs
+++ b/iml-manager-env/src/lib.rs
@@ -171,6 +171,15 @@ pub fn get_mailbox_path() -> PathBuf {
     get_var("MAILBOX_PATH").into()
 }
 
+/// Get the devices port or panic
+pub fn get_device_aggregator_port() -> String {
+    get_var("DEVICE_AGGREGATOR_PORT")
+}
+
+pub fn get_device_aggregator_addr() -> SocketAddr {
+    to_socket_addr(&get_server_host(), &get_device_aggregator_port())
+}
+
 /// Get the api key from the env or panic
 pub fn get_api_key() -> String {
     get_var("API_KEY")

--- a/iml-manager.target
+++ b/iml-manager.target
@@ -70,31 +70,31 @@ After=influxdb.service
 Requires=grafana-server.service
 After=grafana-server.service
 
-Requires=device-aggregator.service
-After=device-aggregator.service
+Requires=iml-device.service
+After=iml-device.service
 
 After=network.target
 
 [Install]
 WantedBy=multi-user.target
+Also=grafana-server.service
+Also=iml-action-runner.service
+Also=iml-agent-comms.service
+Also=iml-api.service
 Also=iml-corosync.service
+Also=iml-device.service
 Also=iml-gunicorn.service
 Also=iml-http-agent.service
 Also=iml-job-scheduler.service
 Also=iml-lustre-audit.service
+Also=iml-mailbox.service
 Also=iml-plugin-runner.service
 Also=iml-power-control.service
 Also=iml-rust-stats.service
 Also=iml-syslog.service
-Also=iml-agent-comms.service
-Also=iml-mailbox.service
-Also=iml-action-runner.service
 Also=iml-update-handler.socket
 Also=iml-warp-drive.service
-Also=iml-api.service
-Also=device-aggregator.service
-Also=nginx.service
-Also=rabbitmq-server.service
-Also=postgresql.service
 Also=influxdb.service
-Also=grafana-server.service
+Also=nginx.service
+Also=postgresql.service
+Also=rabbitmq-server.service

--- a/iml-services/iml-device/Cargo.toml
+++ b/iml-services/iml-device/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "iml-device"
+version = "0.2.0"
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+
+[dependencies]
+device-types = "0.1"
+futures = "0.3"
+iml-rabbit = { path = "../../iml-rabbit", version = "0.2.0" }
+iml-manager-env = { path = "../../iml-manager-env", version = "0.2.0" }
+iml-service-queue = { path = "../iml-service-queue", version = "0.2.0" }
+iml-wire-types = { path = "../../iml-wire-types", version = "0.2", features = ["postgres-interop"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+tokio = { version = "0.2", features = ["macros"] }
+tokio-util = { version = "0.3", features = ["codec"] }
+tracing = "0.1"
+tracing-subscriber = "0.2"
+
+warp = "0.2"
+
+[dev-dependencies]
+insta = "0.15"

--- a/iml-services/iml-device/fixtures/devtree.json
+++ b/iml-services/iml-device/fixtures/devtree.json
@@ -1,0 +1,1717 @@
+{
+  "Root": {
+    "children": [
+      {
+        "ScsiDevice": {
+          "serial": "36001405aa1a4a2010734758a9e57c178",
+          "scsi80": "SLIO-ORG ost5            aa1a4a20-1073-4758-a9e5-7c178c6ed8ef",
+          "major": "8",
+          "minor": "160",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:4/block/sdk",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405aa1a4a2010734758a9e57c178",
+            "/dev/disk/by-id/wwn-0x6001405aa1a4a2010734758a9e57c178",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-4",
+            "/dev/sdk"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-14",
+                "serial": "36001405aa1a4a2010734758a9e57c178",
+                "scsi80": "SLIO-ORG ost5            aa1a4a20-1073-4758-a9e5-7c178c6ed8ef",
+                "dm_name": "mpatho",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "14",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpatho",
+                  "/dev/disk/by-id/dm-name-mpatho",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405aa1a4a2010734758a9e57c178",
+                  "/dev/dm-14"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "3600140598252aa12555428f94b6ea915",
+          "scsi80": "SLIO-ORG ost16           98252aa1-2555-428f-94b6-ea915aadcd5a",
+          "major": "66",
+          "minor": "0",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:15/block/sdag",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140598252aa12555428f94b6ea915",
+            "/dev/disk/by-id/wwn-0x600140598252aa12555428f94b6ea915",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-15",
+            "/dev/sdag"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-7",
+                "serial": "3600140598252aa12555428f94b6ea915",
+                "scsi80": "SLIO-ORG ost16           98252aa1-2555-428f-94b6-ea915aadcd5a",
+                "dm_name": "mpathh",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "7",
+                "filesystem_type": "LVM2_member",
+                "paths": [
+                  "/dev/mapper/mpathh",
+                  "/dev/disk/by-id/dm-name-mpathh",
+                  "/dev/disk/by-id/dm-uuid-mpath-3600140598252aa12555428f94b6ea915",
+                  "/dev/disk/by-id/lvm-pv-uuid-sSb1jT-hBLl-am3F-mc9T-2cMR-oGbb-xG0FZw",
+                  "/dev/dm-7"
+                ],
+                "children": [],
+                "mount": {
+                  "source": "/dev/dm-7",
+                  "target": "/tmp/mnt9aU7P6",
+                  "fs_type": "xfs",
+                  "opts": "rw,relatime,seclabel,attr2,inode64,noquota"
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014054e9b5031f3434c56a0746de1f",
+          "scsi80": "SLIO-ORG ost7            4e9b5031-f343-4c56-a074-6de1feb8f72c",
+          "major": "8",
+          "minor": "224",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:6/block/sdo",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014054e9b5031f3434c56a0746de1f",
+            "/dev/disk/by-id/wwn-0x60014054e9b5031f3434c56a0746de1f",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-6",
+            "/dev/sdo"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-16",
+                "serial": "360014054e9b5031f3434c56a0746de1f",
+                "scsi80": "SLIO-ORG ost7            4e9b5031-f343-4c56-a074-6de1feb8f72c",
+                "dm_name": "mpathq",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "16",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathq",
+                  "/dev/disk/by-id/dm-name-mpathq",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014054e9b5031f3434c56a0746de1f",
+                  "/dev/dm-16"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405aa1a4a2010734758a9e57c178",
+          "scsi80": "SLIO-ORG ost5            aa1a4a20-1073-4758-a9e5-7c178c6ed8ef",
+          "major": "8",
+          "minor": "144",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:4/block/sdj",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405aa1a4a2010734758a9e57c178",
+            "/dev/disk/by-id/wwn-0x6001405aa1a4a2010734758a9e57c178",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-4",
+            "/dev/sdj"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-14",
+                "serial": "36001405aa1a4a2010734758a9e57c178",
+                "scsi80": "SLIO-ORG ost5            aa1a4a20-1073-4758-a9e5-7c178c6ed8ef",
+                "dm_name": "mpatho",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "14",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpatho",
+                  "/dev/disk/by-id/dm-name-mpatho",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405aa1a4a2010734758a9e57c178",
+                  "/dev/dm-14"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405a63b61f10cbb4e229df0792d0",
+          "scsi80": "SLIO-ORG ost2            a63b61f1-0cbb-4e22-9df0-792d0cf69575",
+          "major": "8",
+          "minor": "64",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:1/block/sde",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405a63b61f10cbb4e229df0792d0",
+            "/dev/disk/by-id/wwn-0x6001405a63b61f10cbb4e229df0792d0",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-1",
+            "/dev/sde"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-1",
+                "serial": "36001405a63b61f10cbb4e229df0792d0",
+                "scsi80": "SLIO-ORG ost2            a63b61f1-0cbb-4e22-9df0-792d0cf69575",
+                "dm_name": "mpathb",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "1",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathb",
+                  "/dev/disk/by-id/dm-name-mpathb",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405a63b61f10cbb4e229df0792d0",
+                  "/dev/dm-1"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014051ea57ad4ffc243d6bcab8eb8c",
+          "scsi80": "SLIO-ORG ost3            1ea57ad4-ffc2-43d6-bcab-8eb8c2a60bfb",
+          "major": "8",
+          "minor": "80",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:2/block/sdf",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051ea57ad4ffc243d6bcab8eb8c",
+            "/dev/disk/by-id/wwn-0x60014051ea57ad4ffc243d6bcab8eb8c",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-2",
+            "/dev/sdf"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-12",
+                "serial": "360014051ea57ad4ffc243d6bcab8eb8c",
+                "scsi80": "SLIO-ORG ost3            1ea57ad4-ffc2-43d6-bcab-8eb8c2a60bfb",
+                "dm_name": "mpathm",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "12",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathm",
+                  "/dev/disk/by-id/dm-name-mpathm",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014051ea57ad4ffc243d6bcab8eb8c",
+                  "/dev/dm-12"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405b1662648389c47ae91f7f9c18",
+          "scsi80": "SLIO-ORG ost20           b1662648-389c-47ae-91f7-f9c18ead9f54",
+          "major": "66",
+          "minor": "128",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:19/block/sdao",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405b1662648389c47ae91f7f9c18",
+            "/dev/disk/by-id/wwn-0x6001405b1662648389c47ae91f7f9c18",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-19",
+            "/dev/sdao"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-11",
+                "serial": "36001405b1662648389c47ae91f7f9c18",
+                "scsi80": "SLIO-ORG ost20           b1662648-389c-47ae-91f7-f9c18ead9f54",
+                "dm_name": "mpathl",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "11",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathl",
+                  "/dev/disk/by-id/dm-name-mpathl",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405b1662648389c47ae91f7f9c18",
+                  "/dev/dm-11"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014053fe9e70a1aa8470faaa82b7b0",
+          "scsi80": "SLIO-ORG ost12           3fe9e70a-1aa8-470f-aaa8-2b7b0e525b83",
+          "major": "65",
+          "minor": "112",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:11/block/sdx",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014053fe9e70a1aa8470faaa82b7b0",
+            "/dev/disk/by-id/wwn-0x60014053fe9e70a1aa8470faaa82b7b0",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-11",
+            "/dev/sdx"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-3",
+                "serial": "360014053fe9e70a1aa8470faaa82b7b0",
+                "scsi80": "SLIO-ORG ost12           3fe9e70a-1aa8-470f-aaa8-2b7b0e525b83",
+                "dm_name": "mpathd",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "3",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathd",
+                  "/dev/disk/by-id/dm-name-mpathd",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014053fe9e70a1aa8470faaa82b7b0",
+                  "/dev/dm-3"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405b1662648389c47ae91f7f9c18",
+          "scsi80": "SLIO-ORG ost20           b1662648-389c-47ae-91f7-f9c18ead9f54",
+          "major": "66",
+          "minor": "112",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:19/block/sdan",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405b1662648389c47ae91f7f9c18",
+            "/dev/disk/by-id/wwn-0x6001405b1662648389c47ae91f7f9c18",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-19",
+            "/dev/sdan"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-11",
+                "serial": "36001405b1662648389c47ae91f7f9c18",
+                "scsi80": "SLIO-ORG ost20           b1662648-389c-47ae-91f7-f9c18ead9f54",
+                "dm_name": "mpathl",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "11",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathl",
+                  "/dev/disk/by-id/dm-name-mpathl",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405b1662648389c47ae91f7f9c18",
+                  "/dev/dm-11"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014053fff9fd2761f4efe9143a33ff",
+          "scsi80": "SLIO-ORG ost17           3fff9fd2-761f-4efe-9143-a33ff9ff7a52",
+          "major": "66",
+          "minor": "32",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:16/block/sdai",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014053fff9fd2761f4efe9143a33ff",
+            "/dev/disk/by-id/wwn-0x60014053fff9fd2761f4efe9143a33ff",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-16",
+            "/dev/sdai"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-8",
+                "serial": "360014053fff9fd2761f4efe9143a33ff",
+                "scsi80": "SLIO-ORG ost17           3fff9fd2-761f-4efe-9143-a33ff9ff7a52",
+                "dm_name": "mpathi",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "8",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathi",
+                  "/dev/disk/by-id/dm-name-mpathi",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014053fff9fd2761f4efe9143a33ff",
+                  "/dev/dm-8"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405047a9e1ee2c04af6b26216f3a",
+          "scsi80": "SLIO-ORG ost19           047a9e1e-e2c0-4af6-b262-16f3ac3ca915",
+          "major": "66",
+          "minor": "96",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:18/block/sdam",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405047a9e1ee2c04af6b26216f3a",
+            "/dev/disk/by-id/wwn-0x6001405047a9e1ee2c04af6b26216f3a",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-18",
+            "/dev/sdam"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-10",
+                "serial": "36001405047a9e1ee2c04af6b26216f3a",
+                "scsi80": "SLIO-ORG ost19           047a9e1e-e2c0-4af6-b262-16f3ac3ca915",
+                "dm_name": "mpathk",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "10",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathk",
+                  "/dev/disk/by-id/dm-name-mpathk",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405047a9e1ee2c04af6b26216f3a",
+                  "/dev/dm-10"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405c525c75b8ee1471dbbb344dd8",
+          "scsi80": "SLIO-ORG ost15           c525c75b-8ee1-471d-bbb3-44dd80198b3f",
+          "major": "65",
+          "minor": "224",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:14/block/sdae",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405c525c75b8ee1471dbbb344dd8",
+            "/dev/disk/by-id/wwn-0x6001405c525c75b8ee1471dbbb344dd8",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-14",
+            "/dev/sdae"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-6",
+                "serial": "36001405c525c75b8ee1471dbbb344dd8",
+                "scsi80": "SLIO-ORG ost15           c525c75b-8ee1-471d-bbb3-44dd80198b3f",
+                "dm_name": "mpathg",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "6",
+                "filesystem_type": "LVM2_member",
+                "paths": [
+                  "/dev/mapper/mpathg",
+                  "/dev/disk/by-id/dm-name-mpathg",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405c525c75b8ee1471dbbb344dd8",
+                  "/dev/disk/by-id/lvm-pv-uuid-Y0MPay-Yimt-cJJx-ZN92-KFLT-BPJf-SjPIbO",
+                  "/dev/dm-6"
+                ],
+                "children": [
+                  {
+                    "VolumeGroup": {
+                      "name": "vg1",
+                      "uuid": "UDIbPXrzaeBLNKim8kDOqcWfXbG2eRKt",
+                      "size": 0,
+                      "children": [
+                        {
+                          "LogicalVolume": {
+                            "name": "lv1",
+                            "uuid": "9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+                            "major": "253",
+                            "minor": "20",
+                            "size": 67108864,
+                            "children": [],
+                            "devpath": "/devices/virtual/block/dm-20",
+                            "paths": [
+                              "/dev/mapper/vg1-lv1",
+                              "/dev/disk/by-id/dm-name-vg1-lv1",
+                              "/dev/disk/by-id/dm-uuid-LVM-UDIbPXrzaeBLNKim8kDOqcWfXbG2eRKt9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+                              "/dev/dm-20",
+                              "/dev/vg1/lv1"
+                            ],
+                            "filesystem_type": null,
+                            "mount": null
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "3600140564eea787d99444d79c15fc577",
+          "scsi80": "SLIO-ORG ost10           64eea787-d994-44d7-9c15-fc577fde7809",
+          "major": "65",
+          "minor": "48",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:9/block/sdt",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140564eea787d99444d79c15fc577",
+            "/dev/disk/by-id/wwn-0x600140564eea787d99444d79c15fc577",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-9",
+            "/dev/sdt"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-19",
+                "serial": "3600140564eea787d99444d79c15fc577",
+                "scsi80": "SLIO-ORG ost10           64eea787-d994-44d7-9c15-fc577fde7809",
+                "dm_name": "mpatht",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "19",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpatht",
+                  "/dev/disk/by-id/dm-name-mpatht",
+                  "/dev/disk/by-id/dm-uuid-mpath-3600140564eea787d99444d79c15fc577",
+                  "/dev/dm-19"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405c9535ca96e924f9fa2e32ed89",
+          "scsi80": "SLIO-ORG ost4            c9535ca9-6e92-4f9f-a2e3-2ed89e8cf8be",
+          "major": "8",
+          "minor": "112",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:3/block/sdh",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405c9535ca96e924f9fa2e32ed89",
+            "/dev/disk/by-id/wwn-0x6001405c9535ca96e924f9fa2e32ed89",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-3",
+            "/dev/sdh"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-13",
+                "serial": "36001405c9535ca96e924f9fa2e32ed89",
+                "scsi80": "SLIO-ORG ost4            c9535ca9-6e92-4f9f-a2e3-2ed89e8cf8be",
+                "dm_name": "mpathn",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "13",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathn",
+                  "/dev/disk/by-id/dm-name-mpathn",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405c9535ca96e924f9fa2e32ed89",
+                  "/dev/dm-13"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014058a65c188c7f84052b1b1185d2",
+          "scsi80": "SLIO-ORG ost6            8a65c188-c7f8-4052-b1b1-185d239005ea",
+          "major": "8",
+          "minor": "192",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:5/block/sdm",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014058a65c188c7f84052b1b1185d2",
+            "/dev/disk/by-id/wwn-0x60014058a65c188c7f84052b1b1185d2",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-5",
+            "/dev/sdm"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-15",
+                "serial": "360014058a65c188c7f84052b1b1185d2",
+                "scsi80": "SLIO-ORG ost6            8a65c188-c7f8-4052-b1b1-185d239005ea",
+                "dm_name": "mpathp",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "15",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathp",
+                  "/dev/disk/by-id/dm-name-mpathp",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014058a65c188c7f84052b1b1185d2",
+                  "/dev/dm-15"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014051755d7331b404ff68ae4b6e45",
+          "scsi80": "SLIO-ORG ost14           1755d733-1b40-4ff6-8ae4-b6e4568b03e3",
+          "major": "65",
+          "minor": "176",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:13/block/sdab",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051755d7331b404ff68ae4b6e45",
+            "/dev/disk/by-id/wwn-0x60014051755d7331b404ff68ae4b6e45",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-13",
+            "/dev/sdab"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-5",
+                "serial": "360014051755d7331b404ff68ae4b6e45",
+                "scsi80": "SLIO-ORG ost14           1755d733-1b40-4ff6-8ae4-b6e4568b03e3",
+                "dm_name": "mpathf",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "5",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathf",
+                  "/dev/disk/by-id/dm-name-mpathf",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014051755d7331b404ff68ae4b6e45",
+                  "/dev/dm-5"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "3600140564eea787d99444d79c15fc577",
+          "scsi80": "SLIO-ORG ost10           64eea787-d994-44d7-9c15-fc577fde7809",
+          "major": "65",
+          "minor": "64",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:9/block/sdu",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140564eea787d99444d79c15fc577",
+            "/dev/disk/by-id/wwn-0x600140564eea787d99444d79c15fc577",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-9",
+            "/dev/sdu"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-19",
+                "serial": "3600140564eea787d99444d79c15fc577",
+                "scsi80": "SLIO-ORG ost10           64eea787-d994-44d7-9c15-fc577fde7809",
+                "dm_name": "mpatht",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "19",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpatht",
+                  "/dev/disk/by-id/dm-name-mpatht",
+                  "/dev/disk/by-id/dm-uuid-mpath-3600140564eea787d99444d79c15fc577",
+                  "/dev/dm-19"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405139a84485b2d4ea5b4f59874c",
+          "scsi80": "SLIO-ORG ost13           139a8448-5b2d-4ea5-b4f5-9874cd16127b",
+          "major": "65",
+          "minor": "144",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:12/block/sdz",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405139a84485b2d4ea5b4f59874c",
+            "/dev/disk/by-id/wwn-0x6001405139a84485b2d4ea5b4f59874c",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-12",
+            "/dev/sdz"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-4",
+                "serial": "36001405139a84485b2d4ea5b4f59874c",
+                "scsi80": "SLIO-ORG ost13           139a8448-5b2d-4ea5-b4f5-9874cd16127b",
+                "dm_name": "mpathe",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "4",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathe",
+                  "/dev/disk/by-id/dm-name-mpathe",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405139a84485b2d4ea5b4f59874c",
+                  "/dev/dm-4"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "3600140547e0ffe43b3f464789f1653cc",
+          "scsi80": "SLIO-ORG ost11           47e0ffe4-3b3f-4647-89f1-653cc1b7c954",
+          "major": "65",
+          "minor": "80",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:10/block/sdv",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140547e0ffe43b3f464789f1653cc",
+            "/dev/disk/by-id/wwn-0x600140547e0ffe43b3f464789f1653cc",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-10",
+            "/dev/sdv"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-2",
+                "serial": "3600140547e0ffe43b3f464789f1653cc",
+                "scsi80": "SLIO-ORG ost11           47e0ffe4-3b3f-4647-89f1-653cc1b7c954",
+                "dm_name": "mpathc",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "2",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathc",
+                  "/dev/disk/by-id/dm-name-mpathc",
+                  "/dev/disk/by-id/dm-uuid-mpath-3600140547e0ffe43b3f464789f1653cc",
+                  "/dev/dm-2"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014051c12549d858d4562a2e178018",
+          "scsi80": "SLIO-ORG ost18           1c12549d-858d-4562-a2e1-78018d748a6f",
+          "major": "66",
+          "minor": "48",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:17/block/sdaj",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051c12549d858d4562a2e178018",
+            "/dev/disk/by-id/wwn-0x60014051c12549d858d4562a2e178018",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-17",
+            "/dev/sdaj"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-9",
+                "serial": "360014051c12549d858d4562a2e178018",
+                "scsi80": "SLIO-ORG ost18           1c12549d-858d-4562-a2e1-78018d748a6f",
+                "dm_name": "mpathj",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "9",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathj",
+                  "/dev/disk/by-id/dm-name-mpathj",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014051c12549d858d4562a2e178018",
+                  "/dev/dm-9"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "3600140568c946040400460a896d0b196",
+          "scsi80": "SLIO-ORG ost1            68c94604-0400-460a-896d-0b196cd0a235",
+          "major": "8",
+          "minor": "32",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:0/block/sdc",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140568c946040400460a896d0b196",
+            "/dev/disk/by-id/wwn-0x600140568c946040400460a896d0b196",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-0",
+            "/dev/sdc"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-0",
+                "serial": "3600140568c946040400460a896d0b196",
+                "scsi80": "SLIO-ORG ost1            68c94604-0400-460a-896d-0b196cd0a235",
+                "dm_name": "mpatha",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "0",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpatha",
+                  "/dev/disk/by-id/dm-name-mpatha",
+                  "/dev/disk/by-id/dm-uuid-mpath-3600140568c946040400460a896d0b196",
+                  "/dev/dm-0"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "3600140547f1dbaca8e344809057273c5",
+          "scsi80": "SLIO-ORG ost8            47f1dbac-a8e3-4480-9057-273c502f4dd6",
+          "major": "65",
+          "minor": "0",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:7/block/sdq",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140547f1dbaca8e344809057273c5",
+            "/dev/disk/by-id/wwn-0x600140547f1dbaca8e344809057273c5",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-7",
+            "/dev/sdq"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-17",
+                "serial": "3600140547f1dbaca8e344809057273c5",
+                "scsi80": "SLIO-ORG ost8            47f1dbac-a8e3-4480-9057-273c502f4dd6",
+                "dm_name": "mpathr",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "17",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathr",
+                  "/dev/disk/by-id/dm-name-mpathr",
+                  "/dev/disk/by-id/dm-uuid-mpath-3600140547f1dbaca8e344809057273c5",
+                  "/dev/dm-17"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "1ATA     VBOX HARDDISK                           VB289a63d7-b2394fde",
+          "scsi80": "SATA     VBOX HARDDISK   VB289a63d7-b2394fde",
+          "major": "8",
+          "minor": "0",
+          "devpath": "/devices/pci0000:00/0000:00:01.1/ata1/host0/target0:0:0/0:0:0:0/block/sda",
+          "size": 42949672960,
+          "filesystem_type": null,
+          "paths": [
+            "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde",
+            "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0",
+            "/dev/sda"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Partition": {
+                "partition_number": 1,
+                "size": 42948624384,
+                "major": "8",
+                "minor": "1",
+                "devpath": "/devices/pci0000:00/0000:00:01.1/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1",
+                "filesystem_type": "xfs",
+                "paths": [
+                  "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde-part1",
+                  "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0-part1",
+                  "/dev/disk/by-uuid/f52f361a-da1a-4ea0-8c7f-ca2706e86b46",
+                  "/dev/sda1"
+                ],
+                "mount": {
+                  "source": "/dev/sda1",
+                  "target": "/",
+                  "fs_type": "xfs",
+                  "opts": "rw,relatime,seclabel,attr2,inode64,noquota"
+                },
+                "children": []
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014053fff9fd2761f4efe9143a33ff",
+          "scsi80": "SLIO-ORG ost17           3fff9fd2-761f-4efe-9143-a33ff9ff7a52",
+          "major": "66",
+          "minor": "16",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:16/block/sdah",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014053fff9fd2761f4efe9143a33ff",
+            "/dev/disk/by-id/wwn-0x60014053fff9fd2761f4efe9143a33ff",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-16",
+            "/dev/sdah"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-8",
+                "serial": "360014053fff9fd2761f4efe9143a33ff",
+                "scsi80": "SLIO-ORG ost17           3fff9fd2-761f-4efe-9143-a33ff9ff7a52",
+                "dm_name": "mpathi",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "8",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathi",
+                  "/dev/disk/by-id/dm-name-mpathi",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014053fff9fd2761f4efe9143a33ff",
+                  "/dev/dm-8"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014058a65c188c7f84052b1b1185d2",
+          "scsi80": "SLIO-ORG ost6            8a65c188-c7f8-4052-b1b1-185d239005ea",
+          "major": "8",
+          "minor": "176",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:5/block/sdl",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014058a65c188c7f84052b1b1185d2",
+            "/dev/disk/by-id/wwn-0x60014058a65c188c7f84052b1b1185d2",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-5",
+            "/dev/sdl"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-15",
+                "serial": "360014058a65c188c7f84052b1b1185d2",
+                "scsi80": "SLIO-ORG ost6            8a65c188-c7f8-4052-b1b1-185d239005ea",
+                "dm_name": "mpathp",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "15",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathp",
+                  "/dev/disk/by-id/dm-name-mpathp",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014058a65c188c7f84052b1b1185d2",
+                  "/dev/dm-15"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "3600140547f1dbaca8e344809057273c5",
+          "scsi80": "SLIO-ORG ost8            47f1dbac-a8e3-4480-9057-273c502f4dd6",
+          "major": "8",
+          "minor": "240",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:7/block/sdp",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140547f1dbaca8e344809057273c5",
+            "/dev/disk/by-id/wwn-0x600140547f1dbaca8e344809057273c5",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-7",
+            "/dev/sdp"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-17",
+                "serial": "3600140547f1dbaca8e344809057273c5",
+                "scsi80": "SLIO-ORG ost8            47f1dbac-a8e3-4480-9057-273c502f4dd6",
+                "dm_name": "mpathr",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "17",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathr",
+                  "/dev/disk/by-id/dm-name-mpathr",
+                  "/dev/disk/by-id/dm-uuid-mpath-3600140547f1dbaca8e344809057273c5",
+                  "/dev/dm-17"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014053fe9e70a1aa8470faaa82b7b0",
+          "scsi80": "SLIO-ORG ost12           3fe9e70a-1aa8-470f-aaa8-2b7b0e525b83",
+          "major": "65",
+          "minor": "128",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:11/block/sdy",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014053fe9e70a1aa8470faaa82b7b0",
+            "/dev/disk/by-id/wwn-0x60014053fe9e70a1aa8470faaa82b7b0",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-11",
+            "/dev/sdy"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-3",
+                "serial": "360014053fe9e70a1aa8470faaa82b7b0",
+                "scsi80": "SLIO-ORG ost12           3fe9e70a-1aa8-470f-aaa8-2b7b0e525b83",
+                "dm_name": "mpathd",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "3",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathd",
+                  "/dev/disk/by-id/dm-name-mpathd",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014053fe9e70a1aa8470faaa82b7b0",
+                  "/dev/dm-3"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405047a9e1ee2c04af6b26216f3a",
+          "scsi80": "SLIO-ORG ost19           047a9e1e-e2c0-4af6-b262-16f3ac3ca915",
+          "major": "66",
+          "minor": "80",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:18/block/sdal",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405047a9e1ee2c04af6b26216f3a",
+            "/dev/disk/by-id/wwn-0x6001405047a9e1ee2c04af6b26216f3a",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-18",
+            "/dev/sdal"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-10",
+                "serial": "36001405047a9e1ee2c04af6b26216f3a",
+                "scsi80": "SLIO-ORG ost19           047a9e1e-e2c0-4af6-b262-16f3ac3ca915",
+                "dm_name": "mpathk",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "10",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathk",
+                  "/dev/disk/by-id/dm-name-mpathk",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405047a9e1ee2c04af6b26216f3a",
+                  "/dev/dm-10"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014054e9b5031f3434c56a0746de1f",
+          "scsi80": "SLIO-ORG ost7            4e9b5031-f343-4c56-a074-6de1feb8f72c",
+          "major": "8",
+          "minor": "208",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:6/block/sdn",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014054e9b5031f3434c56a0746de1f",
+            "/dev/disk/by-id/wwn-0x60014054e9b5031f3434c56a0746de1f",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-6",
+            "/dev/sdn"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-16",
+                "serial": "360014054e9b5031f3434c56a0746de1f",
+                "scsi80": "SLIO-ORG ost7            4e9b5031-f343-4c56-a074-6de1feb8f72c",
+                "dm_name": "mpathq",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "16",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathq",
+                  "/dev/disk/by-id/dm-name-mpathq",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014054e9b5031f3434c56a0746de1f",
+                  "/dev/dm-16"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014051c12549d858d4562a2e178018",
+          "scsi80": "SLIO-ORG ost18           1c12549d-858d-4562-a2e1-78018d748a6f",
+          "major": "66",
+          "minor": "64",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:17/block/sdak",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051c12549d858d4562a2e178018",
+            "/dev/disk/by-id/wwn-0x60014051c12549d858d4562a2e178018",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-17",
+            "/dev/sdak"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-9",
+                "serial": "360014051c12549d858d4562a2e178018",
+                "scsi80": "SLIO-ORG ost18           1c12549d-858d-4562-a2e1-78018d748a6f",
+                "dm_name": "mpathj",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "9",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathj",
+                  "/dev/disk/by-id/dm-name-mpathj",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014051c12549d858d4562a2e178018",
+                  "/dev/dm-9"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405139a84485b2d4ea5b4f59874c",
+          "scsi80": "SLIO-ORG ost13           139a8448-5b2d-4ea5-b4f5-9874cd16127b",
+          "major": "65",
+          "minor": "160",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:12/block/sdaa",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405139a84485b2d4ea5b4f59874c",
+            "/dev/disk/by-id/wwn-0x6001405139a84485b2d4ea5b4f59874c",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-12",
+            "/dev/sdaa"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-4",
+                "serial": "36001405139a84485b2d4ea5b4f59874c",
+                "scsi80": "SLIO-ORG ost13           139a8448-5b2d-4ea5-b4f5-9874cd16127b",
+                "dm_name": "mpathe",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "4",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathe",
+                  "/dev/disk/by-id/dm-name-mpathe",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405139a84485b2d4ea5b4f59874c",
+                  "/dev/dm-4"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "3600140568c946040400460a896d0b196",
+          "scsi80": "SLIO-ORG ost1            68c94604-0400-460a-896d-0b196cd0a235",
+          "major": "8",
+          "minor": "16",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:0/block/sdb",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140568c946040400460a896d0b196",
+            "/dev/disk/by-id/wwn-0x600140568c946040400460a896d0b196",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-0",
+            "/dev/sdb"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-0",
+                "serial": "3600140568c946040400460a896d0b196",
+                "scsi80": "SLIO-ORG ost1            68c94604-0400-460a-896d-0b196cd0a235",
+                "dm_name": "mpatha",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "0",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpatha",
+                  "/dev/disk/by-id/dm-name-mpatha",
+                  "/dev/disk/by-id/dm-uuid-mpath-3600140568c946040400460a896d0b196",
+                  "/dev/dm-0"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405c525c75b8ee1471dbbb344dd8",
+          "scsi80": "SLIO-ORG ost15           c525c75b-8ee1-471d-bbb3-44dd80198b3f",
+          "major": "65",
+          "minor": "208",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:14/block/sdad",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405c525c75b8ee1471dbbb344dd8",
+            "/dev/disk/by-id/wwn-0x6001405c525c75b8ee1471dbbb344dd8",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-14",
+            "/dev/sdad"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-6",
+                "serial": "36001405c525c75b8ee1471dbbb344dd8",
+                "scsi80": "SLIO-ORG ost15           c525c75b-8ee1-471d-bbb3-44dd80198b3f",
+                "dm_name": "mpathg",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "6",
+                "filesystem_type": "LVM2_member",
+                "paths": [
+                  "/dev/mapper/mpathg",
+                  "/dev/disk/by-id/dm-name-mpathg",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405c525c75b8ee1471dbbb344dd8",
+                  "/dev/disk/by-id/lvm-pv-uuid-Y0MPay-Yimt-cJJx-ZN92-KFLT-BPJf-SjPIbO",
+                  "/dev/dm-6"
+                ],
+                "children": [
+                  {
+                    "VolumeGroup": {
+                      "name": "vg1",
+                      "uuid": "UDIbPXrzaeBLNKim8kDOqcWfXbG2eRKt",
+                      "size": 0,
+                      "children": [
+                        {
+                          "LogicalVolume": {
+                            "name": "lv1",
+                            "uuid": "9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+                            "major": "253",
+                            "minor": "20",
+                            "size": 67108864,
+                            "children": [],
+                            "devpath": "/devices/virtual/block/dm-20",
+                            "paths": [
+                              "/dev/mapper/vg1-lv1",
+                              "/dev/disk/by-id/dm-name-vg1-lv1",
+                              "/dev/disk/by-id/dm-uuid-LVM-UDIbPXrzaeBLNKim8kDOqcWfXbG2eRKt9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+                              "/dev/dm-20",
+                              "/dev/vg1/lv1"
+                            ],
+                            "filesystem_type": null,
+                            "mount": null
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014051ea57ad4ffc243d6bcab8eb8c",
+          "scsi80": "SLIO-ORG ost3            1ea57ad4-ffc2-43d6-bcab-8eb8c2a60bfb",
+          "major": "8",
+          "minor": "96",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:2/block/sdg",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051ea57ad4ffc243d6bcab8eb8c",
+            "/dev/disk/by-id/wwn-0x60014051ea57ad4ffc243d6bcab8eb8c",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-2",
+            "/dev/sdg"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-12",
+                "serial": "360014051ea57ad4ffc243d6bcab8eb8c",
+                "scsi80": "SLIO-ORG ost3            1ea57ad4-ffc2-43d6-bcab-8eb8c2a60bfb",
+                "dm_name": "mpathm",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "12",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathm",
+                  "/dev/disk/by-id/dm-name-mpathm",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014051ea57ad4ffc243d6bcab8eb8c",
+                  "/dev/dm-12"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405a63b61f10cbb4e229df0792d0",
+          "scsi80": "SLIO-ORG ost2            a63b61f1-0cbb-4e22-9df0-792d0cf69575",
+          "major": "8",
+          "minor": "48",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:1/block/sdd",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405a63b61f10cbb4e229df0792d0",
+            "/dev/disk/by-id/wwn-0x6001405a63b61f10cbb4e229df0792d0",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-1",
+            "/dev/sdd"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-1",
+                "serial": "36001405a63b61f10cbb4e229df0792d0",
+                "scsi80": "SLIO-ORG ost2            a63b61f1-0cbb-4e22-9df0-792d0cf69575",
+                "dm_name": "mpathb",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "1",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathb",
+                  "/dev/disk/by-id/dm-name-mpathb",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405a63b61f10cbb4e229df0792d0",
+                  "/dev/dm-1"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "3600140598252aa12555428f94b6ea915",
+          "scsi80": "SLIO-ORG ost16           98252aa1-2555-428f-94b6-ea915aadcd5a",
+          "major": "65",
+          "minor": "240",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:15/block/sdaf",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140598252aa12555428f94b6ea915",
+            "/dev/disk/by-id/wwn-0x600140598252aa12555428f94b6ea915",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-15",
+            "/dev/sdaf"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-7",
+                "serial": "3600140598252aa12555428f94b6ea915",
+                "scsi80": "SLIO-ORG ost16           98252aa1-2555-428f-94b6-ea915aadcd5a",
+                "dm_name": "mpathh",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "7",
+                "filesystem_type": "LVM2_member",
+                "paths": [
+                  "/dev/mapper/mpathh",
+                  "/dev/disk/by-id/dm-name-mpathh",
+                  "/dev/disk/by-id/dm-uuid-mpath-3600140598252aa12555428f94b6ea915",
+                  "/dev/disk/by-id/lvm-pv-uuid-sSb1jT-hBLl-am3F-mc9T-2cMR-oGbb-xG0FZw",
+                  "/dev/dm-7"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405ce127d66323a4c279ca70706a",
+          "scsi80": "SLIO-ORG ost9            ce127d66-323a-4c27-9ca7-0706adf87bd6",
+          "major": "65",
+          "minor": "32",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:8/block/sds",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ce127d66323a4c279ca70706a",
+            "/dev/disk/by-id/wwn-0x6001405ce127d66323a4c279ca70706a",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-8",
+            "/dev/sds"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-18",
+                "serial": "36001405ce127d66323a4c279ca70706a",
+                "scsi80": "SLIO-ORG ost9            ce127d66-323a-4c27-9ca7-0706adf87bd6",
+                "dm_name": "mpaths",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "18",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpaths",
+                  "/dev/disk/by-id/dm-name-mpaths",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405ce127d66323a4c279ca70706a",
+                  "/dev/dm-18"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "3600140547e0ffe43b3f464789f1653cc",
+          "scsi80": "SLIO-ORG ost11           47e0ffe4-3b3f-4647-89f1-653cc1b7c954",
+          "major": "65",
+          "minor": "96",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:10/block/sdw",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140547e0ffe43b3f464789f1653cc",
+            "/dev/disk/by-id/wwn-0x600140547e0ffe43b3f464789f1653cc",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-10",
+            "/dev/sdw"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-2",
+                "serial": "3600140547e0ffe43b3f464789f1653cc",
+                "scsi80": "SLIO-ORG ost11           47e0ffe4-3b3f-4647-89f1-653cc1b7c954",
+                "dm_name": "mpathc",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "2",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathc",
+                  "/dev/disk/by-id/dm-name-mpathc",
+                  "/dev/disk/by-id/dm-uuid-mpath-3600140547e0ffe43b3f464789f1653cc",
+                  "/dev/dm-2"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "360014051755d7331b404ff68ae4b6e45",
+          "scsi80": "SLIO-ORG ost14           1755d733-1b40-4ff6-8ae4-b6e4568b03e3",
+          "major": "65",
+          "minor": "192",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:13/block/sdac",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051755d7331b404ff68ae4b6e45",
+            "/dev/disk/by-id/wwn-0x60014051755d7331b404ff68ae4b6e45",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-13",
+            "/dev/sdac"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-5",
+                "serial": "360014051755d7331b404ff68ae4b6e45",
+                "scsi80": "SLIO-ORG ost14           1755d733-1b40-4ff6-8ae4-b6e4568b03e3",
+                "dm_name": "mpathf",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "5",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathf",
+                  "/dev/disk/by-id/dm-name-mpathf",
+                  "/dev/disk/by-id/dm-uuid-mpath-360014051755d7331b404ff68ae4b6e45",
+                  "/dev/dm-5"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405c9535ca96e924f9fa2e32ed89",
+          "scsi80": "SLIO-ORG ost4            c9535ca9-6e92-4f9f-a2e3-2ed89e8cf8be",
+          "major": "8",
+          "minor": "128",
+          "devpath": "/devices/platform/host5/session4/target5:0:0/5:0:0:3/block/sdi",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405c9535ca96e924f9fa2e32ed89",
+            "/dev/disk/by-id/wwn-0x6001405c9535ca96e924f9fa2e32ed89",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-3",
+            "/dev/sdi"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-13",
+                "serial": "36001405c9535ca96e924f9fa2e32ed89",
+                "scsi80": "SLIO-ORG ost4            c9535ca9-6e92-4f9f-a2e3-2ed89e8cf8be",
+                "dm_name": "mpathn",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "13",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpathn",
+                  "/dev/disk/by-id/dm-name-mpathn",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405c9535ca96e924f9fa2e32ed89",
+                  "/dev/dm-13"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405ce127d66323a4c279ca70706a",
+          "scsi80": "SLIO-ORG ost9            ce127d66-323a-4c27-9ca7-0706adf87bd6",
+          "major": "65",
+          "minor": "16",
+          "devpath": "/devices/platform/host4/session3/target4:0:0/4:0:0:8/block/sdr",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ce127d66323a4c279ca70706a",
+            "/dev/disk/by-id/wwn-0x6001405ce127d66323a4c279ca70706a",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-8",
+            "/dev/sdr"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-18",
+                "serial": "36001405ce127d66323a4c279ca70706a",
+                "scsi80": "SLIO-ORG ost9            ce127d66-323a-4c27-9ca7-0706adf87bd6",
+                "dm_name": "mpaths",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "18",
+                "filesystem_type": null,
+                "paths": [
+                  "/dev/mapper/mpaths",
+                  "/dev/disk/by-id/dm-name-mpaths",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405ce127d66323a4c279ca70706a",
+                  "/dev/dm-18"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/iml-services/iml-device/fixtures/devtree_zpool.json
+++ b/iml-services/iml-device/fixtures/devtree_zpool.json
@@ -1,0 +1,346 @@
+{
+  "Root": {
+    "children": [
+      {
+        "ScsiDevice": {
+          "serial": "36001405943dd5f394fb4b5ba71ec818f",
+          "scsi80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+          "major": "8",
+          "minor": "64",
+          "devpath": "/devices/platform/host2/session1/target2:0:0/2:0:0:1/block/sde",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+            "/dev/mdt",
+            "/dev/sde"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-1",
+                "serial": "36001405943dd5f394fb4b5ba71ec818f",
+                "scsi80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+                "dm_name": "mpathb",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "1",
+                "filesystem_type": "zfs_member",
+                "paths": [
+                  "/dev/mapper/mpathb",
+                  "/dev/disk/by-id/dm-name-mpathb",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405943dd5f394fb4b5ba71ec818f",
+                  "/dev/disk/by-label/mds",
+                  "/dev/disk/by-uuid/15259234345131681652",
+                  "/dev/dm-1",
+                  "/dev/mdt"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405ecca605408894bc2aa708a09c",
+          "scsi80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+          "major": "8",
+          "minor": "32",
+          "devpath": "/devices/platform/host3/session2/target3:0:0/3:0:0:0/block/sdc",
+          "size": 536870912,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+            "/dev/mgt",
+            "/dev/sdc"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Zpool": {
+                "guid": 3383432994541088300,
+                "name": "mgs",
+                "health": "ONLINE",
+                "state": "ACTIVE",
+                "size": 520093696,
+                "vdev": {
+                  "Root": {
+                    "children": [
+                      {
+                        "Disk": {
+                          "guid": 7562121608132560000,
+                          "state": "ONLINE",
+                          "path": "/dev/mgt",
+                          "dev_id": "dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+                          "phys_path": null,
+                          "whole_disk": false,
+                          "is_log": false
+                        }
+                      }
+                    ],
+                    "spares": [],
+                    "cache": []
+                  }
+                },
+                "props": [],
+                "children": []
+              }
+            },
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-0",
+                "serial": "36001405ecca605408894bc2aa708a09c",
+                "scsi80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+                "dm_name": "mpatha",
+                "size": 536870912,
+                "major": "253",
+                "minor": "0",
+                "filesystem_type": "zfs_member",
+                "paths": [
+                  "/dev/mapper/mpatha",
+                  "/dev/disk/by-id/dm-name-mpatha",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+                  "/dev/disk/by-label/mgs",
+                  "/dev/disk/by-uuid/3383432994541088053",
+                  "/dev/dm-0",
+                  "/dev/mgt"
+                ],
+                "children": [
+                  {
+                    "Zpool": {
+                      "guid": 3383432994541088300,
+                      "name": "mgs",
+                      "health": "ONLINE",
+                      "state": "ACTIVE",
+                      "size": 520093696,
+                      "vdev": {
+                        "Root": {
+                          "children": [
+                            {
+                              "Disk": {
+                                "guid": 7562121608132560000,
+                                "state": "ONLINE",
+                                "path": "/dev/mgt",
+                                "dev_id": "dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+                                "phys_path": null,
+                                "whole_disk": false,
+                                "is_log": false
+                              }
+                            }
+                          ],
+                          "spares": [],
+                          "cache": []
+                        }
+                      },
+                      "props": [],
+                      "children": []
+                    }
+                  }
+                ],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405943dd5f394fb4b5ba71ec818f",
+          "scsi80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+          "major": "8",
+          "minor": "48",
+          "devpath": "/devices/platform/host3/session2/target3:0:0/3:0:0:1/block/sdd",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+            "/dev/mdt",
+            "/dev/sdd"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-1",
+                "serial": "36001405943dd5f394fb4b5ba71ec818f",
+                "scsi80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+                "dm_name": "mpathb",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "1",
+                "filesystem_type": "zfs_member",
+                "paths": [
+                  "/dev/mapper/mpathb",
+                  "/dev/disk/by-id/dm-name-mpathb",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405943dd5f394fb4b5ba71ec818f",
+                  "/dev/disk/by-label/mds",
+                  "/dev/disk/by-uuid/15259234345131681652",
+                  "/dev/dm-1",
+                  "/dev/mdt"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405ecca605408894bc2aa708a09c",
+          "scsi80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+          "major": "8",
+          "minor": "16",
+          "devpath": "/devices/platform/host2/session1/target2:0:0/2:0:0:0/block/sdb",
+          "size": 536870912,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+            "/dev/mgt",
+            "/dev/sdb"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-0",
+                "serial": "36001405ecca605408894bc2aa708a09c",
+                "scsi80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+                "dm_name": "mpatha",
+                "size": 536870912,
+                "major": "253",
+                "minor": "0",
+                "filesystem_type": "zfs_member",
+                "paths": [
+                  "/dev/mapper/mpatha",
+                  "/dev/disk/by-id/dm-name-mpatha",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+                  "/dev/disk/by-label/mgs",
+                  "/dev/disk/by-uuid/3383432994541088053",
+                  "/dev/dm-0",
+                  "/dev/mgt"
+                ],
+                "children": [
+                  {
+                    "Zpool": {
+                      "guid": 3383432994541088300,
+                      "name": "mgs",
+                      "health": "ONLINE",
+                      "state": "ACTIVE",
+                      "size": 520093696,
+                      "vdev": {
+                        "Root": {
+                          "children": [
+                            {
+                              "Disk": {
+                                "guid": 7562121608132560000,
+                                "state": "ONLINE",
+                                "path": "/dev/mgt",
+                                "dev_id": "dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+                                "phys_path": null,
+                                "whole_disk": false,
+                                "is_log": false
+                              }
+                            }
+                          ],
+                          "spares": [],
+                          "cache": []
+                        }
+                      },
+                      "props": [],
+                      "children": []
+                    }
+                  }
+                ],
+                "mount": null
+              }
+            },
+            {
+              "Zpool": {
+                "guid": 3383432994541088300,
+                "name": "mgs",
+                "health": "ONLINE",
+                "state": "ACTIVE",
+                "size": 520093696,
+                "vdev": {
+                  "Root": {
+                    "children": [
+                      {
+                        "Disk": {
+                          "guid": 7562121608132560000,
+                          "state": "ONLINE",
+                          "path": "/dev/mgt",
+                          "dev_id": "dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+                          "phys_path": null,
+                          "whole_disk": false,
+                          "is_log": false
+                        }
+                      }
+                    ],
+                    "spares": [],
+                    "cache": []
+                  }
+                },
+                "props": [],
+                "children": []
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "1ATA     VBOX HARDDISK                           VB289a63d7-b2394fde",
+          "scsi80": "SATA     VBOX HARDDISK   VB289a63d7-b2394fde",
+          "major": "8",
+          "minor": "0",
+          "devpath": "/devices/pci0000:00/0000:00:01.1/ata1/host0/target0:0:0/0:0:0:0/block/sda",
+          "size": 42949672960,
+          "filesystem_type": null,
+          "paths": [
+            "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde",
+            "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0",
+            "/dev/sda"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Partition": {
+                "partition_number": 1,
+                "size": 42948624384,
+                "major": "8",
+                "minor": "1",
+                "devpath": "/devices/pci0000:00/0000:00:01.1/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1",
+                "filesystem_type": "xfs",
+                "paths": [
+                  "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde-part1",
+                  "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0-part1",
+                  "/dev/disk/by-uuid/f52f361a-da1a-4ea0-8c7f-ca2706e86b46",
+                  "/dev/sda1"
+                ],
+                "mount": {
+                  "source": "/dev/sda1",
+                  "target": "/",
+                  "fs_type": "xfs",
+                  "opts": "rw,relatime,attr2,inode64,noquota"
+                },
+                "children": []
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/iml-services/iml-device/fixtures/devtree_zpool_dataset.json
+++ b/iml-services/iml-device/fixtures/devtree_zpool_dataset.json
@@ -1,0 +1,874 @@
+{
+  "Root": {
+    "children": [
+      {
+        "ScsiDevice": {
+          "serial": "36001405ecca605408894bc2aa708a09c",
+          "scsi80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+          "major": "8",
+          "minor": "16",
+          "devpath": "/devices/platform/host2/session1/target2:0:0/2:0:0:0/block/sdb",
+          "size": 536870912,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+            "/dev/disk/by-label/mgs",
+            "/dev/disk/by-uuid/3383432994541088053",
+            "/dev/mgt",
+            "/dev/sdb"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-0",
+                "serial": "36001405ecca605408894bc2aa708a09c",
+                "scsi80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+                "dm_name": "mpatha",
+                "size": 536870912,
+                "major": "253",
+                "minor": "0",
+                "filesystem_type": "zfs_member",
+                "paths": [
+                  "/dev/mapper/mpatha",
+                  "/dev/disk/by-id/dm-name-mpatha",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+                  "/dev/disk/by-label/mgs",
+                  "/dev/disk/by-uuid/3383432994541088053",
+                  "/dev/dm-0",
+                  "/dev/mgt"
+                ],
+                "children": [
+                  {
+                    "Zpool": {
+                      "guid": 3383432994541088300,
+                      "name": "mgs",
+                      "health": "ONLINE",
+                      "state": "ACTIVE",
+                      "size": 520093696,
+                      "vdev": {
+                        "Root": {
+                          "children": [
+                            {
+                              "Disk": {
+                                "guid": 7562121608132560000,
+                                "state": "ONLINE",
+                                "path": "/dev/mgt",
+                                "dev_id": "dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+                                "phys_path": null,
+                                "whole_disk": false,
+                                "is_log": false
+                              }
+                            }
+                          ],
+                          "spares": [],
+                          "cache": []
+                        }
+                      },
+                      "props": [],
+                      "children": [
+                        {
+                          "Dataset": {
+                            "guid": 16140917920099960924,
+                            "name": "mgs/MGS",
+                            "kind": "filesystem",
+                            "props": [
+                              {
+                                "name": "name",
+                                "value": "mgs/MGS"
+                              },
+                              {
+                                "name": "type",
+                                "value": "filesystem"
+                              },
+                              {
+                                "name": "creation",
+                                "value": "1558110908"
+                              },
+                              {
+                                "name": "used",
+                                "value": "24576"
+                              },
+                              {
+                                "name": "available",
+                                "value": "385734656"
+                              },
+                              {
+                                "name": "referenced",
+                                "value": "24576"
+                              },
+                              {
+                                "name": "compressratio",
+                                "value": "1.00x"
+                              },
+                              {
+                                "name": "mounted",
+                                "value": "no"
+                              },
+                              {
+                                "name": "quota",
+                                "value": "0"
+                              },
+                              {
+                                "name": "reservation",
+                                "value": "0"
+                              },
+                              {
+                                "name": "recordsize",
+                                "value": "131072"
+                              },
+                              {
+                                "name": "mountpoint",
+                                "value": "none"
+                              },
+                              {
+                                "name": "sharenfs",
+                                "value": "off"
+                              },
+                              {
+                                "name": "checksum",
+                                "value": "on"
+                              },
+                              {
+                                "name": "compression",
+                                "value": "off"
+                              },
+                              {
+                                "name": "atime",
+                                "value": "on"
+                              },
+                              {
+                                "name": "devices",
+                                "value": "on"
+                              },
+                              {
+                                "name": "exec",
+                                "value": "on"
+                              },
+                              {
+                                "name": "setuid",
+                                "value": "on"
+                              },
+                              {
+                                "name": "readonly",
+                                "value": "off"
+                              },
+                              {
+                                "name": "zoned",
+                                "value": "off"
+                              },
+                              {
+                                "name": "snapdir",
+                                "value": "hidden"
+                              },
+                              {
+                                "name": "aclinherit",
+                                "value": "restricted"
+                              },
+                              {
+                                "name": "createtxg",
+                                "value": "375"
+                              },
+                              {
+                                "name": "canmount",
+                                "value": "off"
+                              },
+                              {
+                                "name": "xattr",
+                                "value": "sa"
+                              },
+                              {
+                                "name": "copies",
+                                "value": "1"
+                              },
+                              {
+                                "name": "version",
+                                "value": "5"
+                              },
+                              {
+                                "name": "utf8only",
+                                "value": "off"
+                              },
+                              {
+                                "name": "normalization",
+                                "value": "none"
+                              },
+                              {
+                                "name": "casesensitivity",
+                                "value": "sensitive"
+                              },
+                              {
+                                "name": "vscan",
+                                "value": "off"
+                              },
+                              {
+                                "name": "nbmand",
+                                "value": "off"
+                              },
+                              {
+                                "name": "sharesmb",
+                                "value": "off"
+                              },
+                              {
+                                "name": "refquota",
+                                "value": "0"
+                              },
+                              {
+                                "name": "refreservation",
+                                "value": "0"
+                              },
+                              {
+                                "name": "guid",
+                                "value": "16140917920099960924"
+                              },
+                              {
+                                "name": "primarycache",
+                                "value": "all"
+                              },
+                              {
+                                "name": "secondarycache",
+                                "value": "all"
+                              },
+                              {
+                                "name": "usedbysnapshots",
+                                "value": "0"
+                              },
+                              {
+                                "name": "usedbydataset",
+                                "value": "24576"
+                              },
+                              {
+                                "name": "usedbychildren",
+                                "value": "0"
+                              },
+                              {
+                                "name": "usedbyrefreservation",
+                                "value": "0"
+                              },
+                              {
+                                "name": "logbias",
+                                "value": "latency"
+                              },
+                              {
+                                "name": "dedup",
+                                "value": "off"
+                              },
+                              {
+                                "name": "mlslabel",
+                                "value": "none"
+                              },
+                              {
+                                "name": "sync",
+                                "value": "standard"
+                              },
+                              {
+                                "name": "dnodesize",
+                                "value": "auto"
+                              },
+                              {
+                                "name": "refcompressratio",
+                                "value": "1.00x"
+                              },
+                              {
+                                "name": "written",
+                                "value": "24576"
+                              },
+                              {
+                                "name": "logicalused",
+                                "value": "12288"
+                              },
+                              {
+                                "name": "logicalreferenced",
+                                "value": "12288"
+                              },
+                              {
+                                "name": "volmode",
+                                "value": "default"
+                              },
+                              {
+                                "name": "filesystem_limit",
+                                "value": "18446744073709551615"
+                              },
+                              {
+                                "name": "snapshot_limit",
+                                "value": "18446744073709551615"
+                              },
+                              {
+                                "name": "filesystem_count",
+                                "value": "18446744073709551615"
+                              },
+                              {
+                                "name": "snapshot_count",
+                                "value": "18446744073709551615"
+                              },
+                              {
+                                "name": "snapdev",
+                                "value": "hidden"
+                              },
+                              {
+                                "name": "acltype",
+                                "value": "off"
+                              },
+                              {
+                                "name": "context",
+                                "value": "none"
+                              },
+                              {
+                                "name": "fscontext",
+                                "value": "none"
+                              },
+                              {
+                                "name": "defcontext",
+                                "value": "none"
+                              },
+                              {
+                                "name": "rootcontext",
+                                "value": "none"
+                              },
+                              {
+                                "name": "relatime",
+                                "value": "off"
+                              },
+                              {
+                                "name": "redundant_metadata",
+                                "value": "all"
+                              },
+                              {
+                                "name": "overlay",
+                                "value": "off"
+                              },
+                              {
+                                "name": "lustre:svname",
+                                "value": "MGS"
+                              },
+                              {
+                                "name": "lustre:flags",
+                                "value": "100"
+                              },
+                              {
+                                "name": "lustre:index",
+                                "value": "65535"
+                              },
+                              {
+                                "name": "lustre:version",
+                                "value": "1"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405943dd5f394fb4b5ba71ec818f",
+          "scsi80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+          "major": "8",
+          "minor": "48",
+          "devpath": "/devices/platform/host2/session1/target2:0:0/2:0:0:1/block/sdd",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+            "/dev/disk/by-label/mds",
+            "/dev/disk/by-uuid/15259234345131681652",
+            "/dev/mdt",
+            "/dev/sdd"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-1",
+                "serial": "36001405943dd5f394fb4b5ba71ec818f",
+                "scsi80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+                "dm_name": "mpathb",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "1",
+                "filesystem_type": "zfs_member",
+                "paths": [
+                  "/dev/mapper/mpathb",
+                  "/dev/disk/by-id/dm-name-mpathb",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405943dd5f394fb4b5ba71ec818f",
+                  "/dev/disk/by-label/mds",
+                  "/dev/disk/by-uuid/15259234345131681652",
+                  "/dev/dm-1",
+                  "/dev/mdt"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "1ATA     VBOX HARDDISK                           VB289a63d7-b2394fde",
+          "scsi80": "SATA     VBOX HARDDISK   VB289a63d7-b2394fde",
+          "major": "8",
+          "minor": "0",
+          "devpath": "/devices/pci0000:00/0000:00:01.1/ata1/host0/target0:0:0/0:0:0:0/block/sda",
+          "size": 42949672960,
+          "filesystem_type": null,
+          "paths": [
+            "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde",
+            "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0",
+            "/dev/sda"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Partition": {
+                "partition_number": 1,
+                "size": 42948624384,
+                "major": "8",
+                "minor": "1",
+                "devpath": "/devices/pci0000:00/0000:00:01.1/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1",
+                "filesystem_type": "xfs",
+                "paths": [
+                  "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde-part1",
+                  "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0-part1",
+                  "/dev/disk/by-uuid/f52f361a-da1a-4ea0-8c7f-ca2706e86b46",
+                  "/dev/sda1"
+                ],
+                "mount": {
+                  "source": "/dev/sda1",
+                  "target": "/",
+                  "fs_type": "xfs",
+                  "opts": "rw,relatime,attr2,inode64,noquota"
+                },
+                "children": []
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405ecca605408894bc2aa708a09c",
+          "scsi80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+          "major": "8",
+          "minor": "32",
+          "devpath": "/devices/platform/host3/session2/target3:0:0/3:0:0:0/block/sdc",
+          "size": 536870912,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+            "/dev/disk/by-label/mgs",
+            "/dev/disk/by-uuid/3383432994541088053",
+            "/dev/mgt",
+            "/dev/sdc"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-0",
+                "serial": "36001405ecca605408894bc2aa708a09c",
+                "scsi80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+                "dm_name": "mpatha",
+                "size": 536870912,
+                "major": "253",
+                "minor": "0",
+                "filesystem_type": "zfs_member",
+                "paths": [
+                  "/dev/mapper/mpatha",
+                  "/dev/disk/by-id/dm-name-mpatha",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+                  "/dev/disk/by-label/mgs",
+                  "/dev/disk/by-uuid/3383432994541088053",
+                  "/dev/dm-0",
+                  "/dev/mgt"
+                ],
+                "children": [
+                  {
+                    "Zpool": {
+                      "guid": 3383432994541088300,
+                      "name": "mgs",
+                      "health": "ONLINE",
+                      "state": "ACTIVE",
+                      "size": 520093696,
+                      "vdev": {
+                        "Root": {
+                          "children": [
+                            {
+                              "Disk": {
+                                "guid": 7562121608132560000,
+                                "state": "ONLINE",
+                                "path": "/dev/mgt",
+                                "dev_id": "dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+                                "phys_path": null,
+                                "whole_disk": false,
+                                "is_log": false
+                              }
+                            }
+                          ],
+                          "spares": [],
+                          "cache": []
+                        }
+                      },
+                      "props": [],
+                      "children": [
+                        {
+                          "Dataset": {
+                            "guid": 16140917920099960924,
+                            "name": "mgs/MGS",
+                            "kind": "filesystem",
+                            "props": [
+                              {
+                                "name": "name",
+                                "value": "mgs/MGS"
+                              },
+                              {
+                                "name": "type",
+                                "value": "filesystem"
+                              },
+                              {
+                                "name": "creation",
+                                "value": "1558110908"
+                              },
+                              {
+                                "name": "used",
+                                "value": "24576"
+                              },
+                              {
+                                "name": "available",
+                                "value": "385734656"
+                              },
+                              {
+                                "name": "referenced",
+                                "value": "24576"
+                              },
+                              {
+                                "name": "compressratio",
+                                "value": "1.00x"
+                              },
+                              {
+                                "name": "mounted",
+                                "value": "no"
+                              },
+                              {
+                                "name": "quota",
+                                "value": "0"
+                              },
+                              {
+                                "name": "reservation",
+                                "value": "0"
+                              },
+                              {
+                                "name": "recordsize",
+                                "value": "131072"
+                              },
+                              {
+                                "name": "mountpoint",
+                                "value": "none"
+                              },
+                              {
+                                "name": "sharenfs",
+                                "value": "off"
+                              },
+                              {
+                                "name": "checksum",
+                                "value": "on"
+                              },
+                              {
+                                "name": "compression",
+                                "value": "off"
+                              },
+                              {
+                                "name": "atime",
+                                "value": "on"
+                              },
+                              {
+                                "name": "devices",
+                                "value": "on"
+                              },
+                              {
+                                "name": "exec",
+                                "value": "on"
+                              },
+                              {
+                                "name": "setuid",
+                                "value": "on"
+                              },
+                              {
+                                "name": "readonly",
+                                "value": "off"
+                              },
+                              {
+                                "name": "zoned",
+                                "value": "off"
+                              },
+                              {
+                                "name": "snapdir",
+                                "value": "hidden"
+                              },
+                              {
+                                "name": "aclinherit",
+                                "value": "restricted"
+                              },
+                              {
+                                "name": "createtxg",
+                                "value": "375"
+                              },
+                              {
+                                "name": "canmount",
+                                "value": "off"
+                              },
+                              {
+                                "name": "xattr",
+                                "value": "sa"
+                              },
+                              {
+                                "name": "copies",
+                                "value": "1"
+                              },
+                              {
+                                "name": "version",
+                                "value": "5"
+                              },
+                              {
+                                "name": "utf8only",
+                                "value": "off"
+                              },
+                              {
+                                "name": "normalization",
+                                "value": "none"
+                              },
+                              {
+                                "name": "casesensitivity",
+                                "value": "sensitive"
+                              },
+                              {
+                                "name": "vscan",
+                                "value": "off"
+                              },
+                              {
+                                "name": "nbmand",
+                                "value": "off"
+                              },
+                              {
+                                "name": "sharesmb",
+                                "value": "off"
+                              },
+                              {
+                                "name": "refquota",
+                                "value": "0"
+                              },
+                              {
+                                "name": "refreservation",
+                                "value": "0"
+                              },
+                              {
+                                "name": "guid",
+                                "value": "16140917920099960924"
+                              },
+                              {
+                                "name": "primarycache",
+                                "value": "all"
+                              },
+                              {
+                                "name": "secondarycache",
+                                "value": "all"
+                              },
+                              {
+                                "name": "usedbysnapshots",
+                                "value": "0"
+                              },
+                              {
+                                "name": "usedbydataset",
+                                "value": "24576"
+                              },
+                              {
+                                "name": "usedbychildren",
+                                "value": "0"
+                              },
+                              {
+                                "name": "usedbyrefreservation",
+                                "value": "0"
+                              },
+                              {
+                                "name": "logbias",
+                                "value": "latency"
+                              },
+                              {
+                                "name": "dedup",
+                                "value": "off"
+                              },
+                              {
+                                "name": "mlslabel",
+                                "value": "none"
+                              },
+                              {
+                                "name": "sync",
+                                "value": "standard"
+                              },
+                              {
+                                "name": "dnodesize",
+                                "value": "auto"
+                              },
+                              {
+                                "name": "refcompressratio",
+                                "value": "1.00x"
+                              },
+                              {
+                                "name": "written",
+                                "value": "24576"
+                              },
+                              {
+                                "name": "logicalused",
+                                "value": "12288"
+                              },
+                              {
+                                "name": "logicalreferenced",
+                                "value": "12288"
+                              },
+                              {
+                                "name": "volmode",
+                                "value": "default"
+                              },
+                              {
+                                "name": "filesystem_limit",
+                                "value": "18446744073709551615"
+                              },
+                              {
+                                "name": "snapshot_limit",
+                                "value": "18446744073709551615"
+                              },
+                              {
+                                "name": "filesystem_count",
+                                "value": "18446744073709551615"
+                              },
+                              {
+                                "name": "snapshot_count",
+                                "value": "18446744073709551615"
+                              },
+                              {
+                                "name": "snapdev",
+                                "value": "hidden"
+                              },
+                              {
+                                "name": "acltype",
+                                "value": "off"
+                              },
+                              {
+                                "name": "context",
+                                "value": "none"
+                              },
+                              {
+                                "name": "fscontext",
+                                "value": "none"
+                              },
+                              {
+                                "name": "defcontext",
+                                "value": "none"
+                              },
+                              {
+                                "name": "rootcontext",
+                                "value": "none"
+                              },
+                              {
+                                "name": "relatime",
+                                "value": "off"
+                              },
+                              {
+                                "name": "redundant_metadata",
+                                "value": "all"
+                              },
+                              {
+                                "name": "overlay",
+                                "value": "off"
+                              },
+                              {
+                                "name": "lustre:svname",
+                                "value": "MGS"
+                              },
+                              {
+                                "name": "lustre:flags",
+                                "value": "100"
+                              },
+                              {
+                                "name": "lustre:index",
+                                "value": "65535"
+                              },
+                              {
+                                "name": "lustre:version",
+                                "value": "1"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "mount": null
+              }
+            }
+          ]
+        }
+      },
+      {
+        "ScsiDevice": {
+          "serial": "36001405943dd5f394fb4b5ba71ec818f",
+          "scsi80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+          "major": "8",
+          "minor": "64",
+          "devpath": "/devices/platform/host3/session2/target3:0:0/3:0:0:1/block/sde",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+            "/dev/disk/by-label/mds",
+            "/dev/disk/by-uuid/15259234345131681652",
+            "/dev/mdt",
+            "/dev/sde"
+          ],
+          "mount": null,
+          "children": [
+            {
+              "Mpath": {
+                "devpath": "/devices/virtual/block/dm-1",
+                "serial": "36001405943dd5f394fb4b5ba71ec818f",
+                "scsi80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+                "dm_name": "mpathb",
+                "size": 5368709120,
+                "major": "253",
+                "minor": "1",
+                "filesystem_type": "zfs_member",
+                "paths": [
+                  "/dev/mapper/mpathb",
+                  "/dev/disk/by-id/dm-name-mpathb",
+                  "/dev/disk/by-id/dm-uuid-mpath-36001405943dd5f394fb4b5ba71ec818f",
+                  "/dev/disk/by-label/mds",
+                  "/dev/disk/by-uuid/15259234345131681652",
+                  "/dev/dm-1",
+                  "/dev/mdt"
+                ],
+                "children": [],
+                "mount": null
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/iml-services/iml-device/src/error.rs
+++ b/iml-services/iml-device/src/error.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use iml_service_queue::service_queue::ImlServiceQueueError;
+use thiserror::Error;
+use warp::reject;
+
+#[derive(Error, Debug)]
+pub enum ImlDeviceError {
+    #[error(transparent)]
+    ImlServiceQueueError(#[from] ImlServiceQueueError),
+}
+
+impl reject::Reject for ImlDeviceError {}

--- a/iml-services/iml-device/src/lib.rs
+++ b/iml-services/iml-device/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+pub mod error;
+pub mod linux_plugin_transforms;
+
+pub use error::ImlDeviceError;

--- a/iml-services/iml-device/src/linux_plugin_transforms.rs
+++ b/iml-services/iml-device/src/linux_plugin_transforms.rs
@@ -1,0 +1,690 @@
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use device_types::{
+    devices::{
+        Dataset, Device, LogicalVolume, MdRaid, Mpath, Partition, Root, ScsiDevice, VolumeGroup,
+        Zpool,
+    },
+    get_vdev_paths,
+    mount::{FsType, Mount, MountPoint},
+    DevicePath,
+};
+use iml_wire_types::Fqdn;
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::Display,
+    hash::{Hash, Hasher},
+};
+
+#[derive(Debug, Clone, Eq, serde::Serialize)]
+pub struct MajorMinor(pub String);
+
+impl Ord for MajorMinor {
+    fn cmp(&self, other: &MajorMinor) -> Ordering {
+        self.0.partial_cmp(&other.0).unwrap()
+    }
+}
+
+impl PartialOrd for MajorMinor {
+    fn partial_cmp(&self, other: &MajorMinor) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for MajorMinor {
+    fn eq(&self, other: &MajorMinor) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Hash for MajorMinor {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.0.hash(h)
+    }
+}
+
+impl<D1: Display, D2: Display> From<(D1, D2)> for MajorMinor {
+    fn from((major, minor): (D1, D2)) -> MajorMinor {
+        MajorMinor(format!("{}:{}", major, minor))
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LinuxPluginMpathDevice<'a> {
+    name: &'a str,
+    block_device: MajorMinor,
+    nodes: BTreeSet<LinuxPluginDevice<'a>>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LinuxPluginVgDevice<'a> {
+    name: &'a str,
+    uuid: &'a str,
+    size: u64,
+    pvs_major_minor: BTreeSet<MajorMinor>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LinuxPluginLvDevice<'a> {
+    block_device: MajorMinor,
+    size: u64,
+    uuid: &'a str,
+    name: &'a str,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, serde::Serialize)]
+pub struct LinuxPluginDevice<'a> {
+    major_minor: MajorMinor,
+    parent: Option<MajorMinor>,
+    partition_number: Option<u64>,
+    path: &'a DevicePath,
+    paths: BTreeSet<&'a DevicePath>,
+    serial_83: &'a Option<String>,
+    serial_80: &'a Option<String>,
+    size: Option<u64>,
+    filesystem_type: &'a Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, serde::Serialize)]
+pub struct LinuxPluginZpool<'a> {
+    block_device: MajorMinor,
+    drives: BTreeSet<MajorMinor>,
+    name: &'a str,
+    path: &'a str,
+    size: u64,
+    uuid: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(untagged)]
+pub enum LinuxPluginItem<'a> {
+    LinuxPluginDevice(LinuxPluginDevice<'a>),
+    LinuxPluginZpool(LinuxPluginZpool<'a>),
+}
+
+impl<'a> Ord for LinuxPluginDevice<'a> {
+    fn cmp(&self, other: &LinuxPluginDevice) -> Ordering {
+        self.major_minor.partial_cmp(&other.major_minor).unwrap()
+    }
+}
+
+impl<'a> PartialOrd for LinuxPluginDevice<'a> {
+    fn partial_cmp(&self, other: &LinuxPluginDevice) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LinuxPluginData<'a> {
+    pub devs: BTreeMap<MajorMinor, LinuxPluginItem<'a>>,
+    pub local_fs: BTreeMap<MajorMinor, (&'a MountPoint, &'a FsType)>,
+    pub mpath: BTreeMap<&'a str, LinuxPluginMpathDevice<'a>>,
+    pub vgs: BTreeMap<&'a str, LinuxPluginVgDevice<'a>>,
+    pub lvs: BTreeMap<&'a str, BTreeMap<&'a str, LinuxPluginLvDevice<'a>>>,
+    pub zfspools: BTreeMap<u64, LinuxPluginZpool<'a>>,
+    pub zfsdatasets: BTreeMap<u64, LinuxPluginZpool<'a>>,
+}
+
+impl<'a> Default for LinuxPluginData<'a> {
+    fn default() -> LinuxPluginData<'a> {
+        LinuxPluginData {
+            devs: BTreeMap::new(),
+            local_fs: BTreeMap::new(),
+            mpath: BTreeMap::new(),
+            vgs: BTreeMap::new(),
+            lvs: BTreeMap::new(),
+            zfspools: BTreeMap::new(),
+            zfsdatasets: BTreeMap::new(),
+        }
+    }
+}
+
+impl<'a> From<&'a ScsiDevice> for LinuxPluginDevice<'a> {
+    fn from(s: &ScsiDevice) -> LinuxPluginDevice {
+        LinuxPluginDevice {
+            major_minor: (&s.major, &s.minor).into(),
+            parent: None,
+            path: s.paths.get_min().unwrap(),
+            paths: s.paths.iter().collect(),
+            partition_number: None,
+            serial_83: &s.serial,
+            serial_80: &s.scsi80,
+            size: Some(s.size),
+            filesystem_type: &s.filesystem_type,
+        }
+    }
+}
+
+impl<'a> From<(&'a Partition, Option<&LinuxPluginDevice<'a>>)> for LinuxPluginDevice<'a> {
+    fn from((x, p): (&'a Partition, Option<&LinuxPluginDevice>)) -> LinuxPluginDevice<'a> {
+        LinuxPluginDevice {
+            major_minor: (&x.major, &x.minor).into(),
+            parent: p.map(|y| y.major_minor.clone()),
+            path: x.paths.get_min().unwrap(),
+            paths: x.paths.iter().collect(),
+            partition_number: Some(x.partition_number),
+            serial_83: &None,
+            serial_80: &None,
+            size: Some(x.size),
+            filesystem_type: &x.filesystem_type,
+        }
+    }
+}
+
+impl<'a> From<(&'a Mpath, Option<&LinuxPluginDevice<'a>>)> for LinuxPluginDevice<'a> {
+    fn from((x, _p): (&'a Mpath, Option<&LinuxPluginDevice>)) -> LinuxPluginDevice<'a> {
+        LinuxPluginDevice {
+            major_minor: (&x.major, &x.minor).into(),
+            // @FIXME
+            // linux.py erroneously declares that
+            // only partitions should have a parent.
+            // To make interop work with this assumption
+            // we set the parent to `None`.
+            // https://github.com/whamcloud/integrated-manager-for-lustre/blob/841567bb99edde5b635fb1573a6485f6eb75428a/chroma_core/plugins/linux.py#L439
+            parent: None,
+            path: x.paths.get_min().unwrap(),
+            paths: x.paths.iter().collect(),
+            partition_number: None,
+            serial_83: &x.serial,
+            serial_80: &x.scsi80,
+            size: Some(x.size),
+            filesystem_type: &x.filesystem_type,
+        }
+    }
+}
+
+impl<'a> From<(&'a LogicalVolume, Option<&LinuxPluginDevice<'a>>)> for LinuxPluginDevice<'a> {
+    fn from((x, _p): (&'a LogicalVolume, Option<&LinuxPluginDevice>)) -> LinuxPluginDevice<'a> {
+        LinuxPluginDevice {
+            major_minor: ("lv", &x.uuid).into(),
+            // @FIXME
+            // linux.py erroneously declares that
+            // only partitions should have a parent.
+            // To make interop work with this assumption
+            // we set the parent to `None`.
+            // https://github.com/whamcloud/integrated-manager-for-lustre/blob/841567bb99edde5b635fb1573a6485f6eb75428a/chroma_core/plugins/linux.py#L439
+            parent: None,
+            path: x.paths.get_min().unwrap(),
+            paths: x.paths.iter().collect(),
+            partition_number: None,
+            serial_83: &None,
+            serial_80: &None,
+            size: Some(x.size),
+            filesystem_type: &x.filesystem_type,
+        }
+    }
+}
+
+impl<'a> From<&'a Zpool> for LinuxPluginZpool<'a> {
+    fn from(x: &'a Zpool) -> LinuxPluginZpool<'a> {
+        LinuxPluginZpool {
+            name: &x.name,
+            path: &x.name,
+            block_device: ("zfspool", &x.guid).into(),
+            size: x.size,
+            uuid: x.guid,
+            drives: BTreeSet::new(),
+        }
+    }
+}
+
+impl<'a> From<(&'a Dataset, u64)> for LinuxPluginZpool<'a> {
+    fn from((x, size): (&'a Dataset, u64)) -> LinuxPluginZpool<'a> {
+        LinuxPluginZpool {
+            name: &x.name,
+            path: &x.name,
+            block_device: ("zfsset", &x.guid).into(),
+            size,
+            uuid: x.guid,
+            drives: BTreeSet::new(),
+        }
+    }
+}
+
+fn add_mount<'a>(
+    mount: &'a Mount,
+    d: &LinuxPluginDevice<'a>,
+    linux_plugin_data: &mut LinuxPluginData<'a>,
+) {
+    // This check is working around one cause of https://github.com/whamcloud/integrated-manager-for-lustre/issues/895
+    // Once we persist device-scanner input directly in the IML database, we won't need this fn anymore,
+    // as device-scanner correctly reports that the mount is transient.
+    if mount.target.0.as_os_str().len() == 14
+        && mount.target.0.to_string_lossy().starts_with("/tmp/mnt")
+    {
+        return;
+    }
+
+    linux_plugin_data
+        .local_fs
+        .insert(d.major_minor.clone(), (&mount.target, &mount.fs_type));
+}
+
+pub fn populate_zpool<'a>(
+    x: &'a Zpool,
+    mm: MajorMinor,
+    linux_plugin_data: &mut LinuxPluginData<'a>,
+) {
+    if x.children.is_empty() {
+        let pool = linux_plugin_data
+            .devs
+            .entry(("zfspool", x.guid).into())
+            .or_insert_with(|| LinuxPluginItem::LinuxPluginZpool(x.into()));
+
+        if let LinuxPluginItem::LinuxPluginZpool(p) = pool {
+            p.drives.insert(mm.clone());
+
+            let p2 = linux_plugin_data
+                .zfspools
+                .entry(p.uuid)
+                .or_insert_with(|| p.clone());
+
+            p2.drives.insert(mm);
+        };
+    } else {
+        for dev in &x.children {
+            if let Device::Dataset(d) = dev {
+                let dataset = linux_plugin_data
+                    .devs
+                    .entry(("zfsset", d.guid).into())
+                    .or_insert_with(|| LinuxPluginItem::LinuxPluginZpool((d, x.size).into()));
+
+                if let LinuxPluginItem::LinuxPluginZpool(d) = dataset {
+                    d.drives.insert(mm.clone());
+
+                    let d2 = linux_plugin_data
+                        .zfsdatasets
+                        .entry(d.uuid)
+                        .or_insert_with(|| d.clone());
+
+                    d2.drives.insert(mm.clone());
+                };
+            }
+        }
+    }
+}
+
+pub fn devtree2linuxoutput<'a>(
+    device: &'a Device,
+    parent: Option<&LinuxPluginDevice<'a>>,
+    mut linux_plugin_data: &mut LinuxPluginData<'a>,
+) {
+    match device {
+        Device::Root(x) => {
+            for c in &x.children {
+                devtree2linuxoutput(c, None, &mut linux_plugin_data);
+            }
+        }
+        Device::ScsiDevice(x) => {
+            let d: LinuxPluginDevice = x.into();
+
+            if let Some(mount) = &x.mount {
+                add_mount(mount, &d, linux_plugin_data);
+            }
+
+            for c in &x.children {
+                devtree2linuxoutput(&c, Some(&d), &mut linux_plugin_data);
+            }
+
+            linux_plugin_data
+                .devs
+                .insert(d.major_minor.clone(), LinuxPluginItem::LinuxPluginDevice(d));
+        }
+        Device::Partition(x) => {
+            let d: LinuxPluginDevice = (x, parent).into();
+
+            if let Some(mount) = &x.mount {
+                add_mount(mount, &d, linux_plugin_data);
+            }
+
+            for c in &x.children {
+                devtree2linuxoutput(c, Some(&d), &mut linux_plugin_data);
+            }
+
+            linux_plugin_data
+                .devs
+                .insert(d.major_minor.clone(), LinuxPluginItem::LinuxPluginDevice(d));
+        }
+        Device::Mpath(x) => {
+            let d: LinuxPluginDevice<'a> = (x, parent).into();
+
+            if let Some(mount) = &x.mount {
+                add_mount(mount, &d, linux_plugin_data);
+            }
+
+            for c in &x.children {
+                devtree2linuxoutput(c, Some(&d), &mut linux_plugin_data);
+            }
+
+            let block_device = d.major_minor.clone();
+
+            linux_plugin_data
+                .devs
+                .insert(d.major_minor.clone(), LinuxPluginItem::LinuxPluginDevice(d));
+
+            let mpath_device =
+                linux_plugin_data
+                    .mpath
+                    .entry(&x.dm_name)
+                    .or_insert(LinuxPluginMpathDevice {
+                        block_device,
+                        name: &x.dm_name,
+                        nodes: BTreeSet::new(),
+                    });
+
+            if let Some(parent) = parent {
+                mpath_device.nodes.insert(parent.clone());
+            }
+        }
+        Device::VolumeGroup(x) => {
+            let vg_device = linux_plugin_data
+                .vgs
+                .entry(&x.name)
+                .or_insert(LinuxPluginVgDevice {
+                    name: &x.name,
+                    size: x.size,
+                    uuid: &x.uuid,
+                    pvs_major_minor: BTreeSet::new(),
+                });
+
+            if let Some(parent) = parent {
+                vg_device.pvs_major_minor.insert(parent.major_minor.clone());
+            }
+
+            x.children
+                .iter()
+                .filter_map(|d| match d {
+                    Device::LogicalVolume(lv) => Some(lv),
+                    _ => None,
+                })
+                .for_each(|lv| {
+                    let d: LinuxPluginDevice = (lv, parent).into();
+
+                    if let Some(mount) = &lv.mount {
+                        add_mount(mount, &d, linux_plugin_data);
+                    }
+
+                    for c in &lv.children {
+                        devtree2linuxoutput(c, Some(&d), &mut linux_plugin_data);
+                    }
+
+                    let block_device = d.major_minor.clone();
+
+                    linux_plugin_data
+                        .devs
+                        .insert(d.major_minor.clone(), LinuxPluginItem::LinuxPluginDevice(d));
+
+                    linux_plugin_data
+                        .lvs
+                        .entry(&x.name)
+                        .or_insert_with(BTreeMap::new)
+                        .entry(&lv.name)
+                        .or_insert(LinuxPluginLvDevice {
+                            name: &lv.name,
+                            size: lv.size,
+                            uuid: &lv.uuid,
+                            block_device,
+                        });
+                });
+        }
+        Device::Zpool(x) => {
+            populate_zpool(x, parent.unwrap().major_minor.clone(), linux_plugin_data);
+        }
+        _ => {}
+    };
+}
+
+type PoolMap<'a> = BTreeMap<u64, (&'a Zpool, BTreeSet<DevicePath>)>;
+
+pub fn build_device_lookup<'a>(
+    dev_tree: &'a Device,
+    path_map: &mut BTreeMap<&'a DevicePath, MajorMinor>,
+    pool_map: &mut PoolMap<'a>,
+) {
+    match dev_tree {
+        Device::Root(Root { children }) | Device::VolumeGroup(VolumeGroup { children, .. }) => {
+            for c in children {
+                build_device_lookup(c, path_map, pool_map);
+            }
+        }
+        Device::ScsiDevice(ScsiDevice {
+            children,
+            paths,
+            major,
+            minor,
+            ..
+        })
+        | Device::Partition(Partition {
+            children,
+            paths,
+            major,
+            minor,
+            ..
+        })
+        | Device::MdRaid(MdRaid {
+            children,
+            paths,
+            major,
+            minor,
+            ..
+        })
+        | Device::Mpath(Mpath {
+            children,
+            paths,
+            major,
+            minor,
+            ..
+        }) => {
+            for p in paths {
+                path_map.insert(p, (major, minor).into());
+            }
+
+            for c in children {
+                build_device_lookup(c, path_map, pool_map);
+            }
+        }
+        Device::LogicalVolume(LogicalVolume {
+            children,
+            paths,
+            uuid,
+            ..
+        }) => {
+            for p in paths {
+                path_map.insert(p, ("lv", uuid).into());
+            }
+
+            for c in children {
+                build_device_lookup(c, path_map, pool_map);
+            }
+        }
+        Device::Zpool(x) => {
+            let paths = get_vdev_paths(&x.vdev);
+
+            pool_map.entry(x.guid).or_insert_with(|| (x, paths));
+        }
+        Device::Dataset(_) => {}
+    }
+}
+
+/// In order for a pool to exist on > 1 node, *all* of it's backing
+/// storage must exist on > 1 host.
+///
+/// This fn figures out if all of a pools VDEVs exist on
+/// multiple hosts and if so, returns
+/// where they need to be inserted.
+pub fn get_shared_pools<'a, S: ::std::hash::BuildHasher>(
+    host: &Fqdn,
+    path_map: &'a BTreeMap<&'a DevicePath, MajorMinor>,
+    cluster_pools: &'a HashMap<&'a Fqdn, PoolMap<'a>, S>,
+) -> Vec<(&'a Zpool, MajorMinor)> {
+    let mut shared_pools: Vec<_> = vec![];
+
+    let paths: BTreeSet<&DevicePath> = path_map.keys().copied().collect();
+
+    for (&h, ps) in cluster_pools.iter() {
+        if host == h {
+            continue;
+        }
+
+        for v in ps.values() {
+            let ds = v.1.iter().collect();
+
+            if !paths.is_superset(&ds) {
+                continue;
+            };
+
+            tracing::debug!("pool is shared between {} and {}", h, host);
+
+            for d in ds {
+                let parent = path_map[&d].clone();
+
+                shared_pools.push((v.0, parent));
+            }
+        }
+    }
+
+    shared_pools
+}
+
+/// Given a slice of major minors,
+/// figures out all cooresponding the device paths and returns them.
+fn major_minors_to_dev_paths<'a>(
+    xs: &BTreeSet<MajorMinor>,
+    path_map: &BTreeMap<&'a DevicePath, MajorMinor>,
+) -> BTreeSet<&'a DevicePath> {
+    xs.iter().fold(BTreeSet::new(), |acc, mm| {
+        let paths = path_map
+            .iter()
+            .filter(|(_, pmm)| &mm == pmm)
+            .map(|(p, _)| *p)
+            .collect();
+
+        acc.union(&paths).copied().collect()
+    })
+}
+
+/// Given some aggregated data
+/// Figure out what VGs can be shared between hosts and add them to the other hosts.
+pub fn update_vgs<'a>(
+    mut xs: BTreeMap<&'a Fqdn, LinuxPluginData<'a>>,
+    path_map: &HashMap<&'a Fqdn, BTreeMap<&'a DevicePath, MajorMinor>>,
+) -> BTreeMap<&'a Fqdn, LinuxPluginData<'a>> {
+    let shared_vgs = xs.iter().fold(vec![], |mut acc, (from_host, x)| {
+        let from_paths = &path_map[from_host];
+
+        let mut others: Vec<_> = xs
+            .iter()
+            .filter(|(k, _)| k != &from_host)
+            .filter_map(|(to_host, _)| {
+                let to_paths: BTreeSet<&DevicePath> =
+                    (&path_map[to_host]).keys().copied().collect();
+
+                let shared_vgs: Vec<_> = x
+                    .vgs
+                    .iter()
+                    .filter(|(_, vg)| {
+                        let p = major_minors_to_dev_paths(&vg.pvs_major_minor, &from_paths);
+
+                        to_paths.is_superset(&p)
+                    })
+                    .map(|(vg_name, _)| (Fqdn::clone(from_host), Fqdn::clone(to_host), *vg_name))
+                    .collect();
+
+                if shared_vgs.is_empty() {
+                    None
+                } else {
+                    Some(shared_vgs)
+                }
+            })
+            .flatten()
+            .collect();
+
+        acc.append(&mut others);
+
+        acc
+    });
+
+    for (from_host, to_host, vg_name) in shared_vgs {
+        let from = xs.get(&from_host).unwrap();
+
+        let vg = from.vgs.get(&vg_name).cloned().unwrap();
+
+        let lvs = from.lvs.get(&vg_name).cloned();
+
+        let lv_devs: Option<Vec<_>> = lvs.as_ref().map(|lvs| {
+            lvs.iter()
+                .map(|(_, lv)| {
+                    (
+                        lv.block_device.clone(),
+                        from.devs.get(&lv.block_device).cloned().unwrap_or_else(|| {
+                            panic!("Did not find lv block device {:?}", lv.block_device)
+                        }),
+                    )
+                })
+                .collect()
+        });
+
+        let to = xs.get_mut(&to_host).unwrap();
+
+        to.vgs.insert(vg_name, vg);
+
+        if let Some(lvs) = lvs {
+            to.lvs.insert(vg_name, lvs);
+        }
+
+        if let Some(lv_devs) = lv_devs {
+            for (mm, lv_dev) in lv_devs {
+                to.devs.insert(mm, lv_dev);
+            }
+        }
+    }
+
+    xs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{devtree2linuxoutput, LinuxPluginData};
+    use device_types::devices::Device;
+    use insta::assert_json_snapshot;
+
+    #[test]
+    fn test_devtree2linuxoutput() {
+        let device: Device =
+            serde_json::from_slice(include_bytes!("../fixtures/devtree.json")).unwrap();
+
+        let mut data = LinuxPluginData::default();
+
+        devtree2linuxoutput(&device, None, &mut data);
+
+        assert_json_snapshot!(data);
+    }
+
+    #[test]
+    fn test_devtree2linuxoutput_zpool() {
+        let device: Device =
+            serde_json::from_slice(include_bytes!("../fixtures/devtree_zpool.json")).unwrap();
+
+        let mut data = LinuxPluginData::default();
+
+        devtree2linuxoutput(&device, None, &mut data);
+
+        assert_json_snapshot!(data);
+    }
+
+    #[test]
+    fn test_devtree2linuxoutput_dataset() {
+        let device: Device =
+            serde_json::from_slice(include_bytes!("../fixtures/devtree_zpool_dataset.json"))
+                .unwrap();
+
+        let mut data = LinuxPluginData::default();
+
+        devtree2linuxoutput(&device, None, &mut data);
+
+        assert_json_snapshot!(data);
+    }
+}

--- a/iml-services/iml-device/src/main.rs
+++ b/iml-services/iml-device/src/main.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use device_types::devices::Device;
+use futures::{lock::Mutex, TryFutureExt, TryStreamExt};
+use iml_device::{
+    linux_plugin_transforms::{
+        build_device_lookup, devtree2linuxoutput, get_shared_pools, populate_zpool, update_vgs,
+        LinuxPluginData,
+    },
+    ImlDeviceError,
+};
+use iml_service_queue::service_queue::consume_data;
+use iml_wire_types::Fqdn;
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
+use tracing_subscriber::{fmt::Subscriber, EnvFilter};
+use warp::Filter;
+
+type Cache = Arc<Mutex<HashMap<Fqdn, Device>>>;
+
+#[tokio::main]
+async fn main() -> Result<(), ImlDeviceError> {
+    let subscriber = Subscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    let addr = iml_manager_env::get_device_aggregator_addr();
+
+    let cache = Arc::new(Mutex::new(HashMap::new()));
+    let cache2 = Arc::clone(&cache);
+    let cache = warp::any().map(move || Arc::clone(&cache));
+
+    let get = warp::get().and(cache).and_then(|cache: Cache| {
+        async move {
+            let cache = cache.lock().await;
+
+            let mut xs: BTreeMap<&Fqdn, _> = cache
+                .iter()
+                .map(|(k, v)| {
+                    let mut out = LinuxPluginData::default();
+
+                    devtree2linuxoutput(&v, None, &mut out);
+
+                    (k, out)
+                })
+                .collect();
+
+            let (path_index, cluster_pools): (HashMap<&Fqdn, _>, HashMap<&Fqdn, _>) = cache
+                .iter()
+                .map(|(k, v)| {
+                    let mut path_to_mm = BTreeMap::new();
+                    let mut pools = BTreeMap::new();
+
+                    build_device_lookup(v, &mut path_to_mm, &mut pools);
+
+                    ((k, path_to_mm), (k, pools))
+                })
+                .unzip();
+
+            for (&h, x) in xs.iter_mut() {
+                let path_to_mm = &path_index[h];
+                let shared_pools = get_shared_pools(&h, path_to_mm, &cluster_pools);
+
+                for (a, b) in shared_pools {
+                    populate_zpool(a, b, x);
+                }
+            }
+
+            let xs: BTreeMap<&Fqdn, LinuxPluginData> = update_vgs(xs, &path_index);
+
+            Ok::<_, ImlDeviceError>(warp::reply::json(&xs))
+        }
+        .map_err(warp::reject::custom)
+    });
+
+    tracing::info!("Server starting");
+
+    let server = warp::serve(get.with(warp::log("devices"))).run(addr);
+
+    tokio::spawn(server);
+
+    let mut s = consume_data("rust_agent_device_rx");
+
+    while let Some((fqdn, device)) = s.try_next().await? {
+        let mut cache = cache2.lock().await;
+
+        cache.insert(fqdn, device);
+    }
+
+    Ok(())
+}

--- a/iml-services/iml-device/src/snapshots/iml_device__linux_plugin_transforms__tests__devtree2linuxoutput.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__linux_plugin_transforms__tests__devtree2linuxoutput.snap
@@ -1,0 +1,1808 @@
+---
+source: iml-services/iml-device/src/linux_plugin_transforms.rs
+expression: data
+---
+{
+  "devs": {
+    "253:0": {
+      "major_minor": "253:0",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpatha",
+      "paths": [
+        "/dev/mapper/mpatha",
+        "/dev/disk/by-id/dm-name-mpatha",
+        "/dev/disk/by-id/dm-uuid-mpath-3600140568c946040400460a896d0b196",
+        "/dev/dm-0"
+      ],
+      "serial_83": "3600140568c946040400460a896d0b196",
+      "serial_80": "SLIO-ORG ost1            68c94604-0400-460a-896d-0b196cd0a235",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:1": {
+      "major_minor": "253:1",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathb",
+      "paths": [
+        "/dev/mapper/mpathb",
+        "/dev/disk/by-id/dm-name-mpathb",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405a63b61f10cbb4e229df0792d0",
+        "/dev/dm-1"
+      ],
+      "serial_83": "36001405a63b61f10cbb4e229df0792d0",
+      "serial_80": "SLIO-ORG ost2            a63b61f1-0cbb-4e22-9df0-792d0cf69575",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:10": {
+      "major_minor": "253:10",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathk",
+      "paths": [
+        "/dev/mapper/mpathk",
+        "/dev/disk/by-id/dm-name-mpathk",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405047a9e1ee2c04af6b26216f3a",
+        "/dev/dm-10"
+      ],
+      "serial_83": "36001405047a9e1ee2c04af6b26216f3a",
+      "serial_80": "SLIO-ORG ost19           047a9e1e-e2c0-4af6-b262-16f3ac3ca915",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:11": {
+      "major_minor": "253:11",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathl",
+      "paths": [
+        "/dev/mapper/mpathl",
+        "/dev/disk/by-id/dm-name-mpathl",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405b1662648389c47ae91f7f9c18",
+        "/dev/dm-11"
+      ],
+      "serial_83": "36001405b1662648389c47ae91f7f9c18",
+      "serial_80": "SLIO-ORG ost20           b1662648-389c-47ae-91f7-f9c18ead9f54",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:12": {
+      "major_minor": "253:12",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathm",
+      "paths": [
+        "/dev/mapper/mpathm",
+        "/dev/disk/by-id/dm-name-mpathm",
+        "/dev/disk/by-id/dm-uuid-mpath-360014051ea57ad4ffc243d6bcab8eb8c",
+        "/dev/dm-12"
+      ],
+      "serial_83": "360014051ea57ad4ffc243d6bcab8eb8c",
+      "serial_80": "SLIO-ORG ost3            1ea57ad4-ffc2-43d6-bcab-8eb8c2a60bfb",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:13": {
+      "major_minor": "253:13",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathn",
+      "paths": [
+        "/dev/mapper/mpathn",
+        "/dev/disk/by-id/dm-name-mpathn",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405c9535ca96e924f9fa2e32ed89",
+        "/dev/dm-13"
+      ],
+      "serial_83": "36001405c9535ca96e924f9fa2e32ed89",
+      "serial_80": "SLIO-ORG ost4            c9535ca9-6e92-4f9f-a2e3-2ed89e8cf8be",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:14": {
+      "major_minor": "253:14",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpatho",
+      "paths": [
+        "/dev/mapper/mpatho",
+        "/dev/disk/by-id/dm-name-mpatho",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405aa1a4a2010734758a9e57c178",
+        "/dev/dm-14"
+      ],
+      "serial_83": "36001405aa1a4a2010734758a9e57c178",
+      "serial_80": "SLIO-ORG ost5            aa1a4a20-1073-4758-a9e5-7c178c6ed8ef",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:15": {
+      "major_minor": "253:15",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathp",
+      "paths": [
+        "/dev/mapper/mpathp",
+        "/dev/disk/by-id/dm-name-mpathp",
+        "/dev/disk/by-id/dm-uuid-mpath-360014058a65c188c7f84052b1b1185d2",
+        "/dev/dm-15"
+      ],
+      "serial_83": "360014058a65c188c7f84052b1b1185d2",
+      "serial_80": "SLIO-ORG ost6            8a65c188-c7f8-4052-b1b1-185d239005ea",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:16": {
+      "major_minor": "253:16",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathq",
+      "paths": [
+        "/dev/mapper/mpathq",
+        "/dev/disk/by-id/dm-name-mpathq",
+        "/dev/disk/by-id/dm-uuid-mpath-360014054e9b5031f3434c56a0746de1f",
+        "/dev/dm-16"
+      ],
+      "serial_83": "360014054e9b5031f3434c56a0746de1f",
+      "serial_80": "SLIO-ORG ost7            4e9b5031-f343-4c56-a074-6de1feb8f72c",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:17": {
+      "major_minor": "253:17",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathr",
+      "paths": [
+        "/dev/mapper/mpathr",
+        "/dev/disk/by-id/dm-name-mpathr",
+        "/dev/disk/by-id/dm-uuid-mpath-3600140547f1dbaca8e344809057273c5",
+        "/dev/dm-17"
+      ],
+      "serial_83": "3600140547f1dbaca8e344809057273c5",
+      "serial_80": "SLIO-ORG ost8            47f1dbac-a8e3-4480-9057-273c502f4dd6",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:18": {
+      "major_minor": "253:18",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpaths",
+      "paths": [
+        "/dev/mapper/mpaths",
+        "/dev/disk/by-id/dm-name-mpaths",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405ce127d66323a4c279ca70706a",
+        "/dev/dm-18"
+      ],
+      "serial_83": "36001405ce127d66323a4c279ca70706a",
+      "serial_80": "SLIO-ORG ost9            ce127d66-323a-4c27-9ca7-0706adf87bd6",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:19": {
+      "major_minor": "253:19",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpatht",
+      "paths": [
+        "/dev/mapper/mpatht",
+        "/dev/disk/by-id/dm-name-mpatht",
+        "/dev/disk/by-id/dm-uuid-mpath-3600140564eea787d99444d79c15fc577",
+        "/dev/dm-19"
+      ],
+      "serial_83": "3600140564eea787d99444d79c15fc577",
+      "serial_80": "SLIO-ORG ost10           64eea787-d994-44d7-9c15-fc577fde7809",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:2": {
+      "major_minor": "253:2",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathc",
+      "paths": [
+        "/dev/mapper/mpathc",
+        "/dev/disk/by-id/dm-name-mpathc",
+        "/dev/disk/by-id/dm-uuid-mpath-3600140547e0ffe43b3f464789f1653cc",
+        "/dev/dm-2"
+      ],
+      "serial_83": "3600140547e0ffe43b3f464789f1653cc",
+      "serial_80": "SLIO-ORG ost11           47e0ffe4-3b3f-4647-89f1-653cc1b7c954",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:3": {
+      "major_minor": "253:3",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathd",
+      "paths": [
+        "/dev/mapper/mpathd",
+        "/dev/disk/by-id/dm-name-mpathd",
+        "/dev/disk/by-id/dm-uuid-mpath-360014053fe9e70a1aa8470faaa82b7b0",
+        "/dev/dm-3"
+      ],
+      "serial_83": "360014053fe9e70a1aa8470faaa82b7b0",
+      "serial_80": "SLIO-ORG ost12           3fe9e70a-1aa8-470f-aaa8-2b7b0e525b83",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:4": {
+      "major_minor": "253:4",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathe",
+      "paths": [
+        "/dev/mapper/mpathe",
+        "/dev/disk/by-id/dm-name-mpathe",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405139a84485b2d4ea5b4f59874c",
+        "/dev/dm-4"
+      ],
+      "serial_83": "36001405139a84485b2d4ea5b4f59874c",
+      "serial_80": "SLIO-ORG ost13           139a8448-5b2d-4ea5-b4f5-9874cd16127b",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:5": {
+      "major_minor": "253:5",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathf",
+      "paths": [
+        "/dev/mapper/mpathf",
+        "/dev/disk/by-id/dm-name-mpathf",
+        "/dev/disk/by-id/dm-uuid-mpath-360014051755d7331b404ff68ae4b6e45",
+        "/dev/dm-5"
+      ],
+      "serial_83": "360014051755d7331b404ff68ae4b6e45",
+      "serial_80": "SLIO-ORG ost14           1755d733-1b40-4ff6-8ae4-b6e4568b03e3",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:6": {
+      "major_minor": "253:6",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathg",
+      "paths": [
+        "/dev/mapper/mpathg",
+        "/dev/disk/by-id/dm-name-mpathg",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405c525c75b8ee1471dbbb344dd8",
+        "/dev/disk/by-id/lvm-pv-uuid-Y0MPay-Yimt-cJJx-ZN92-KFLT-BPJf-SjPIbO",
+        "/dev/dm-6"
+      ],
+      "serial_83": "36001405c525c75b8ee1471dbbb344dd8",
+      "serial_80": "SLIO-ORG ost15           c525c75b-8ee1-471d-bbb3-44dd80198b3f",
+      "size": 5368709120,
+      "filesystem_type": "LVM2_member"
+    },
+    "253:7": {
+      "major_minor": "253:7",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathh",
+      "paths": [
+        "/dev/mapper/mpathh",
+        "/dev/disk/by-id/dm-name-mpathh",
+        "/dev/disk/by-id/dm-uuid-mpath-3600140598252aa12555428f94b6ea915",
+        "/dev/disk/by-id/lvm-pv-uuid-sSb1jT-hBLl-am3F-mc9T-2cMR-oGbb-xG0FZw",
+        "/dev/dm-7"
+      ],
+      "serial_83": "3600140598252aa12555428f94b6ea915",
+      "serial_80": "SLIO-ORG ost16           98252aa1-2555-428f-94b6-ea915aadcd5a",
+      "size": 5368709120,
+      "filesystem_type": "LVM2_member"
+    },
+    "253:8": {
+      "major_minor": "253:8",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathi",
+      "paths": [
+        "/dev/mapper/mpathi",
+        "/dev/disk/by-id/dm-name-mpathi",
+        "/dev/disk/by-id/dm-uuid-mpath-360014053fff9fd2761f4efe9143a33ff",
+        "/dev/dm-8"
+      ],
+      "serial_83": "360014053fff9fd2761f4efe9143a33ff",
+      "serial_80": "SLIO-ORG ost17           3fff9fd2-761f-4efe-9143-a33ff9ff7a52",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "253:9": {
+      "major_minor": "253:9",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathj",
+      "paths": [
+        "/dev/mapper/mpathj",
+        "/dev/disk/by-id/dm-name-mpathj",
+        "/dev/disk/by-id/dm-uuid-mpath-360014051c12549d858d4562a2e178018",
+        "/dev/dm-9"
+      ],
+      "serial_83": "360014051c12549d858d4562a2e178018",
+      "serial_80": "SLIO-ORG ost18           1c12549d-858d-4562-a2e1-78018d748a6f",
+      "size": 5368709120,
+      "filesystem_type": null
+    },
+    "65:0": {
+      "major_minor": "65:0",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-3600140547f1dbaca8e344809057273c5",
+      "paths": [
+        "/dev/disk/by-id/scsi-3600140547f1dbaca8e344809057273c5",
+        "/dev/disk/by-id/wwn-0x600140547f1dbaca8e344809057273c5",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-7",
+        "/dev/sdq"
+      ],
+      "serial_83": "3600140547f1dbaca8e344809057273c5",
+      "serial_80": "SLIO-ORG ost8            47f1dbac-a8e3-4480-9057-273c502f4dd6",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:112": {
+      "major_minor": "65:112",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014053fe9e70a1aa8470faaa82b7b0",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014053fe9e70a1aa8470faaa82b7b0",
+        "/dev/disk/by-id/wwn-0x60014053fe9e70a1aa8470faaa82b7b0",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-11",
+        "/dev/sdx"
+      ],
+      "serial_83": "360014053fe9e70a1aa8470faaa82b7b0",
+      "serial_80": "SLIO-ORG ost12           3fe9e70a-1aa8-470f-aaa8-2b7b0e525b83",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:128": {
+      "major_minor": "65:128",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014053fe9e70a1aa8470faaa82b7b0",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014053fe9e70a1aa8470faaa82b7b0",
+        "/dev/disk/by-id/wwn-0x60014053fe9e70a1aa8470faaa82b7b0",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-11",
+        "/dev/sdy"
+      ],
+      "serial_83": "360014053fe9e70a1aa8470faaa82b7b0",
+      "serial_80": "SLIO-ORG ost12           3fe9e70a-1aa8-470f-aaa8-2b7b0e525b83",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:144": {
+      "major_minor": "65:144",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405139a84485b2d4ea5b4f59874c",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405139a84485b2d4ea5b4f59874c",
+        "/dev/disk/by-id/wwn-0x6001405139a84485b2d4ea5b4f59874c",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-12",
+        "/dev/sdz"
+      ],
+      "serial_83": "36001405139a84485b2d4ea5b4f59874c",
+      "serial_80": "SLIO-ORG ost13           139a8448-5b2d-4ea5-b4f5-9874cd16127b",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:16": {
+      "major_minor": "65:16",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405ce127d66323a4c279ca70706a",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405ce127d66323a4c279ca70706a",
+        "/dev/disk/by-id/wwn-0x6001405ce127d66323a4c279ca70706a",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-8",
+        "/dev/sdr"
+      ],
+      "serial_83": "36001405ce127d66323a4c279ca70706a",
+      "serial_80": "SLIO-ORG ost9            ce127d66-323a-4c27-9ca7-0706adf87bd6",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:160": {
+      "major_minor": "65:160",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405139a84485b2d4ea5b4f59874c",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405139a84485b2d4ea5b4f59874c",
+        "/dev/disk/by-id/wwn-0x6001405139a84485b2d4ea5b4f59874c",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-12",
+        "/dev/sdaa"
+      ],
+      "serial_83": "36001405139a84485b2d4ea5b4f59874c",
+      "serial_80": "SLIO-ORG ost13           139a8448-5b2d-4ea5-b4f5-9874cd16127b",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:176": {
+      "major_minor": "65:176",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014051755d7331b404ff68ae4b6e45",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014051755d7331b404ff68ae4b6e45",
+        "/dev/disk/by-id/wwn-0x60014051755d7331b404ff68ae4b6e45",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-13",
+        "/dev/sdab"
+      ],
+      "serial_83": "360014051755d7331b404ff68ae4b6e45",
+      "serial_80": "SLIO-ORG ost14           1755d733-1b40-4ff6-8ae4-b6e4568b03e3",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:192": {
+      "major_minor": "65:192",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014051755d7331b404ff68ae4b6e45",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014051755d7331b404ff68ae4b6e45",
+        "/dev/disk/by-id/wwn-0x60014051755d7331b404ff68ae4b6e45",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-13",
+        "/dev/sdac"
+      ],
+      "serial_83": "360014051755d7331b404ff68ae4b6e45",
+      "serial_80": "SLIO-ORG ost14           1755d733-1b40-4ff6-8ae4-b6e4568b03e3",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:208": {
+      "major_minor": "65:208",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405c525c75b8ee1471dbbb344dd8",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405c525c75b8ee1471dbbb344dd8",
+        "/dev/disk/by-id/wwn-0x6001405c525c75b8ee1471dbbb344dd8",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-14",
+        "/dev/sdad"
+      ],
+      "serial_83": "36001405c525c75b8ee1471dbbb344dd8",
+      "serial_80": "SLIO-ORG ost15           c525c75b-8ee1-471d-bbb3-44dd80198b3f",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:224": {
+      "major_minor": "65:224",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405c525c75b8ee1471dbbb344dd8",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405c525c75b8ee1471dbbb344dd8",
+        "/dev/disk/by-id/wwn-0x6001405c525c75b8ee1471dbbb344dd8",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-14",
+        "/dev/sdae"
+      ],
+      "serial_83": "36001405c525c75b8ee1471dbbb344dd8",
+      "serial_80": "SLIO-ORG ost15           c525c75b-8ee1-471d-bbb3-44dd80198b3f",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:240": {
+      "major_minor": "65:240",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-3600140598252aa12555428f94b6ea915",
+      "paths": [
+        "/dev/disk/by-id/scsi-3600140598252aa12555428f94b6ea915",
+        "/dev/disk/by-id/wwn-0x600140598252aa12555428f94b6ea915",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-15",
+        "/dev/sdaf"
+      ],
+      "serial_83": "3600140598252aa12555428f94b6ea915",
+      "serial_80": "SLIO-ORG ost16           98252aa1-2555-428f-94b6-ea915aadcd5a",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:32": {
+      "major_minor": "65:32",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405ce127d66323a4c279ca70706a",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405ce127d66323a4c279ca70706a",
+        "/dev/disk/by-id/wwn-0x6001405ce127d66323a4c279ca70706a",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-8",
+        "/dev/sds"
+      ],
+      "serial_83": "36001405ce127d66323a4c279ca70706a",
+      "serial_80": "SLIO-ORG ost9            ce127d66-323a-4c27-9ca7-0706adf87bd6",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:48": {
+      "major_minor": "65:48",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-3600140564eea787d99444d79c15fc577",
+      "paths": [
+        "/dev/disk/by-id/scsi-3600140564eea787d99444d79c15fc577",
+        "/dev/disk/by-id/wwn-0x600140564eea787d99444d79c15fc577",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-9",
+        "/dev/sdt"
+      ],
+      "serial_83": "3600140564eea787d99444d79c15fc577",
+      "serial_80": "SLIO-ORG ost10           64eea787-d994-44d7-9c15-fc577fde7809",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:64": {
+      "major_minor": "65:64",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-3600140564eea787d99444d79c15fc577",
+      "paths": [
+        "/dev/disk/by-id/scsi-3600140564eea787d99444d79c15fc577",
+        "/dev/disk/by-id/wwn-0x600140564eea787d99444d79c15fc577",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-9",
+        "/dev/sdu"
+      ],
+      "serial_83": "3600140564eea787d99444d79c15fc577",
+      "serial_80": "SLIO-ORG ost10           64eea787-d994-44d7-9c15-fc577fde7809",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:80": {
+      "major_minor": "65:80",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-3600140547e0ffe43b3f464789f1653cc",
+      "paths": [
+        "/dev/disk/by-id/scsi-3600140547e0ffe43b3f464789f1653cc",
+        "/dev/disk/by-id/wwn-0x600140547e0ffe43b3f464789f1653cc",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-10",
+        "/dev/sdv"
+      ],
+      "serial_83": "3600140547e0ffe43b3f464789f1653cc",
+      "serial_80": "SLIO-ORG ost11           47e0ffe4-3b3f-4647-89f1-653cc1b7c954",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "65:96": {
+      "major_minor": "65:96",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-3600140547e0ffe43b3f464789f1653cc",
+      "paths": [
+        "/dev/disk/by-id/scsi-3600140547e0ffe43b3f464789f1653cc",
+        "/dev/disk/by-id/wwn-0x600140547e0ffe43b3f464789f1653cc",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-10",
+        "/dev/sdw"
+      ],
+      "serial_83": "3600140547e0ffe43b3f464789f1653cc",
+      "serial_80": "SLIO-ORG ost11           47e0ffe4-3b3f-4647-89f1-653cc1b7c954",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "66:0": {
+      "major_minor": "66:0",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-3600140598252aa12555428f94b6ea915",
+      "paths": [
+        "/dev/disk/by-id/scsi-3600140598252aa12555428f94b6ea915",
+        "/dev/disk/by-id/wwn-0x600140598252aa12555428f94b6ea915",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-15",
+        "/dev/sdag"
+      ],
+      "serial_83": "3600140598252aa12555428f94b6ea915",
+      "serial_80": "SLIO-ORG ost16           98252aa1-2555-428f-94b6-ea915aadcd5a",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "66:112": {
+      "major_minor": "66:112",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405b1662648389c47ae91f7f9c18",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405b1662648389c47ae91f7f9c18",
+        "/dev/disk/by-id/wwn-0x6001405b1662648389c47ae91f7f9c18",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-19",
+        "/dev/sdan"
+      ],
+      "serial_83": "36001405b1662648389c47ae91f7f9c18",
+      "serial_80": "SLIO-ORG ost20           b1662648-389c-47ae-91f7-f9c18ead9f54",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "66:128": {
+      "major_minor": "66:128",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405b1662648389c47ae91f7f9c18",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405b1662648389c47ae91f7f9c18",
+        "/dev/disk/by-id/wwn-0x6001405b1662648389c47ae91f7f9c18",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-19",
+        "/dev/sdao"
+      ],
+      "serial_83": "36001405b1662648389c47ae91f7f9c18",
+      "serial_80": "SLIO-ORG ost20           b1662648-389c-47ae-91f7-f9c18ead9f54",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "66:16": {
+      "major_minor": "66:16",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014053fff9fd2761f4efe9143a33ff",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014053fff9fd2761f4efe9143a33ff",
+        "/dev/disk/by-id/wwn-0x60014053fff9fd2761f4efe9143a33ff",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-16",
+        "/dev/sdah"
+      ],
+      "serial_83": "360014053fff9fd2761f4efe9143a33ff",
+      "serial_80": "SLIO-ORG ost17           3fff9fd2-761f-4efe-9143-a33ff9ff7a52",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "66:32": {
+      "major_minor": "66:32",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014053fff9fd2761f4efe9143a33ff",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014053fff9fd2761f4efe9143a33ff",
+        "/dev/disk/by-id/wwn-0x60014053fff9fd2761f4efe9143a33ff",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-16",
+        "/dev/sdai"
+      ],
+      "serial_83": "360014053fff9fd2761f4efe9143a33ff",
+      "serial_80": "SLIO-ORG ost17           3fff9fd2-761f-4efe-9143-a33ff9ff7a52",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "66:48": {
+      "major_minor": "66:48",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014051c12549d858d4562a2e178018",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014051c12549d858d4562a2e178018",
+        "/dev/disk/by-id/wwn-0x60014051c12549d858d4562a2e178018",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-17",
+        "/dev/sdaj"
+      ],
+      "serial_83": "360014051c12549d858d4562a2e178018",
+      "serial_80": "SLIO-ORG ost18           1c12549d-858d-4562-a2e1-78018d748a6f",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "66:64": {
+      "major_minor": "66:64",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014051c12549d858d4562a2e178018",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014051c12549d858d4562a2e178018",
+        "/dev/disk/by-id/wwn-0x60014051c12549d858d4562a2e178018",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-17",
+        "/dev/sdak"
+      ],
+      "serial_83": "360014051c12549d858d4562a2e178018",
+      "serial_80": "SLIO-ORG ost18           1c12549d-858d-4562-a2e1-78018d748a6f",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "66:80": {
+      "major_minor": "66:80",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405047a9e1ee2c04af6b26216f3a",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405047a9e1ee2c04af6b26216f3a",
+        "/dev/disk/by-id/wwn-0x6001405047a9e1ee2c04af6b26216f3a",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-18",
+        "/dev/sdal"
+      ],
+      "serial_83": "36001405047a9e1ee2c04af6b26216f3a",
+      "serial_80": "SLIO-ORG ost19           047a9e1e-e2c0-4af6-b262-16f3ac3ca915",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "66:96": {
+      "major_minor": "66:96",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405047a9e1ee2c04af6b26216f3a",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405047a9e1ee2c04af6b26216f3a",
+        "/dev/disk/by-id/wwn-0x6001405047a9e1ee2c04af6b26216f3a",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-18",
+        "/dev/sdam"
+      ],
+      "serial_83": "36001405047a9e1ee2c04af6b26216f3a",
+      "serial_80": "SLIO-ORG ost19           047a9e1e-e2c0-4af6-b262-16f3ac3ca915",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:0": {
+      "major_minor": "8:0",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde",
+      "paths": [
+        "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde",
+        "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0",
+        "/dev/sda"
+      ],
+      "serial_83": "1ATA     VBOX HARDDISK                           VB289a63d7-b2394fde",
+      "serial_80": "SATA     VBOX HARDDISK   VB289a63d7-b2394fde",
+      "size": 42949672960,
+      "filesystem_type": null
+    },
+    "8:1": {
+      "major_minor": "8:1",
+      "parent": "8:0",
+      "partition_number": 1,
+      "path": "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde-part1",
+      "paths": [
+        "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde-part1",
+        "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0-part1",
+        "/dev/disk/by-uuid/f52f361a-da1a-4ea0-8c7f-ca2706e86b46",
+        "/dev/sda1"
+      ],
+      "serial_83": null,
+      "serial_80": null,
+      "size": 42948624384,
+      "filesystem_type": "xfs"
+    },
+    "8:112": {
+      "major_minor": "8:112",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405c9535ca96e924f9fa2e32ed89",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405c9535ca96e924f9fa2e32ed89",
+        "/dev/disk/by-id/wwn-0x6001405c9535ca96e924f9fa2e32ed89",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-3",
+        "/dev/sdh"
+      ],
+      "serial_83": "36001405c9535ca96e924f9fa2e32ed89",
+      "serial_80": "SLIO-ORG ost4            c9535ca9-6e92-4f9f-a2e3-2ed89e8cf8be",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:128": {
+      "major_minor": "8:128",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405c9535ca96e924f9fa2e32ed89",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405c9535ca96e924f9fa2e32ed89",
+        "/dev/disk/by-id/wwn-0x6001405c9535ca96e924f9fa2e32ed89",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-3",
+        "/dev/sdi"
+      ],
+      "serial_83": "36001405c9535ca96e924f9fa2e32ed89",
+      "serial_80": "SLIO-ORG ost4            c9535ca9-6e92-4f9f-a2e3-2ed89e8cf8be",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:144": {
+      "major_minor": "8:144",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405aa1a4a2010734758a9e57c178",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405aa1a4a2010734758a9e57c178",
+        "/dev/disk/by-id/wwn-0x6001405aa1a4a2010734758a9e57c178",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-4",
+        "/dev/sdj"
+      ],
+      "serial_83": "36001405aa1a4a2010734758a9e57c178",
+      "serial_80": "SLIO-ORG ost5            aa1a4a20-1073-4758-a9e5-7c178c6ed8ef",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:16": {
+      "major_minor": "8:16",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-3600140568c946040400460a896d0b196",
+      "paths": [
+        "/dev/disk/by-id/scsi-3600140568c946040400460a896d0b196",
+        "/dev/disk/by-id/wwn-0x600140568c946040400460a896d0b196",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-0",
+        "/dev/sdb"
+      ],
+      "serial_83": "3600140568c946040400460a896d0b196",
+      "serial_80": "SLIO-ORG ost1            68c94604-0400-460a-896d-0b196cd0a235",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:160": {
+      "major_minor": "8:160",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405aa1a4a2010734758a9e57c178",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405aa1a4a2010734758a9e57c178",
+        "/dev/disk/by-id/wwn-0x6001405aa1a4a2010734758a9e57c178",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-4",
+        "/dev/sdk"
+      ],
+      "serial_83": "36001405aa1a4a2010734758a9e57c178",
+      "serial_80": "SLIO-ORG ost5            aa1a4a20-1073-4758-a9e5-7c178c6ed8ef",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:176": {
+      "major_minor": "8:176",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014058a65c188c7f84052b1b1185d2",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014058a65c188c7f84052b1b1185d2",
+        "/dev/disk/by-id/wwn-0x60014058a65c188c7f84052b1b1185d2",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-5",
+        "/dev/sdl"
+      ],
+      "serial_83": "360014058a65c188c7f84052b1b1185d2",
+      "serial_80": "SLIO-ORG ost6            8a65c188-c7f8-4052-b1b1-185d239005ea",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:192": {
+      "major_minor": "8:192",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014058a65c188c7f84052b1b1185d2",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014058a65c188c7f84052b1b1185d2",
+        "/dev/disk/by-id/wwn-0x60014058a65c188c7f84052b1b1185d2",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-5",
+        "/dev/sdm"
+      ],
+      "serial_83": "360014058a65c188c7f84052b1b1185d2",
+      "serial_80": "SLIO-ORG ost6            8a65c188-c7f8-4052-b1b1-185d239005ea",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:208": {
+      "major_minor": "8:208",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014054e9b5031f3434c56a0746de1f",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014054e9b5031f3434c56a0746de1f",
+        "/dev/disk/by-id/wwn-0x60014054e9b5031f3434c56a0746de1f",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-6",
+        "/dev/sdn"
+      ],
+      "serial_83": "360014054e9b5031f3434c56a0746de1f",
+      "serial_80": "SLIO-ORG ost7            4e9b5031-f343-4c56-a074-6de1feb8f72c",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:224": {
+      "major_minor": "8:224",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014054e9b5031f3434c56a0746de1f",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014054e9b5031f3434c56a0746de1f",
+        "/dev/disk/by-id/wwn-0x60014054e9b5031f3434c56a0746de1f",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-6",
+        "/dev/sdo"
+      ],
+      "serial_83": "360014054e9b5031f3434c56a0746de1f",
+      "serial_80": "SLIO-ORG ost7            4e9b5031-f343-4c56-a074-6de1feb8f72c",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:240": {
+      "major_minor": "8:240",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-3600140547f1dbaca8e344809057273c5",
+      "paths": [
+        "/dev/disk/by-id/scsi-3600140547f1dbaca8e344809057273c5",
+        "/dev/disk/by-id/wwn-0x600140547f1dbaca8e344809057273c5",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-7",
+        "/dev/sdp"
+      ],
+      "serial_83": "3600140547f1dbaca8e344809057273c5",
+      "serial_80": "SLIO-ORG ost8            47f1dbac-a8e3-4480-9057-273c502f4dd6",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:32": {
+      "major_minor": "8:32",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-3600140568c946040400460a896d0b196",
+      "paths": [
+        "/dev/disk/by-id/scsi-3600140568c946040400460a896d0b196",
+        "/dev/disk/by-id/wwn-0x600140568c946040400460a896d0b196",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-0",
+        "/dev/sdc"
+      ],
+      "serial_83": "3600140568c946040400460a896d0b196",
+      "serial_80": "SLIO-ORG ost1            68c94604-0400-460a-896d-0b196cd0a235",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:48": {
+      "major_minor": "8:48",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405a63b61f10cbb4e229df0792d0",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405a63b61f10cbb4e229df0792d0",
+        "/dev/disk/by-id/wwn-0x6001405a63b61f10cbb4e229df0792d0",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-1",
+        "/dev/sdd"
+      ],
+      "serial_83": "36001405a63b61f10cbb4e229df0792d0",
+      "serial_80": "SLIO-ORG ost2            a63b61f1-0cbb-4e22-9df0-792d0cf69575",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:64": {
+      "major_minor": "8:64",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405a63b61f10cbb4e229df0792d0",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405a63b61f10cbb4e229df0792d0",
+        "/dev/disk/by-id/wwn-0x6001405a63b61f10cbb4e229df0792d0",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-1",
+        "/dev/sde"
+      ],
+      "serial_83": "36001405a63b61f10cbb4e229df0792d0",
+      "serial_80": "SLIO-ORG ost2            a63b61f1-0cbb-4e22-9df0-792d0cf69575",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:80": {
+      "major_minor": "8:80",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014051ea57ad4ffc243d6bcab8eb8c",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014051ea57ad4ffc243d6bcab8eb8c",
+        "/dev/disk/by-id/wwn-0x60014051ea57ad4ffc243d6bcab8eb8c",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-2",
+        "/dev/sdf"
+      ],
+      "serial_83": "360014051ea57ad4ffc243d6bcab8eb8c",
+      "serial_80": "SLIO-ORG ost3            1ea57ad4-ffc2-43d6-bcab-8eb8c2a60bfb",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:96": {
+      "major_minor": "8:96",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-360014051ea57ad4ffc243d6bcab8eb8c",
+      "paths": [
+        "/dev/disk/by-id/scsi-360014051ea57ad4ffc243d6bcab8eb8c",
+        "/dev/disk/by-id/wwn-0x60014051ea57ad4ffc243d6bcab8eb8c",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-2",
+        "/dev/sdg"
+      ],
+      "serial_83": "360014051ea57ad4ffc243d6bcab8eb8c",
+      "serial_80": "SLIO-ORG ost3            1ea57ad4-ffc2-43d6-bcab-8eb8c2a60bfb",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "lv:9rYEeS4U3eCNTgx1UovfQIXv16TTjel4": {
+      "major_minor": "lv:9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/vg1-lv1",
+      "paths": [
+        "/dev/mapper/vg1-lv1",
+        "/dev/disk/by-id/dm-name-vg1-lv1",
+        "/dev/disk/by-id/dm-uuid-LVM-UDIbPXrzaeBLNKim8kDOqcWfXbG2eRKt9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+        "/dev/dm-20",
+        "/dev/vg1/lv1"
+      ],
+      "serial_83": null,
+      "serial_80": null,
+      "size": 67108864,
+      "filesystem_type": null
+    }
+  },
+  "local_fs": {
+    "8:1": [
+      "/",
+      "xfs"
+    ]
+  },
+  "mpath": {
+    "mpatha": {
+      "name": "mpatha",
+      "block_device": "253:0",
+      "nodes": [
+        {
+          "major_minor": "8:16",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-3600140568c946040400460a896d0b196",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140568c946040400460a896d0b196",
+            "/dev/disk/by-id/wwn-0x600140568c946040400460a896d0b196",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-0",
+            "/dev/sdb"
+          ],
+          "serial_83": "3600140568c946040400460a896d0b196",
+          "serial_80": "SLIO-ORG ost1            68c94604-0400-460a-896d-0b196cd0a235",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:32",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-3600140568c946040400460a896d0b196",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140568c946040400460a896d0b196",
+            "/dev/disk/by-id/wwn-0x600140568c946040400460a896d0b196",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-0",
+            "/dev/sdc"
+          ],
+          "serial_83": "3600140568c946040400460a896d0b196",
+          "serial_80": "SLIO-ORG ost1            68c94604-0400-460a-896d-0b196cd0a235",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathb": {
+      "name": "mpathb",
+      "block_device": "253:1",
+      "nodes": [
+        {
+          "major_minor": "8:48",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405a63b61f10cbb4e229df0792d0",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405a63b61f10cbb4e229df0792d0",
+            "/dev/disk/by-id/wwn-0x6001405a63b61f10cbb4e229df0792d0",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-1",
+            "/dev/sdd"
+          ],
+          "serial_83": "36001405a63b61f10cbb4e229df0792d0",
+          "serial_80": "SLIO-ORG ost2            a63b61f1-0cbb-4e22-9df0-792d0cf69575",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:64",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405a63b61f10cbb4e229df0792d0",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405a63b61f10cbb4e229df0792d0",
+            "/dev/disk/by-id/wwn-0x6001405a63b61f10cbb4e229df0792d0",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-1",
+            "/dev/sde"
+          ],
+          "serial_83": "36001405a63b61f10cbb4e229df0792d0",
+          "serial_80": "SLIO-ORG ost2            a63b61f1-0cbb-4e22-9df0-792d0cf69575",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathc": {
+      "name": "mpathc",
+      "block_device": "253:2",
+      "nodes": [
+        {
+          "major_minor": "65:80",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-3600140547e0ffe43b3f464789f1653cc",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140547e0ffe43b3f464789f1653cc",
+            "/dev/disk/by-id/wwn-0x600140547e0ffe43b3f464789f1653cc",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-10",
+            "/dev/sdv"
+          ],
+          "serial_83": "3600140547e0ffe43b3f464789f1653cc",
+          "serial_80": "SLIO-ORG ost11           47e0ffe4-3b3f-4647-89f1-653cc1b7c954",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "65:96",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-3600140547e0ffe43b3f464789f1653cc",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140547e0ffe43b3f464789f1653cc",
+            "/dev/disk/by-id/wwn-0x600140547e0ffe43b3f464789f1653cc",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-10",
+            "/dev/sdw"
+          ],
+          "serial_83": "3600140547e0ffe43b3f464789f1653cc",
+          "serial_80": "SLIO-ORG ost11           47e0ffe4-3b3f-4647-89f1-653cc1b7c954",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathd": {
+      "name": "mpathd",
+      "block_device": "253:3",
+      "nodes": [
+        {
+          "major_minor": "65:112",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014053fe9e70a1aa8470faaa82b7b0",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014053fe9e70a1aa8470faaa82b7b0",
+            "/dev/disk/by-id/wwn-0x60014053fe9e70a1aa8470faaa82b7b0",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-11",
+            "/dev/sdx"
+          ],
+          "serial_83": "360014053fe9e70a1aa8470faaa82b7b0",
+          "serial_80": "SLIO-ORG ost12           3fe9e70a-1aa8-470f-aaa8-2b7b0e525b83",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "65:128",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014053fe9e70a1aa8470faaa82b7b0",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014053fe9e70a1aa8470faaa82b7b0",
+            "/dev/disk/by-id/wwn-0x60014053fe9e70a1aa8470faaa82b7b0",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-11",
+            "/dev/sdy"
+          ],
+          "serial_83": "360014053fe9e70a1aa8470faaa82b7b0",
+          "serial_80": "SLIO-ORG ost12           3fe9e70a-1aa8-470f-aaa8-2b7b0e525b83",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathe": {
+      "name": "mpathe",
+      "block_device": "253:4",
+      "nodes": [
+        {
+          "major_minor": "65:144",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405139a84485b2d4ea5b4f59874c",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405139a84485b2d4ea5b4f59874c",
+            "/dev/disk/by-id/wwn-0x6001405139a84485b2d4ea5b4f59874c",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-12",
+            "/dev/sdz"
+          ],
+          "serial_83": "36001405139a84485b2d4ea5b4f59874c",
+          "serial_80": "SLIO-ORG ost13           139a8448-5b2d-4ea5-b4f5-9874cd16127b",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "65:160",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405139a84485b2d4ea5b4f59874c",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405139a84485b2d4ea5b4f59874c",
+            "/dev/disk/by-id/wwn-0x6001405139a84485b2d4ea5b4f59874c",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-12",
+            "/dev/sdaa"
+          ],
+          "serial_83": "36001405139a84485b2d4ea5b4f59874c",
+          "serial_80": "SLIO-ORG ost13           139a8448-5b2d-4ea5-b4f5-9874cd16127b",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathf": {
+      "name": "mpathf",
+      "block_device": "253:5",
+      "nodes": [
+        {
+          "major_minor": "65:176",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014051755d7331b404ff68ae4b6e45",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051755d7331b404ff68ae4b6e45",
+            "/dev/disk/by-id/wwn-0x60014051755d7331b404ff68ae4b6e45",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-13",
+            "/dev/sdab"
+          ],
+          "serial_83": "360014051755d7331b404ff68ae4b6e45",
+          "serial_80": "SLIO-ORG ost14           1755d733-1b40-4ff6-8ae4-b6e4568b03e3",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "65:192",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014051755d7331b404ff68ae4b6e45",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051755d7331b404ff68ae4b6e45",
+            "/dev/disk/by-id/wwn-0x60014051755d7331b404ff68ae4b6e45",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-13",
+            "/dev/sdac"
+          ],
+          "serial_83": "360014051755d7331b404ff68ae4b6e45",
+          "serial_80": "SLIO-ORG ost14           1755d733-1b40-4ff6-8ae4-b6e4568b03e3",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathg": {
+      "name": "mpathg",
+      "block_device": "253:6",
+      "nodes": [
+        {
+          "major_minor": "65:208",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405c525c75b8ee1471dbbb344dd8",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405c525c75b8ee1471dbbb344dd8",
+            "/dev/disk/by-id/wwn-0x6001405c525c75b8ee1471dbbb344dd8",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-14",
+            "/dev/sdad"
+          ],
+          "serial_83": "36001405c525c75b8ee1471dbbb344dd8",
+          "serial_80": "SLIO-ORG ost15           c525c75b-8ee1-471d-bbb3-44dd80198b3f",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "65:224",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405c525c75b8ee1471dbbb344dd8",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405c525c75b8ee1471dbbb344dd8",
+            "/dev/disk/by-id/wwn-0x6001405c525c75b8ee1471dbbb344dd8",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-14",
+            "/dev/sdae"
+          ],
+          "serial_83": "36001405c525c75b8ee1471dbbb344dd8",
+          "serial_80": "SLIO-ORG ost15           c525c75b-8ee1-471d-bbb3-44dd80198b3f",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathh": {
+      "name": "mpathh",
+      "block_device": "253:7",
+      "nodes": [
+        {
+          "major_minor": "65:240",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-3600140598252aa12555428f94b6ea915",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140598252aa12555428f94b6ea915",
+            "/dev/disk/by-id/wwn-0x600140598252aa12555428f94b6ea915",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-15",
+            "/dev/sdaf"
+          ],
+          "serial_83": "3600140598252aa12555428f94b6ea915",
+          "serial_80": "SLIO-ORG ost16           98252aa1-2555-428f-94b6-ea915aadcd5a",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "66:0",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-3600140598252aa12555428f94b6ea915",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140598252aa12555428f94b6ea915",
+            "/dev/disk/by-id/wwn-0x600140598252aa12555428f94b6ea915",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-15",
+            "/dev/sdag"
+          ],
+          "serial_83": "3600140598252aa12555428f94b6ea915",
+          "serial_80": "SLIO-ORG ost16           98252aa1-2555-428f-94b6-ea915aadcd5a",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathi": {
+      "name": "mpathi",
+      "block_device": "253:8",
+      "nodes": [
+        {
+          "major_minor": "66:16",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014053fff9fd2761f4efe9143a33ff",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014053fff9fd2761f4efe9143a33ff",
+            "/dev/disk/by-id/wwn-0x60014053fff9fd2761f4efe9143a33ff",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-16",
+            "/dev/sdah"
+          ],
+          "serial_83": "360014053fff9fd2761f4efe9143a33ff",
+          "serial_80": "SLIO-ORG ost17           3fff9fd2-761f-4efe-9143-a33ff9ff7a52",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "66:32",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014053fff9fd2761f4efe9143a33ff",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014053fff9fd2761f4efe9143a33ff",
+            "/dev/disk/by-id/wwn-0x60014053fff9fd2761f4efe9143a33ff",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-16",
+            "/dev/sdai"
+          ],
+          "serial_83": "360014053fff9fd2761f4efe9143a33ff",
+          "serial_80": "SLIO-ORG ost17           3fff9fd2-761f-4efe-9143-a33ff9ff7a52",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathj": {
+      "name": "mpathj",
+      "block_device": "253:9",
+      "nodes": [
+        {
+          "major_minor": "66:48",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014051c12549d858d4562a2e178018",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051c12549d858d4562a2e178018",
+            "/dev/disk/by-id/wwn-0x60014051c12549d858d4562a2e178018",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-17",
+            "/dev/sdaj"
+          ],
+          "serial_83": "360014051c12549d858d4562a2e178018",
+          "serial_80": "SLIO-ORG ost18           1c12549d-858d-4562-a2e1-78018d748a6f",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "66:64",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014051c12549d858d4562a2e178018",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051c12549d858d4562a2e178018",
+            "/dev/disk/by-id/wwn-0x60014051c12549d858d4562a2e178018",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-17",
+            "/dev/sdak"
+          ],
+          "serial_83": "360014051c12549d858d4562a2e178018",
+          "serial_80": "SLIO-ORG ost18           1c12549d-858d-4562-a2e1-78018d748a6f",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathk": {
+      "name": "mpathk",
+      "block_device": "253:10",
+      "nodes": [
+        {
+          "major_minor": "66:80",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405047a9e1ee2c04af6b26216f3a",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405047a9e1ee2c04af6b26216f3a",
+            "/dev/disk/by-id/wwn-0x6001405047a9e1ee2c04af6b26216f3a",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-18",
+            "/dev/sdal"
+          ],
+          "serial_83": "36001405047a9e1ee2c04af6b26216f3a",
+          "serial_80": "SLIO-ORG ost19           047a9e1e-e2c0-4af6-b262-16f3ac3ca915",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "66:96",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405047a9e1ee2c04af6b26216f3a",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405047a9e1ee2c04af6b26216f3a",
+            "/dev/disk/by-id/wwn-0x6001405047a9e1ee2c04af6b26216f3a",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-18",
+            "/dev/sdam"
+          ],
+          "serial_83": "36001405047a9e1ee2c04af6b26216f3a",
+          "serial_80": "SLIO-ORG ost19           047a9e1e-e2c0-4af6-b262-16f3ac3ca915",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathl": {
+      "name": "mpathl",
+      "block_device": "253:11",
+      "nodes": [
+        {
+          "major_minor": "66:112",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405b1662648389c47ae91f7f9c18",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405b1662648389c47ae91f7f9c18",
+            "/dev/disk/by-id/wwn-0x6001405b1662648389c47ae91f7f9c18",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-19",
+            "/dev/sdan"
+          ],
+          "serial_83": "36001405b1662648389c47ae91f7f9c18",
+          "serial_80": "SLIO-ORG ost20           b1662648-389c-47ae-91f7-f9c18ead9f54",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "66:128",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405b1662648389c47ae91f7f9c18",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405b1662648389c47ae91f7f9c18",
+            "/dev/disk/by-id/wwn-0x6001405b1662648389c47ae91f7f9c18",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-19",
+            "/dev/sdao"
+          ],
+          "serial_83": "36001405b1662648389c47ae91f7f9c18",
+          "serial_80": "SLIO-ORG ost20           b1662648-389c-47ae-91f7-f9c18ead9f54",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathm": {
+      "name": "mpathm",
+      "block_device": "253:12",
+      "nodes": [
+        {
+          "major_minor": "8:80",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014051ea57ad4ffc243d6bcab8eb8c",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051ea57ad4ffc243d6bcab8eb8c",
+            "/dev/disk/by-id/wwn-0x60014051ea57ad4ffc243d6bcab8eb8c",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-2",
+            "/dev/sdf"
+          ],
+          "serial_83": "360014051ea57ad4ffc243d6bcab8eb8c",
+          "serial_80": "SLIO-ORG ost3            1ea57ad4-ffc2-43d6-bcab-8eb8c2a60bfb",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:96",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014051ea57ad4ffc243d6bcab8eb8c",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014051ea57ad4ffc243d6bcab8eb8c",
+            "/dev/disk/by-id/wwn-0x60014051ea57ad4ffc243d6bcab8eb8c",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-2",
+            "/dev/sdg"
+          ],
+          "serial_83": "360014051ea57ad4ffc243d6bcab8eb8c",
+          "serial_80": "SLIO-ORG ost3            1ea57ad4-ffc2-43d6-bcab-8eb8c2a60bfb",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathn": {
+      "name": "mpathn",
+      "block_device": "253:13",
+      "nodes": [
+        {
+          "major_minor": "8:112",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405c9535ca96e924f9fa2e32ed89",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405c9535ca96e924f9fa2e32ed89",
+            "/dev/disk/by-id/wwn-0x6001405c9535ca96e924f9fa2e32ed89",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-3",
+            "/dev/sdh"
+          ],
+          "serial_83": "36001405c9535ca96e924f9fa2e32ed89",
+          "serial_80": "SLIO-ORG ost4            c9535ca9-6e92-4f9f-a2e3-2ed89e8cf8be",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:128",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405c9535ca96e924f9fa2e32ed89",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405c9535ca96e924f9fa2e32ed89",
+            "/dev/disk/by-id/wwn-0x6001405c9535ca96e924f9fa2e32ed89",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-3",
+            "/dev/sdi"
+          ],
+          "serial_83": "36001405c9535ca96e924f9fa2e32ed89",
+          "serial_80": "SLIO-ORG ost4            c9535ca9-6e92-4f9f-a2e3-2ed89e8cf8be",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpatho": {
+      "name": "mpatho",
+      "block_device": "253:14",
+      "nodes": [
+        {
+          "major_minor": "8:144",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405aa1a4a2010734758a9e57c178",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405aa1a4a2010734758a9e57c178",
+            "/dev/disk/by-id/wwn-0x6001405aa1a4a2010734758a9e57c178",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-4",
+            "/dev/sdj"
+          ],
+          "serial_83": "36001405aa1a4a2010734758a9e57c178",
+          "serial_80": "SLIO-ORG ost5            aa1a4a20-1073-4758-a9e5-7c178c6ed8ef",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:160",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405aa1a4a2010734758a9e57c178",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405aa1a4a2010734758a9e57c178",
+            "/dev/disk/by-id/wwn-0x6001405aa1a4a2010734758a9e57c178",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-4",
+            "/dev/sdk"
+          ],
+          "serial_83": "36001405aa1a4a2010734758a9e57c178",
+          "serial_80": "SLIO-ORG ost5            aa1a4a20-1073-4758-a9e5-7c178c6ed8ef",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathp": {
+      "name": "mpathp",
+      "block_device": "253:15",
+      "nodes": [
+        {
+          "major_minor": "8:176",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014058a65c188c7f84052b1b1185d2",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014058a65c188c7f84052b1b1185d2",
+            "/dev/disk/by-id/wwn-0x60014058a65c188c7f84052b1b1185d2",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-5",
+            "/dev/sdl"
+          ],
+          "serial_83": "360014058a65c188c7f84052b1b1185d2",
+          "serial_80": "SLIO-ORG ost6            8a65c188-c7f8-4052-b1b1-185d239005ea",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:192",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014058a65c188c7f84052b1b1185d2",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014058a65c188c7f84052b1b1185d2",
+            "/dev/disk/by-id/wwn-0x60014058a65c188c7f84052b1b1185d2",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-5",
+            "/dev/sdm"
+          ],
+          "serial_83": "360014058a65c188c7f84052b1b1185d2",
+          "serial_80": "SLIO-ORG ost6            8a65c188-c7f8-4052-b1b1-185d239005ea",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathq": {
+      "name": "mpathq",
+      "block_device": "253:16",
+      "nodes": [
+        {
+          "major_minor": "8:208",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014054e9b5031f3434c56a0746de1f",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014054e9b5031f3434c56a0746de1f",
+            "/dev/disk/by-id/wwn-0x60014054e9b5031f3434c56a0746de1f",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-6",
+            "/dev/sdn"
+          ],
+          "serial_83": "360014054e9b5031f3434c56a0746de1f",
+          "serial_80": "SLIO-ORG ost7            4e9b5031-f343-4c56-a074-6de1feb8f72c",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:224",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-360014054e9b5031f3434c56a0746de1f",
+          "paths": [
+            "/dev/disk/by-id/scsi-360014054e9b5031f3434c56a0746de1f",
+            "/dev/disk/by-id/wwn-0x60014054e9b5031f3434c56a0746de1f",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-6",
+            "/dev/sdo"
+          ],
+          "serial_83": "360014054e9b5031f3434c56a0746de1f",
+          "serial_80": "SLIO-ORG ost7            4e9b5031-f343-4c56-a074-6de1feb8f72c",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathr": {
+      "name": "mpathr",
+      "block_device": "253:17",
+      "nodes": [
+        {
+          "major_minor": "65:0",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-3600140547f1dbaca8e344809057273c5",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140547f1dbaca8e344809057273c5",
+            "/dev/disk/by-id/wwn-0x600140547f1dbaca8e344809057273c5",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-7",
+            "/dev/sdq"
+          ],
+          "serial_83": "3600140547f1dbaca8e344809057273c5",
+          "serial_80": "SLIO-ORG ost8            47f1dbac-a8e3-4480-9057-273c502f4dd6",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:240",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-3600140547f1dbaca8e344809057273c5",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140547f1dbaca8e344809057273c5",
+            "/dev/disk/by-id/wwn-0x600140547f1dbaca8e344809057273c5",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-7",
+            "/dev/sdp"
+          ],
+          "serial_83": "3600140547f1dbaca8e344809057273c5",
+          "serial_80": "SLIO-ORG ost8            47f1dbac-a8e3-4480-9057-273c502f4dd6",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpaths": {
+      "name": "mpaths",
+      "block_device": "253:18",
+      "nodes": [
+        {
+          "major_minor": "65:16",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405ce127d66323a4c279ca70706a",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ce127d66323a4c279ca70706a",
+            "/dev/disk/by-id/wwn-0x6001405ce127d66323a4c279ca70706a",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-8",
+            "/dev/sdr"
+          ],
+          "serial_83": "36001405ce127d66323a4c279ca70706a",
+          "serial_80": "SLIO-ORG ost9            ce127d66-323a-4c27-9ca7-0706adf87bd6",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "65:32",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405ce127d66323a4c279ca70706a",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ce127d66323a4c279ca70706a",
+            "/dev/disk/by-id/wwn-0x6001405ce127d66323a4c279ca70706a",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-8",
+            "/dev/sds"
+          ],
+          "serial_83": "36001405ce127d66323a4c279ca70706a",
+          "serial_80": "SLIO-ORG ost9            ce127d66-323a-4c27-9ca7-0706adf87bd6",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpatht": {
+      "name": "mpatht",
+      "block_device": "253:19",
+      "nodes": [
+        {
+          "major_minor": "65:48",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-3600140564eea787d99444d79c15fc577",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140564eea787d99444d79c15fc577",
+            "/dev/disk/by-id/wwn-0x600140564eea787d99444d79c15fc577",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-9",
+            "/dev/sdt"
+          ],
+          "serial_83": "3600140564eea787d99444d79c15fc577",
+          "serial_80": "SLIO-ORG ost10           64eea787-d994-44d7-9c15-fc577fde7809",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "65:64",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-3600140564eea787d99444d79c15fc577",
+          "paths": [
+            "/dev/disk/by-id/scsi-3600140564eea787d99444d79c15fc577",
+            "/dev/disk/by-id/wwn-0x600140564eea787d99444d79c15fc577",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:oss-lun-9",
+            "/dev/sdu"
+          ],
+          "serial_83": "3600140564eea787d99444d79c15fc577",
+          "serial_80": "SLIO-ORG ost10           64eea787-d994-44d7-9c15-fc577fde7809",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    }
+  },
+  "vgs": {
+    "vg1": {
+      "name": "vg1",
+      "uuid": "UDIbPXrzaeBLNKim8kDOqcWfXbG2eRKt",
+      "size": 0,
+      "pvs_major_minor": [
+        "253:6"
+      ]
+    }
+  },
+  "lvs": {
+    "vg1": {
+      "lv1": {
+        "block_device": "lv:9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+        "size": 67108864,
+        "uuid": "9rYEeS4U3eCNTgx1UovfQIXv16TTjel4",
+        "name": "lv1"
+      }
+    }
+  },
+  "zfspools": {},
+  "zfsdatasets": {}
+}

--- a/iml-services/iml-device/src/snapshots/iml_device__linux_plugin_transforms__tests__devtree2linuxoutput_dataset.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__linux_plugin_transforms__tests__devtree2linuxoutput_dataset.snap
@@ -1,0 +1,274 @@
+---
+source: iml-services/iml-device/src/linux_plugin_transforms.rs
+expression: data
+---
+{
+  "devs": {
+    "253:0": {
+      "major_minor": "253:0",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpatha",
+      "paths": [
+        "/dev/mapper/mpatha",
+        "/dev/disk/by-id/dm-name-mpatha",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+        "/dev/disk/by-label/mgs",
+        "/dev/disk/by-uuid/3383432994541088053",
+        "/dev/dm-0",
+        "/dev/mgt"
+      ],
+      "serial_83": "36001405ecca605408894bc2aa708a09c",
+      "serial_80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+      "size": 536870912,
+      "filesystem_type": "zfs_member"
+    },
+    "253:1": {
+      "major_minor": "253:1",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathb",
+      "paths": [
+        "/dev/mapper/mpathb",
+        "/dev/disk/by-id/dm-name-mpathb",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405943dd5f394fb4b5ba71ec818f",
+        "/dev/disk/by-label/mds",
+        "/dev/disk/by-uuid/15259234345131681652",
+        "/dev/dm-1",
+        "/dev/mdt"
+      ],
+      "serial_83": "36001405943dd5f394fb4b5ba71ec818f",
+      "serial_80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+      "size": 5368709120,
+      "filesystem_type": "zfs_member"
+    },
+    "8:0": {
+      "major_minor": "8:0",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde",
+      "paths": [
+        "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde",
+        "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0",
+        "/dev/sda"
+      ],
+      "serial_83": "1ATA     VBOX HARDDISK                           VB289a63d7-b2394fde",
+      "serial_80": "SATA     VBOX HARDDISK   VB289a63d7-b2394fde",
+      "size": 42949672960,
+      "filesystem_type": null
+    },
+    "8:1": {
+      "major_minor": "8:1",
+      "parent": "8:0",
+      "partition_number": 1,
+      "path": "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde-part1",
+      "paths": [
+        "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde-part1",
+        "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0-part1",
+        "/dev/disk/by-uuid/f52f361a-da1a-4ea0-8c7f-ca2706e86b46",
+        "/dev/sda1"
+      ],
+      "serial_83": null,
+      "serial_80": null,
+      "size": 42948624384,
+      "filesystem_type": "xfs"
+    },
+    "8:16": {
+      "major_minor": "8:16",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+        "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+        "/dev/disk/by-label/mgs",
+        "/dev/disk/by-uuid/3383432994541088053",
+        "/dev/mgt",
+        "/dev/sdb"
+      ],
+      "serial_83": "36001405ecca605408894bc2aa708a09c",
+      "serial_80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+      "size": 536870912,
+      "filesystem_type": "mpath_member"
+    },
+    "8:32": {
+      "major_minor": "8:32",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+        "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+        "/dev/disk/by-label/mgs",
+        "/dev/disk/by-uuid/3383432994541088053",
+        "/dev/mgt",
+        "/dev/sdc"
+      ],
+      "serial_83": "36001405ecca605408894bc2aa708a09c",
+      "serial_80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+      "size": 536870912,
+      "filesystem_type": "mpath_member"
+    },
+    "8:48": {
+      "major_minor": "8:48",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+        "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+        "/dev/disk/by-label/mds",
+        "/dev/disk/by-uuid/15259234345131681652",
+        "/dev/mdt",
+        "/dev/sdd"
+      ],
+      "serial_83": "36001405943dd5f394fb4b5ba71ec818f",
+      "serial_80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:64": {
+      "major_minor": "8:64",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+        "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+        "/dev/disk/by-label/mds",
+        "/dev/disk/by-uuid/15259234345131681652",
+        "/dev/mdt",
+        "/dev/sde"
+      ],
+      "serial_83": "36001405943dd5f394fb4b5ba71ec818f",
+      "serial_80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "zfsset:16140917920099960924": {
+      "block_device": "zfsset:16140917920099960924",
+      "drives": [
+        "253:0"
+      ],
+      "name": "mgs/MGS",
+      "path": "mgs/MGS",
+      "size": 520093696,
+      "uuid": 16140917920099960924
+    }
+  },
+  "local_fs": {
+    "8:1": [
+      "/",
+      "xfs"
+    ]
+  },
+  "mpath": {
+    "mpatha": {
+      "name": "mpatha",
+      "block_device": "253:0",
+      "nodes": [
+        {
+          "major_minor": "8:16",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+            "/dev/disk/by-label/mgs",
+            "/dev/disk/by-uuid/3383432994541088053",
+            "/dev/mgt",
+            "/dev/sdb"
+          ],
+          "serial_83": "36001405ecca605408894bc2aa708a09c",
+          "serial_80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+          "size": 536870912,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:32",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+            "/dev/disk/by-label/mgs",
+            "/dev/disk/by-uuid/3383432994541088053",
+            "/dev/mgt",
+            "/dev/sdc"
+          ],
+          "serial_83": "36001405ecca605408894bc2aa708a09c",
+          "serial_80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+          "size": 536870912,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathb": {
+      "name": "mpathb",
+      "block_device": "253:1",
+      "nodes": [
+        {
+          "major_minor": "8:48",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+            "/dev/disk/by-label/mds",
+            "/dev/disk/by-uuid/15259234345131681652",
+            "/dev/mdt",
+            "/dev/sdd"
+          ],
+          "serial_83": "36001405943dd5f394fb4b5ba71ec818f",
+          "serial_80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:64",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+            "/dev/disk/by-label/mds",
+            "/dev/disk/by-uuid/15259234345131681652",
+            "/dev/mdt",
+            "/dev/sde"
+          ],
+          "serial_83": "36001405943dd5f394fb4b5ba71ec818f",
+          "serial_80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    }
+  },
+  "vgs": {},
+  "lvs": {},
+  "zfspools": {},
+  "zfsdatasets": {
+    "16140917920099960924": {
+      "block_device": "zfsset:16140917920099960924",
+      "drives": [
+        "253:0"
+      ],
+      "name": "mgs/MGS",
+      "path": "mgs/MGS",
+      "size": 520093696,
+      "uuid": 16140917920099960924
+    }
+  }
+}

--- a/iml-services/iml-device/src/snapshots/iml_device__linux_plugin_transforms__tests__devtree2linuxoutput_zpool.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__linux_plugin_transforms__tests__devtree2linuxoutput_zpool.snap
@@ -1,0 +1,262 @@
+---
+source: iml-services/iml-device/src/linux_plugin_transforms.rs
+expression: data
+---
+{
+  "devs": {
+    "253:0": {
+      "major_minor": "253:0",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpatha",
+      "paths": [
+        "/dev/mapper/mpatha",
+        "/dev/disk/by-id/dm-name-mpatha",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405ecca605408894bc2aa708a09c",
+        "/dev/disk/by-label/mgs",
+        "/dev/disk/by-uuid/3383432994541088053",
+        "/dev/dm-0",
+        "/dev/mgt"
+      ],
+      "serial_83": "36001405ecca605408894bc2aa708a09c",
+      "serial_80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+      "size": 536870912,
+      "filesystem_type": "zfs_member"
+    },
+    "253:1": {
+      "major_minor": "253:1",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/mapper/mpathb",
+      "paths": [
+        "/dev/mapper/mpathb",
+        "/dev/disk/by-id/dm-name-mpathb",
+        "/dev/disk/by-id/dm-uuid-mpath-36001405943dd5f394fb4b5ba71ec818f",
+        "/dev/disk/by-label/mds",
+        "/dev/disk/by-uuid/15259234345131681652",
+        "/dev/dm-1",
+        "/dev/mdt"
+      ],
+      "serial_83": "36001405943dd5f394fb4b5ba71ec818f",
+      "serial_80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+      "size": 5368709120,
+      "filesystem_type": "zfs_member"
+    },
+    "8:0": {
+      "major_minor": "8:0",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde",
+      "paths": [
+        "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde",
+        "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0",
+        "/dev/sda"
+      ],
+      "serial_83": "1ATA     VBOX HARDDISK                           VB289a63d7-b2394fde",
+      "serial_80": "SATA     VBOX HARDDISK   VB289a63d7-b2394fde",
+      "size": 42949672960,
+      "filesystem_type": null
+    },
+    "8:1": {
+      "major_minor": "8:1",
+      "parent": "8:0",
+      "partition_number": 1,
+      "path": "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde-part1",
+      "paths": [
+        "/dev/disk/by-id/ata-VBOX_HARDDISK_VB289a63d7-b2394fde-part1",
+        "/dev/disk/by-path/pci-0000:00:01.1-ata-1.0-part1",
+        "/dev/disk/by-uuid/f52f361a-da1a-4ea0-8c7f-ca2706e86b46",
+        "/dev/sda1"
+      ],
+      "serial_83": null,
+      "serial_80": null,
+      "size": 42948624384,
+      "filesystem_type": "xfs"
+    },
+    "8:16": {
+      "major_minor": "8:16",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+        "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+        "/dev/mgt",
+        "/dev/sdb"
+      ],
+      "serial_83": "36001405ecca605408894bc2aa708a09c",
+      "serial_80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+      "size": 536870912,
+      "filesystem_type": "mpath_member"
+    },
+    "8:32": {
+      "major_minor": "8:32",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+        "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+        "/dev/mgt",
+        "/dev/sdc"
+      ],
+      "serial_83": "36001405ecca605408894bc2aa708a09c",
+      "serial_80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+      "size": 536870912,
+      "filesystem_type": "mpath_member"
+    },
+    "8:48": {
+      "major_minor": "8:48",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+        "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+        "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+        "/dev/mdt",
+        "/dev/sdd"
+      ],
+      "serial_83": "36001405943dd5f394fb4b5ba71ec818f",
+      "serial_80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "8:64": {
+      "major_minor": "8:64",
+      "parent": null,
+      "partition_number": null,
+      "path": "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+      "paths": [
+        "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+        "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+        "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+        "/dev/mdt",
+        "/dev/sde"
+      ],
+      "serial_83": "36001405943dd5f394fb4b5ba71ec818f",
+      "serial_80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+      "size": 5368709120,
+      "filesystem_type": "mpath_member"
+    },
+    "zfspool:3383432994541088300": {
+      "block_device": "zfspool:3383432994541088300",
+      "drives": [
+        "253:0",
+        "8:16",
+        "8:32"
+      ],
+      "name": "mgs",
+      "path": "mgs",
+      "size": 520093696,
+      "uuid": 3383432994541088300
+    }
+  },
+  "local_fs": {
+    "8:1": [
+      "/",
+      "xfs"
+    ]
+  },
+  "mpath": {
+    "mpatha": {
+      "name": "mpatha",
+      "block_device": "253:0",
+      "nodes": [
+        {
+          "major_minor": "8:16",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+            "/dev/mgt",
+            "/dev/sdb"
+          ],
+          "serial_83": "36001405ecca605408894bc2aa708a09c",
+          "serial_80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+          "size": 536870912,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:32",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-id/wwn-0x6001405ecca605408894bc2aa708a09c",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-0",
+            "/dev/mgt",
+            "/dev/sdc"
+          ],
+          "serial_83": "36001405ecca605408894bc2aa708a09c",
+          "serial_80": "SLIO-ORG mgt1            ecca6054-0889-4bc2-aa70-8a09cd7d63a8",
+          "size": 536870912,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    },
+    "mpathb": {
+      "name": "mpathb",
+      "block_device": "253:1",
+      "nodes": [
+        {
+          "major_minor": "8:48",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-path/ip-10.73.50.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+            "/dev/mdt",
+            "/dev/sdd"
+          ],
+          "serial_83": "36001405943dd5f394fb4b5ba71ec818f",
+          "serial_80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        },
+        {
+          "major_minor": "8:64",
+          "parent": null,
+          "partition_number": null,
+          "path": "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+          "paths": [
+            "/dev/disk/by-id/scsi-36001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-id/wwn-0x6001405943dd5f394fb4b5ba71ec818f",
+            "/dev/disk/by-path/ip-10.73.40.10:3260-iscsi-iqn.2015-01.com.whamcloud.lu:mds-lun-1",
+            "/dev/mdt",
+            "/dev/sde"
+          ],
+          "serial_83": "36001405943dd5f394fb4b5ba71ec818f",
+          "serial_80": "SLIO-ORG mdt1            943dd5f3-94fb-4b5b-a71e-c818f04b201c",
+          "size": 5368709120,
+          "filesystem_type": "mpath_member"
+        }
+      ]
+    }
+  },
+  "vgs": {},
+  "lvs": {},
+  "zfspools": {
+    "3383432994541088300": {
+      "block_device": "zfspool:3383432994541088300",
+      "drives": [
+        "253:0",
+        "8:16",
+        "8:32"
+      ],
+      "name": "mgs",
+      "path": "mgs",
+      "size": 520093696,
+      "uuid": 3383432994541088300
+    }
+  },
+  "zfsdatasets": {}
+}

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -69,7 +69,6 @@ Requires(post): selinux-policy-targeted
 # IML Repo
 Requires:       python2-django-tastypie = 0.14.1
 Requires:       python2-django-picklefield >= 1.0.0
-Requires:       iml-device-scanner-aggregator >= 3.0.1
 Requires:       iml-online-help >= 3.0.0
 Requires:       iml_sos_plugin >= 2.3.1
 Requires:       iml-update-handler >= 1.0.4, iml-update-handler < 2
@@ -88,6 +87,7 @@ Requires:       rust-iml-ostpool >= 0.2.0
 Requires:       rust-iml-postoffice >= 0.2.0
 Requires:       rust-iml-stats >= 0.2.0
 Requires:       rust-iml-warp-drive >= 0.2.0
+Requires:       rust-iml-device >= 0.2.0
 # Other Repos
 Requires:       influxdb
 Requires:       grafana
@@ -189,7 +189,6 @@ mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
 install chroma-config.1.gz $RPM_BUILD_ROOT%{_mandir}/man1
 install -m 644 logrotate.cfg $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/chroma-manager
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}/
-mkdir -p $RPM_BUILD_ROOT%{_unitdir}/device-aggregator.service.d/
 install -m 644 iml-manager.target $RPM_BUILD_ROOT%{_unitdir}/
 install -m 644 iml-corosync.service $RPM_BUILD_ROOT%{_unitdir}/
 install -m 644 iml-gunicorn.service $RPM_BUILD_ROOT%{_unitdir}/
@@ -200,7 +199,6 @@ install -m 644 iml-plugin-runner.service $RPM_BUILD_ROOT%{_unitdir}/
 install -m 644 iml-power-control.service $RPM_BUILD_ROOT%{_unitdir}/
 install -m 644 iml-settings-populator.service $RPM_BUILD_ROOT%{_unitdir}/
 install -m 644 iml-syslog.service $RPM_BUILD_ROOT%{_unitdir}/
-install -m 644 10-device-aggregator.service.conf $RPM_BUILD_ROOT%{_unitdir}/device-aggregator.service.d/
 mkdir -p $RPM_BUILD_ROOT/var/log/chroma
 
 # only include modules in the main package
@@ -301,7 +299,6 @@ fi
 %attr(0644,root,grafana)%{_sysconfdir}/grafana/provisioning/datasources/influxdb-iml-datasource.yml
 %attr(0644,root,root)%{_unitdir}/iml-manager.target
 %attr(0644,root,root)%{_unitdir}/*.service
-%attr(0644,root,root)%{_unitdir}/device-aggregator.service.d/10-device-aggregator.service.conf
 %attr(0755,root,root)%{manager_root}/manage.py
 %{manager_root}/agent-bootstrap-script.template
 %{manager_root}/chroma-manager.conf.template

--- a/rust-iml.spec
+++ b/rust-iml.spec
@@ -32,6 +32,7 @@ cp iml-agent %{buildroot}%{_bindir}
 cp iml-agent-daemon %{buildroot}%{_bindir}
 cp iml-api %{buildroot}%{_bindir}
 cp iml-ostpool %{buildroot}%{_bindir}
+cp iml-device %{buildroot}%{_bindir}
 cp iml-stats %{buildroot}%{_bindir}
 cp iml-agent-comms %{buildroot}%{_bindir}
 cp iml-action-runner %{buildroot}%{_bindir}
@@ -40,6 +41,7 @@ cp iml-mailbox %{buildroot}%{_bindir}
 cp iml-postoffice %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_unitdir}
 cp iml-api.service %{buildroot}%{_unitdir}
+cp iml-device.service %{buildroot}%{_unitdir}
 cp iml-ostpool.service %{buildroot}%{_unitdir}
 cp iml-rust-stats.service %{buildroot}%{_unitdir}
 cp iml-agent-comms.service %{buildroot}%{_unitdir}
@@ -271,6 +273,28 @@ systemctl preset iml-postoffice.service
 %files postoffice
 %{_bindir}/iml-postoffice
 %attr(0644,root,root)%{_unitdir}/iml-postoffice.service
+
+%package device
+Summary: Consumer of IML Agent device push queue
+License: MIT
+Group: System Environment/Libraries
+Requires: rust-iml-agent-comms
+
+%description device
+%{summary}
+
+%post device
+systemctl preset iml-device.service
+
+%preun device
+%systemd_preun iml-device.service
+
+%postun device
+%systemd_postun_with_restart iml-device.service
+
+%files device
+%{_bindir}/iml-device
+%attr(0644,root,root)%{_unitdir}/iml-device.service
 
 %changelog
 * Wed Mar 6 2019 Joe Grund <jgrund@whamcloud.com> - 0.1.0-1

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -32,7 +32,7 @@ yum autoremove -y rpmdevtools
 rm -rf /tmp/{manager,agent}-rpms
 mkdir -p /tmp/{manager,agent}-rpms
 
-cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-{action-runner,agent-comms,api,cli,mailbox,ostpool,postoffice,stats,warp-drive}-*.rpm /tmp/manager-rpms/
+cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-{action-runner,agent-comms,api,cli,mailbox,ostpool,postoffice,stats,device,warp-drive}-*.rpm /tmp/manager-rpms/
 cp /integrated-manager-for-lustre/_topdir/RPMS/noarch/python2-iml-manager-*.rpm /tmp/manager-rpms/
 cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-agent-[0-9]*.rpm /tmp/agent-rpms
 cp /integrated-manager-for-lustre/chroma_support.repo /etc/yum.repos.d/


### PR DESCRIPTION
Implement a device plugin that should do the same thing
device-aggregator did.

This should allow us to start landing some of the device-scanner change
work and move duplicated concepts out of the device-scanner repo.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1757)
<!-- Reviewable:end -->
