### PR TITLE
Fix z-index

### DIFF
--- a/iml-gui/crate/src/components/action_dropdown/mod.rs
+++ b/iml-gui/crate/src/components/action_dropdown/mod.rs
@@ -345,7 +345,7 @@ pub fn unstyled_view<'a>(
                         model.dropdown_state.is_open(),
                         items_view(id, &model.actions)
                     )
-                    .merge_attrs(class![C.z_30, C.w_56])
+                    .merge_attrs(class![C.z_20, C.w_56])
                 ]
             }
         }

--- a/iml-gui/crate/src/page/partial/header.rs
+++ b/iml-gui/crate/src/page/partial/header.rs
@@ -46,7 +46,7 @@ fn nav_manage_dropdown(open: bool) -> Node<Msg> {
             C.rounded,
             C.bg_menu,
             C.p_4,
-            C.z_20
+            C.z_40
         ],
         style! { "top" => "110%" },
         ul![

--- a/iml-gui/crate/src/status_section.rs
+++ b/iml-gui/crate/src/status_section.rs
@@ -121,6 +121,7 @@ pub fn view(
 ) -> Node<Msg> {
     div![
         class![
+            C.z_30,
             C.flex,
             C.lg__fixed => model.section.is_some(),
             C.lg__right_0 => model.section.is_some()


### PR DESCRIPTION
  50 - Modals

  40 - Menu

  30 - Side panel with alerts and logs

  20 - Tooltips

  10 - Popovers and dropdowns

  0 - anything else (header, footer, main panels, etc.)

Closes #1748.

![Doc - 15-4-20 - 13-53 - p1](https://user-images.githubusercontent.com/131844/79353675-a9fdc500-7f3b-11ea-8774-4297697a08bb.jpg)


Signed-off-by: Igor Pashev <pashev.igor@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1786)
<!-- Reviewable:end -->
