### PR TITLE
Obsolete device-scanner-proxy

### DIFF
--- a/rust-iml.spec
+++ b/rust-iml.spec
@@ -75,7 +75,8 @@ Group: System Environment/Libraries
 Summary: IML Agent Daemon and CLI
 License: MIT
 Group: System Environment/Libraries
-Requires: iml-device-scanner >= 3.0
+Requires: iml-device-scanner >= 4.0
+Obsoletes: iml-device-scanner-proxy
 
 %description agent
 %{summary}


### PR DESCRIPTION
The `rust-iml-agent` package provides the functionallity that
`iml-device-scanner-proxy` did.

Require newest `device-scanner` and obsolete `iml-device-scanner-proxy`
going forward.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1795)
<!-- Reviewable:end -->
