### PR TITLE
Update deploy restart policy

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 x-deploy: &default-deploy
   restart_policy:
-    condition: on-failure
+    condition: any
     delay: 5s
     window: 5s
 services:
@@ -344,7 +344,11 @@ services:
       - "/etc/iml-docker/setup:/var/lib/chroma-setup"
     secrets:
       - iml_pw
-    deploy: *default-deploy
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        window: 5s
 volumes:
   manager-config:
   db-data:


### PR DESCRIPTION
The restart policy needs to be changed from `on-failure` to `any`.
`Setup` is an exception and should continue to have a restart policy of
`on-failure`.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1811)
<!-- Reviewable:end -->
