### PR TITLE
Use postgres 9.6 instead of 9.2

### DIFF
--- a/chroma_core/lib/service_config.py
+++ b/chroma_core/lib/service_config.py
@@ -418,19 +418,19 @@ class ServiceConfig(CommandLine):
             raise RuntimeError(error)
 
     def _init_pgsql(self, database):
-        rc, out, err = self.shell(["service", "postgresql", "initdb"])
+        rc, out, err = self.shell(["/usr/pgsql-9.6/bin/postgresql96-setup", "initdb"])
         if rc != 0:
             if "is not empty" not in out:
-                log.error("Failed to initialize postgresql service")
+                log.error("Failed to initialize postgresql 9.6 database")
                 log.error("stdout:\n%s" % out)
                 log.error("stderr:\n%s" % err)
-                raise CommandError("service postgresql initdb", rc, out, err)
+                raise CommandError("/usr/pgsql-9.6/bin/postgresql96-setup initdb", rc, out, err)
         # Always fixup postgres auth
         self._config_pgsql_auth(database)
 
     @staticmethod
     def _config_pgsql_auth(database):
-        auth_cfg_file = "/var/lib/pgsql/data/pg_hba.conf"
+        auth_cfg_file = "/var/lib/pgsql/9.6/data/pg_hba.conf"
         if not os.path.exists("%s.dist" % auth_cfg_file):
             os.rename(auth_cfg_file, "%s.dist" % auth_cfg_file)
         with open(auth_cfg_file, "w") as cfg:
@@ -477,7 +477,7 @@ class ServiceConfig(CommandLine):
             return error_msg
 
     def _restart_pgsql(self):
-        postgresql_service = ServiceControl.create("postgresql")
+        postgresql_service = ServiceControl.create("postgresql-9.6")
         if postgresql_service.running:
             postgresql_service.reload()
         else:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ x-deploy: &default-deploy
     window: 5s
 services:
   postgres:
-    image: "postgres:9.2.23-alpine"
+    image: "postgres:9.6.17-alpine"
     hostname: "postgres"
     deploy:
       <<: *default-deploy

--- a/docker/python-service-base.dockerfile
+++ b/docker/python-service-base.dockerfile
@@ -18,8 +18,8 @@ WORKDIR /usr/share/chroma-manager/
 COPY . .
 COPY --from=builder /build/base.repo .
 RUN yum update -y \
-  && yum install -y epel-release \
-  && yum install -y python python-pip python-devel postgresql openssl gcc-c++ \
+  && yum install -y epel-release https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+  && yum install -y python python-pip python-devel postgresql96 openssl gcc-c++ \
   && pip install -r requirements.txt \
   && yum autoremove -y gcc-c++ python-pip python-devel \
   && rm -rf /root/.cache/pip \

--- a/iml-job-scheduler.service
+++ b/iml-job-scheduler.service
@@ -2,7 +2,7 @@
 Description=IML Job Scheduler Service
 PartOf=iml-manager.target
 After=rabbitmq-server.service
-After=postgresql.service
+After=postgresql-9.6.service
 
 [Service]
 Type=simple

--- a/iml-manager.target
+++ b/iml-manager.target
@@ -61,8 +61,8 @@ After=nginx.service
 Requires=rabbitmq-server.service
 After=rabbitmq-server.service
 
-Requires=postgresql.service
-After=postgresql.service
+Requires=postgresql-9.6.service
+After=postgresql-9.6.service
 
 Requires=influxdb.service
 After=influxdb.service
@@ -96,5 +96,5 @@ Also=iml-update-handler.socket
 Also=iml-warp-drive.service
 Also=influxdb.service
 Also=nginx.service
-Also=postgresql.service
+Also=postgresql-9.6.service
 Also=rabbitmq-server.service

--- a/iml-settings-populator.service
+++ b/iml-settings-populator.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=IML Settings Populator
-Wants=postgresql.service
-After=postgresql.service
+Wants=postgresql-9.6.service
+After=postgresql-9.6.service
 
 [Service]
 WorkingDirectory=/usr/share/chroma-manager

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -42,14 +42,14 @@ Requires:       fence-agents
 Requires:       fence-agents-virsh
 Requires:       ntp
 Requires:       pygobject2
-Requires:       postgresql-server >= 9.2.24
+Requires:       postgresql96-server >= 9.6.17
 Requires:       python-daemon
 Requires:       python-gunicorn
 Requires:       python-networkx
 Requires:       python-ordereddict
 Requires:       python-paramiko
 Requires:       python-prettytable
-Requires:       python-psycopg2 >= 2.7.7
+Requires:       python-psycopg2 = 2.7.7
 Requires:       python-setuptools
 Requires:       python-requests >= 2.6.0
 Requires:       python-uuid

--- a/tests/framework/chroma_support.repo.in
+++ b/tests/framework/chroma_support.repo.in
@@ -42,3 +42,10 @@ gpgcheck=1
 gpgkey=https://packages.grafana.com/gpg.key
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+
+[pgdg96]
+name=PostgreSQL 9.6 for RHEL/CentOS $releasever - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-$releasever-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96

--- a/tests/framework/services/runner.sh.in
+++ b/tests/framework/services/runner.sh.in
@@ -1,7 +1,8 @@
 #!/bin/bash -ex
 
 yum install -y epel-release
-yum install -y git python-virtualenv python-setuptools python-devel gcc make graphviz-devel postgresql-server postgresql-devel rabbitmq-server telnet python-ethtool erlang-inets patch gcc-c++ systemd-devel python-pip curl libcurl-devel nss
+yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+yum install -y git python-virtualenv python-setuptools python-devel gcc make graphviz-devel postgresql96-server postgresql96-devel rabbitmq-server telnet python-ethtool erlang-inets patch gcc-c++ systemd-devel python-pip curl libcurl-devel nss
 systemctl enable rabbitmq-server
 
 export PATH=$PATH:/usr/lib/rabbitmq/bin/
@@ -43,17 +44,17 @@ echo "counter: $COUNTER, trials: $MAX_TRIALS"
 
 
 # Configure postgres
-systemctl enable postgresql
-postgresql-setup initdb
-systemctl start postgresql
+systemctl enable postgresql-9.6
+/usr/pgsql-9.6/bin/postgresql96-setup initdb
+systemctl start postgresql-9.6
 # TODO: sleeping is racy.  should check for up-ness, not just assume it
 #       will happen within 5 seconds
 sleep 5  # Unfortunately postgresql start seems to return before its truly up and ready for business
 su postgres -c 'createuser -R -S -d chroma'
 su postgres -c 'createdb -O chroma chroma'
 sed -i -e '/local[[:space:]]\+all/i\
-local   all         chroma                            trust' /var/lib/pgsql/data/pg_hba.conf
-systemctl restart postgresql
+local   all         chroma                            trust' /var/lib/pgsql/9.6/data/pg_hba.conf
+systemctl restart postgresql-9.6
 
 
 yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/@MFL_COPR_REPO@/repo/epel-7/@MFL_COPR_NAME@-epel-7.repo

--- a/tests/integration/core/api_testcase_with_test_reset.py
+++ b/tests/integration/core/api_testcase_with_test_reset.py
@@ -551,7 +551,9 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                 )
 
             # Completely nuke the database to start from a clean state.
-            self.remote_command(chroma_manager["address"], "service postgresql stop && rm -fr /var/lib/pgsql/data/*")
+            self.remote_command(
+                chroma_manager["address"], "systemctl stop postgresql-9.6  && rm -fr /var/lib/pgsql/9.6/data/*"
+            )
 
             # Run chroma-config setup to recreate the database and start the manager.
             result = self.remote_command(

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -5,7 +5,8 @@ set -ex
 yum copr enable -y managerforlustre/manager-for-lustre-devel
 # Get latest rpmdevtools
 yum install -y https://copr-be.cloud.fedoraproject.org/results/managerforlustre/buildtools/epel-8-x86_64/01152137-rpmdevtools/rpmdevtools-8.10-7.el8.noarch.rpm
-yum install -y rpmdevtools git ed epel-release python-setuptools gcc openssl-devel postgresql-devel
+yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+yum install -y rpmdevtools git ed epel-release python-setuptools gcc openssl-devel postgresql96-devel
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 source $HOME/.cargo/env
 rustup update

--- a/vagrant/scripts/install_iml_repouri.sh
+++ b/vagrant/scripts/install_iml_repouri.sh
@@ -39,6 +39,13 @@ gpgcheck=1
 gpgkey=https://packages.grafana.com/gpg.key
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+
+[pgdg96]
+name=PostgreSQL 9.6 for RHEL/CentOS \$releasever - \$basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-\$releasever-\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
 EOF
 
 yum install -y python2-iml-manager


### PR DESCRIPTION
Update the RPM and docker installs to use postgres 9.6 instead of 9.2.

9.6 has improved JSON support and `INSERT ... ON CONFLICT DO NOTHING/UPDATE` support,
both of which are useful for upcoming features.

See https://www.postgresql.org/about/featurematrix/ for a more complete
comparision.

Centos 8 provides 9.6 in the appstream repo which should make migration
simpler as well.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1781)
<!-- Reviewable:end -->
