### PR TITLE
Add POSTGRES_HOST_AUTH_METHOD environment var

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - db-data:/var/lib/postgresql/data/
     environment:
       - POSTGRES_USER=chroma
+      - POSTGRES_HOST_AUTH_METHOD=trust
     healthcheck:
       test: ["CMD-SHELL", "psql -h 'postgres' -U 'chroma' -c '\\q'"]
       interval: 5s


### PR DESCRIPTION
Due to https://github.com/docker-library/postgres/issues/681, we need to
add `- POSTGRES_HOST_AUTH_METHOD=trust` to the docker-compose.yml.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1799)
<!-- Reviewable:end -->
