### PR TITLE
Add iml-tracing crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
+checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
 
 [[package]]
 name = "arrayref"
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
+checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
 dependencies = [
  "cc",
  "libc",
@@ -318,9 +318,9 @@ checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "9c9384ca4b90c0ea47e19a5c996d6643a3e73dedf9b89c65efb67587e34da1bb"
 
 [[package]]
 name = "cexpr"
@@ -530,16 +530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c5e5ac752e18207b12e16b10631ae5f7f68f8805f335f9b817ead83d9ffce1"
-dependencies = [
- "quote 1.0.3",
- "syn 1.0.17",
 ]
 
 [[package]]
@@ -1163,6 +1153,7 @@ dependencies = [
  "iml-manager-env",
  "iml-rabbit",
  "iml-service-queue",
+ "iml-tracing",
  "iml-util",
  "iml-wire-types",
  "rand 0.7.3",
@@ -1172,7 +1163,6 @@ dependencies = [
  "tokio-runtime-shutdown",
  "tokio-test",
  "tracing",
- "tracing-subscriber",
  "warp",
 ]
 
@@ -1194,6 +1184,7 @@ dependencies = [
  "iml-cmd",
  "iml-fs",
  "iml-systemd",
+ "iml-tracing",
  "iml-util",
  "iml-wire-types",
  "inotify",
@@ -1205,7 +1196,6 @@ dependencies = [
  "mockito",
  "native-tls",
  "parking_lot 0.9.0",
- "pretty_assertions",
  "prettytable-rs",
  "regex",
  "reqwest",
@@ -1219,9 +1209,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
  "url",
- "uuid 0.7.4",
+ "uuid",
  "v_hist",
  "version-utils",
 ]
@@ -1233,13 +1222,13 @@ dependencies = [
  "futures",
  "iml-manager-env",
  "iml-rabbit",
+ "iml-tracing",
  "iml-wire-types",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber",
- "uuid 0.7.4",
+ "uuid",
  "warp",
 ]
 
@@ -1251,12 +1240,12 @@ dependencies = [
  "iml-job-scheduler-rpc",
  "iml-manager-env",
  "iml-rabbit",
+ "iml-tracing",
  "iml-wire-types",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "warp",
 ]
 
@@ -1290,6 +1279,7 @@ dependencies = [
  "iml-postgres",
  "iml-rabbit",
  "iml-service-queue",
+ "iml-tracing",
  "iml-wire-types",
  "insta",
  "serde",
@@ -1298,7 +1288,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
  "warp",
 ]
 
@@ -1308,7 +1297,6 @@ version = "0.2.0"
 dependencies = [
  "bytes",
  "futures",
- "pretty_assertions",
  "tempdir",
  "tempfile",
  "tokio",
@@ -1334,7 +1322,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "uuid 0.8.1",
+ "uuid",
 ]
 
 [[package]]
@@ -1345,11 +1333,10 @@ dependencies = [
  "futures",
  "iml-fs",
  "iml-manager-env",
- "pretty_assertions",
+ "iml-tracing",
  "tempdir",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "warp",
 ]
 
@@ -1366,6 +1353,7 @@ dependencies = [
  "iml-api-utils",
  "iml-influx",
  "iml-manager-client",
+ "iml-tracing",
  "iml-wire-types",
  "indicatif",
  "number-formatter",
@@ -1377,7 +1365,6 @@ dependencies = [
  "structopt",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1405,10 +1392,10 @@ dependencies = [
  "iml-orm",
  "iml-rabbit",
  "iml-service-queue",
+ "iml-tracing",
  "iml-wire-types",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1435,10 +1422,10 @@ dependencies = [
  "futures-util",
  "iml-postgres",
  "iml-service-queue",
+ "iml-tracing",
  "iml-wire-types",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1458,10 +1445,10 @@ dependencies = [
  "futures",
  "iml-rabbit",
  "iml-service-queue",
+ "iml-tracing",
  "iml-wire-types",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1515,12 +1502,12 @@ dependencies = [
  "futures",
  "iml-manager-env",
  "iml-service-queue",
+ "iml-tracing",
  "iml-wire-types",
  "influx_db_client",
  "lustre_collector",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "url",
 ]
 
@@ -1545,13 +1532,22 @@ dependencies = [
  "iml-cmd",
  "iml-manager-client",
  "iml-manager-env",
+ "iml-tracing",
  "serde",
  "serde_json",
  "structopt",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "warp",
+]
+
+[[package]]
+name = "iml-tracing"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1576,14 +1572,14 @@ dependencies = [
  "iml-manager-env",
  "iml-postgres",
  "iml-rabbit",
+ "iml-tracing",
  "iml-wire-types",
  "serde",
  "serde_json",
  "tokio",
  "tokio-runtime-shutdown",
  "tracing",
- "tracing-subscriber",
- "uuid 0.7.4",
+ "uuid",
  "warp",
 ]
 
@@ -2200,15 +2196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "output_vt100"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
-dependencies = [
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,7 +2213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.7.1",
+ "parking_lot_core 0.7.2",
 ]
 
 [[package]]
@@ -2246,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e136c1904604defe99ce5fd71a28d473fa60a12255d511aa78a9ddf11237aeb"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
  "cloudabi",
@@ -2398,9 +2385,9 @@ checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 
 [[package]]
 name = "pin-utils"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinky-swear"
@@ -2468,18 +2455,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "pretty_assertions"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
-dependencies = [
- "ansi_term 0.11.0",
- "ctor",
- "difference",
- "output_vt100",
-]
 
 [[package]]
 name = "prettytable-rs"
@@ -3105,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae75d0445b5d3778c9da3d1f840faa16d0627c8607f78a74daf69e5b988c39a1"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
 dependencies = [
  "lazy_static",
 ]
@@ -3269,9 +3244,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
+checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3280,9 +3255,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
+checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error 1.0.2",
@@ -3357,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "tcp-stream"
-version = "0.10.3"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90b1c8f6ae2edd9fd48158cdf10eea2c57c71560bc36d020e8f053e1c98cd5a"
+checksum = "ae73d8436406c3db72ee8c71afb734b8e9b35deb58ccda9fb9c76fc9111d0b90"
 dependencies = [
  "cfg-if",
  "mio 0.7.0",
@@ -3469,12 +3444,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "redox_syscall",
  "winapi 0.3.8",
 ]
 
@@ -3664,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50df245be6f0adf35c399cb16dea60e2c7d6cc83ff5dc22d727df06dd6f0c"
+checksum = "1d53c40489aa69c9aed21ff483f26886ca8403df33bdc2d2f87c60c1617826d2"
 dependencies = [
  "ansi_term 0.11.0",
  "chrono",
@@ -3816,15 +3790,6 @@ name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
-
-[[package]]
-name = "uuid"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-dependencies = [
- "rand 0.6.5",
-]
 
 [[package]]
 name = "uuid"
@@ -4048,9 +4013,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi 0.3.8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     'iml-timer',
     'iml-services/iml-ntp',
     'iml-systemd',
+    'iml-tracing',
     'iml-util',
     'iml-warp-drive',
     'iml-wire-types',

--- a/iml-agent-comms/Cargo.toml
+++ b/iml-agent-comms/Cargo.toml
@@ -13,6 +13,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 tokio = "0.2"
 tracing = "0.1"
-tracing-subscriber = "0.2"
-uuid = { version = "0.7", features = ["v4"] }
+iml-tracing = { version = "0.1", path="../iml-tracing"}
+uuid = { version = "0.8", features = ["v4"] }
 warp = "0.2"

--- a/iml-agent-comms/src/main.rs
+++ b/iml-agent-comms/src/main.rs
@@ -15,7 +15,6 @@ use iml_wire_types::{
     Envelope, Fqdn, ManagerMessage, ManagerMessages, Message, PluginMessage, PluginName,
 };
 use std::{sync::Arc, time::Duration};
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::Filter;
 
 async fn data_handler(
@@ -120,11 +119,7 @@ struct MessageFqdn {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     // Handle an error in locks by shutting down
     let (tx, rx) = oneshot::channel();

--- a/iml-agent/Cargo.toml
+++ b/iml-agent/Cargo.toml
@@ -22,6 +22,7 @@ http = "0.2"
 iml-cmd = { path = "../iml-cmd", version = "0.2.0" }
 iml-fs = { path = "../iml-fs", version = "0.2.0" }
 iml-systemd = { path = "../iml-systemd", version = "0.2.0" }
+iml-tracing = { version = "0.1", path = "../iml-tracing" }
 iml-util = { path = "../iml-util", version = "0.2.0" }
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
 inotify = "0.8"
@@ -42,9 +43,8 @@ structopt = "0.3"
 tokio = { version = "0.2", features = ["fs", "process", "macros", "net"] }
 tokio-util = { version = "0.3", features = ["codec"] }
 tracing = "0.1"
-tracing-subscriber = "0.2"
 url = "2.1"
-uuid = { version = "0.7", features = ["v4"] }
+uuid = { version = "0.8", features = ["v4"] }
 v_hist = "0.1.2"
 version-utils = { path = "../version-utils", version = "0.1.0" }
 
@@ -55,7 +55,6 @@ features = ["std"]
 
 [dev-dependencies]
 mockito = "0.25.1"
-pretty_assertions = "0.6.1"
 insta = "0.16"
 tempfile = "3.1.0"
 

--- a/iml-agent/src/cli.rs
+++ b/iml-agent/src/cli.rs
@@ -22,7 +22,6 @@ use std::{
     process::exit,
 };
 use structopt::StructOpt;
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 
 #[derive(Debug, StructOpt)]
 pub enum StratagemCommand {
@@ -425,11 +424,8 @@ fn add_counter_entry(x: impl Counter, t: &mut Table, h: &mut v_hist::Histogram) 
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
+    iml_tracing::init();
 
-    tracing::subscriber::set_global_default(subscriber).unwrap();
     dotenv::from_path("/etc/iml/iml-agent.conf").expect("Could not load cli env");
 
     let matches = App::from_args();

--- a/iml-agent/src/http_comms/crypto_client.rs
+++ b/iml-agent/src/http_comms/crypto_client.rs
@@ -136,7 +136,6 @@ mod tests {
     use futures::TryStreamExt;
     use iml_fs::read_lines;
     use mockito::mock;
-    use pretty_assertions::assert_eq;
     use reqwest::Client;
     use std::str;
     use url::Url;

--- a/iml-agent/src/main.rs
+++ b/iml-agent/src/main.rs
@@ -10,15 +10,10 @@ use iml_agent::{
     http_comms::{agent_client::AgentClient, crypto_client, session},
     poller, reader,
 };
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     tracing::info!("Starting Rust agent_daemon");
 

--- a/iml-api/Cargo.toml
+++ b/iml-api/Cargo.toml
@@ -9,10 +9,10 @@ futures = "0.3"
 iml-job-scheduler-rpc = { path = "../iml-job-scheduler-rpc", version = "0.2" }
 iml-manager-env = { path = "../iml-manager-env", version = "0.2" }
 iml-rabbit = { path = "../iml-rabbit", version = "0.2.0", features = ["warp-filters"] }
+iml-tracing = { version = "0.1", path="../iml-tracing"}
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
 tracing = "0.1"
-tracing-subscriber = "0.2"
 warp = "0.2"

--- a/iml-api/src/main.rs
+++ b/iml-api/src/main.rs
@@ -7,11 +7,12 @@ mod error;
 
 use iml_rabbit::{self, create_connection_filter};
 use iml_wire_types::Conf;
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::Filter;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    iml_tracing::init();
+
     let addr = iml_manager_env::get_iml_api_addr();
 
     let conf = Conf {
@@ -22,12 +23,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         branding: iml_manager_env::get_branding().into(),
         use_stratagem: iml_manager_env::get_use_stratagem(),
     };
-
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
 
     let (fut, client_filter) = create_connection_filter().await?;
 

--- a/iml-fs/Cargo.toml
+++ b/iml-fs/Cargo.toml
@@ -12,6 +12,5 @@ tempfile = "3.1"
 bytes = "0.5"
 
 [dev-dependencies]
-pretty_assertions = "0.6"
 tempdir = "0.3"
 tokio = { version = "0.2", features = ["macros"] }

--- a/iml-mailbox/Cargo.toml
+++ b/iml-mailbox/Cargo.toml
@@ -7,13 +7,12 @@ edition = "2018"
 [dependencies]
 bytes = "0.5"
 futures = "0.3"
-iml-manager-env = { path = "../iml-manager-env", version = "0.2.0" }
 iml-fs = { path = "../iml-fs", version = "0.2" }
+iml-manager-env = { path = "../iml-manager-env", version = "0.2.0" }
+iml-tracing = { version = "0.1", path="../iml-tracing"}
 tokio = "0.2"
-warp = "0.2"
 tracing = "0.1"
-tracing-subscriber = "0.2"
+warp = "0.2"
 
 [dev-dependencies]
-pretty_assertions = "0.6.1"
 tempdir = "0.3"

--- a/iml-mailbox/src/main.rs
+++ b/iml-mailbox/src/main.rs
@@ -13,16 +13,11 @@
 use futures::{lock::Mutex, Stream, TryFutureExt, TryStreamExt};
 use iml_mailbox::{Errors, Incoming, MailboxSenders};
 use std::{fs, path::PathBuf, pin::Pin, sync::Arc};
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::Filter as _;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     let addr = iml_manager_env::get_mailbox_addr();
     let mailbox_path = iml_manager_env::get_mailbox_path();

--- a/iml-manager-cli/Cargo.toml
+++ b/iml-manager-cli/Cargo.toml
@@ -14,6 +14,7 @@ hostlist-parser = "0.1.2"
 iml-api-utils = { path = "../iml-api-utils", version = "0.2" }
 iml-influx = { path = "../iml-influx", version = "0.1" }
 iml-manager-client = { path = "../iml-manager-client", version = "0.2.0" }
+iml-tracing = { version = "0.1", path="../iml-tracing"}
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
 indicatif = "0.14"
 number-formatter = { path = "../number-formatter", version = "0.1" }
@@ -25,7 +26,6 @@ spinners = "1.2.0"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["macros", "io-std", "io-util"] }
 tracing = "0.1"
-tracing-subscriber = "0.2"
 
 [[bin]]
 name = "iml"

--- a/iml-manager-cli/src/main.rs
+++ b/iml-manager-cli/src/main.rs
@@ -11,7 +11,6 @@ use iml_manager_cli::{
 };
 use std::process::exit;
 use structopt::StructOpt;
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "iml", setting = structopt::clap::AppSettings::ColoredHelp)]
@@ -42,11 +41,7 @@ pub enum App {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     let matches = App::from_args();
 

--- a/iml-services/iml-action-runner/Cargo.toml
+++ b/iml-services/iml-action-runner/Cargo.toml
@@ -6,20 +6,20 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-tokio = "0.2"
+iml-manager-env = { path = "../../iml-manager-env", version = "0.2.0" }
+iml-rabbit = { path = "../../iml-rabbit", version = "0.2.0", features = ["warp-filters"]}
+iml-service-queue = { path = "../iml-service-queue", version = "0.2.0" }
+iml-tracing = { version = "0.1", path="../../iml-tracing"}
+iml-util = { path = "../../iml-util", version = "0.2.0" }
+iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-warp = "0.2"
-iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
-iml-rabbit = { path = "../../iml-rabbit", version = "0.2.0", features = ["warp-filters"]}
-iml-manager-env = { path = "../../iml-manager-env", version = "0.2.0" }
-iml-service-queue = { path = "../iml-service-queue", version = "0.2.0" }
-iml-util = { path = "../../iml-util", version = "0.2.0" }
+tokio = "0.2"
 tokio-runtime-shutdown = { path = "../../tokio-runtime-shutdown", version = "0.2.0" }
 tracing = "0.1"
-tracing-subscriber = "0.2"
+warp = "0.2"
 
 [dev-dependencies]
 iml-agent-comms = { path = "../../iml-agent-comms", version = "0.2.0"}
-rand = "0.7.2"
+rand = "0.7"
 tokio-test = "0.2"

--- a/iml-services/iml-action-runner/src/main.rs
+++ b/iml-services/iml-action-runner/src/main.rs
@@ -13,18 +13,13 @@ use iml_rabbit::create_connection_filter;
 use iml_service_queue::service_queue::{consume_service_queue, ImlServiceQueueError};
 use iml_util::tokio_utils::get_tcp_or_unix_listener;
 use std::{collections::HashMap, sync::Arc};
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::{self, Filter as _};
 
 pub static AGENT_TX_RUST: &str = "agent_tx_rust";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     let (exit, valve) = tokio_runtime_shutdown::shared_shutdown();
 

--- a/iml-services/iml-device/Cargo.toml
+++ b/iml-services/iml-device/Cargo.toml
@@ -6,12 +6,14 @@ edition = "2018"
 
 [dependencies]
 device-types = "0.1"
+diesel = { version = "1.4", default_features = false, features = ["postgres", "r2d2", "chrono", "serde_json"] }
 futures = "0.3"
-iml-rabbit = { path = "../../iml-rabbit", version = "0.2.0" }
 iml-manager-env = { path = "../../iml-manager-env", version = "0.2.0" }
 iml-orm = { path = "../../iml-orm", version = "0.2.0", features = ["postgres-interop"] }
 iml-postgres = { path = "../../iml-postgres", version = "0.2.0" }
+iml-rabbit = { path = "../../iml-rabbit", version = "0.2.0" }
 iml-service-queue = { path = "../iml-service-queue", version = "0.2.0" }
+iml-tracing = { version = "0.1", path="../../iml-tracing"}
 iml-wire-types = { path = "../../iml-wire-types", version = "0.2", features = ["postgres-interop"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
@@ -19,9 +21,7 @@ thiserror = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
 tokio-util = { version = "0.3", features = ["codec"] }
 tracing = "0.1"
-tracing-subscriber = "0.2"
 warp = "0.2"
-diesel = { version = "1.4", default_features = false, features = ["postgres", "r2d2", "chrono", "serde_json"] }
 
 [dev-dependencies]
 insta = "0.16"

--- a/iml-services/iml-device/src/main.rs
+++ b/iml-services/iml-device/src/main.rs
@@ -23,18 +23,13 @@ use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
 };
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::Filter;
 
 type Cache = Arc<Mutex<HashMap<Fqdn, Device>>>;
 
 #[tokio::main]
 async fn main() -> Result<(), ImlDeviceError> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     let addr = iml_manager_env::get_device_aggregator_addr();
 

--- a/iml-services/iml-ntp/Cargo.toml
+++ b/iml-services/iml-ntp/Cargo.toml
@@ -9,7 +9,7 @@ futures = "0.3"
 iml-orm = { path = "../../iml-orm", version = "0.2.0", features = ["postgres-interop"] }
 iml-rabbit = { path = "../../iml-rabbit", version = "0.2.0" }
 iml-service-queue = { path = "../iml-service-queue", version = "0.2.0" }
+iml-tracing = { version = "0.1", path="../../iml-tracing"}
 iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
 tokio = { version = "0.2", features = [ "rt-threaded", "blocking" ] }
 tracing = "0.1"
-tracing-subscriber = "0.2"

--- a/iml-services/iml-ntp/src/main.rs
+++ b/iml-services/iml-ntp/src/main.rs
@@ -10,7 +10,6 @@ use iml_orm::{
 };
 use iml_service_queue::service_queue::consume_data;
 use iml_wire_types::time::State;
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 
 pub async fn get_host_by_fqdn(
     x: impl ToString,
@@ -24,11 +23,7 @@ pub async fn get_host_by_fqdn(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     let pool = iml_orm::pool()?;
 

--- a/iml-services/iml-ostpool/Cargo.toml
+++ b/iml-services/iml-ostpool/Cargo.toml
@@ -9,7 +9,7 @@ futures = "0.3"
 futures-util = "0.3"
 iml-postgres = { path = "../../iml-postgres", version = "0.2.0" }
 iml-service-queue = { path = "../iml-service-queue", version = "0.2.0" }
+iml-tracing = { version = "0.1", path="../../iml-tracing"}
 iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
 tokio = "0.2"
 tracing = "0.1"
-tracing-subscriber = "0.2"

--- a/iml-services/iml-ostpool/src/main.rs
+++ b/iml-services/iml-ostpool/src/main.rs
@@ -11,14 +11,10 @@ use iml_ostpool::{
 use iml_service_queue::service_queue::consume_data;
 use iml_wire_types::FsPoolMap;
 use std::collections::BTreeSet;
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     let mut s = consume_data::<FsPoolMap>("rust_agent_ostpool_rx");
 

--- a/iml-services/iml-postoffice/Cargo.toml
+++ b/iml-services/iml-postoffice/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
 iml-rabbit = { path = "../../iml-rabbit", version = "0.2.0" }
 iml-service-queue = { path = "../iml-service-queue", version = "0.2.0" }
+iml-tracing = { version = "0.1", path="../../iml-tracing"}
+iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
 tokio = "0.2"
 tracing = "0.1"
-tracing-subscriber = "0.2"

--- a/iml-services/iml-postoffice/src/main.rs
+++ b/iml-services/iml-postoffice/src/main.rs
@@ -4,15 +4,10 @@
 
 use futures::TryStreamExt;
 use iml_service_queue::service_queue::consume_data;
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     let mut s = consume_data::<String>("rust_agent_postoffice_rx");
 

--- a/iml-services/iml-stats/Cargo.toml
+++ b/iml-services/iml-stats/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 futures = "0.3"
 iml-manager-env = { path = "../../iml-manager-env", version = "0.2.0" }
 iml-service-queue = { path = "../iml-service-queue", version = "0.2.0" }
+iml-tracing = { version = "0.1", path="../../iml-tracing"}
 iml-wire-types = { path = "../../iml-wire-types", version = "0.2" }
-influx_db_client = "0.4.0"
+influx_db_client = "0.4"
 lustre_collector = "0.2.12"
 tokio = { version = "0.2", features = [ "macros" ] }
 tracing = "0.1"
-tracing-subscriber = "0.2"
 url = "2.1.1"

--- a/iml-services/iml-stats/src/main.rs
+++ b/iml-services/iml-stats/src/main.rs
@@ -15,7 +15,6 @@ use lustre_collector::{
         Stat, TargetStat,
     },
 };
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use url::Url;
 
 fn build_stats_query(x: &TargetStat<Vec<Stat>>, stat: &Stat, query: Point) -> Point {
@@ -457,11 +456,7 @@ fn handle_node(node: NodeStats, host: &Fqdn) -> Option<Vec<Point>> {
 
 #[tokio::main]
 async fn main() -> Result<(), ImlStatsError> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     let mut s = consume_data::<Vec<Record>>("rust_agent_stats_rx");
     let influx_url: String = format!("http://{}", get_influxdb_addr());

--- a/iml-timer/Cargo.toml
+++ b/iml-timer/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 [dependencies]
 futures = "0.3"
 iml-cmd = { path = "../iml-cmd", version = "0.2", features = ["warp-errs"] }
-iml-manager-env = { path = "../iml-manager-env", version = "0.2.0" }
 iml-manager-client = { path = "../iml-manager-client", version = "0.2" }
+iml-manager-env = { path = "../iml-manager-env", version = "0.2.0" }
+iml-tracing = { version = "0.1", path="../iml-tracing"}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["process", "macros"] }
 tracing = "0.1"
-tracing-subscriber = "0.2"
 warp = "0.2"

--- a/iml-timer/src/bin/iml-timer.rs
+++ b/iml-timer/src/bin/iml-timer.rs
@@ -7,16 +7,11 @@ use iml_cmd::{CheckedCommandExt, Command};
 use iml_timer::config::{
     delete_config, get_config, service_file, timer_file, unit_name, write_configs,
 };
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::{self, http::StatusCode, Filter};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     // Match a config route
     let config_route = warp::put()

--- a/iml-timer/src/bin/start-stratagem-scan.rs
+++ b/iml-timer/src/bin/start-stratagem-scan.rs
@@ -4,7 +4,6 @@
 
 use iml_manager_client::{get_client, post};
 use structopt::StructOpt;
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "start-stratagem-scan")]
@@ -29,11 +28,7 @@ struct StratagemData {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     let opts = App::from_args();
 

--- a/iml-tracing/Cargo.toml
+++ b/iml-tracing/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "iml-tracing"
+version = "0.1.0"
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+
+[dependencies]
+tokio = { version = "0.2", features = [ "signal", "rt-core" ] }
+tracing = "0.1"
+tracing-subscriber = "0.2"

--- a/iml-tracing/src/lib.rs
+++ b/iml-tracing/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use tokio::signal::unix::{signal, SignalKind};
+pub use tracing;
+use tracing_subscriber::{fmt::Subscriber, EnvFilter};
+
+/// Initialize logging by reading the `RUST_LOG` environment variable.
+/// In addition, setup signal handlers
+///
+/// - `SIGUSR1` will set log level to info.
+/// - `SIGUSR2` will set log level to debug.
+pub fn init() {
+    let builder = Subscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_filter_reloading();
+
+    let handle = builder.reload_handle();
+    builder.try_init().expect("Could not init builder");
+
+    let handle2 = handle.clone();
+
+    tokio::spawn(async move {
+        let mut stream = signal(SignalKind::user_defined1()).expect("Could not listen to SIGUSR1");
+
+        while let Some(_) = stream.recv().await {
+            handle2.reload("info").unwrap();
+        }
+    });
+
+    tokio::spawn(async move {
+        let mut stream = signal(SignalKind::user_defined2()).expect("Could not listen to SIGUSR2");
+
+        while let Some(_) = stream.recv().await {
+            handle.reload("debug").unwrap();
+        }
+    });
+}

--- a/iml-warp-drive/Cargo.toml
+++ b/iml-warp-drive/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-tracing = "0.1"
-tracing-subscriber = "0.2"
-tokio = { version = "0.2", features = ["macros"] }
+im = { version = "14.1", features = ["serde"] }
+iml-manager-client = { path = "../iml-manager-client", version = "0.2" }
+iml-manager-env = { path = "../iml-manager-env", version = "0.2.0" }
+iml-postgres = { path = "../iml-postgres", version = "0.2.0" }
+iml-rabbit = { path = "../iml-rabbit", version = "0.2.0" }
+iml-tracing = { version = "0.1", path="../iml-tracing"}
+iml-wire-types = { path = "../iml-wire-types", version = "0.2", features = ["postgres-interop"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-uuid = { version = "0.7", features = ["v4"] }
-im = { version = "14.1", features = ["serde"] }
-warp = "0.2"
-iml-manager-env = { path = "../iml-manager-env", version = "0.2.0" }
-iml-rabbit = { path = "../iml-rabbit", version = "0.2.0" }
-iml-postgres = { path = "../iml-postgres", version = "0.2.0" }
-iml-wire-types = { path = "../iml-wire-types", version = "0.2", features = ["postgres-interop"] }
-iml-manager-client = { path = "../iml-manager-client", version = "0.2" }
+tokio = { version = "0.2", features = ["macros"] }
 tokio-runtime-shutdown = { path = "../tokio-runtime-shutdown", version = "0.2" }
+tracing = "0.1"
+uuid = { version = "0.8", features = ["v4"] }
+warp = "0.2"

--- a/iml-warp-drive/src/main.rs
+++ b/iml-warp-drive/src/main.rs
@@ -13,19 +13,13 @@ use iml_warp_drive::{
 };
 use iml_wire_types::warp_drive::{Cache, Message};
 use std::sync::Arc;
-use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 use warp::Filter;
 
 type SharedLocks = Arc<Mutex<Locks>>;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = Subscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .without_time()
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+    iml_tracing::init();
 
     // Keep track of all connected users, key is `usize`, value
     // is a event stream sender.


### PR DESCRIPTION
Add a new iml-tracing crate. It can change the loglevel of a service
at runtime.

- `systemctl kill -s SIGUSR2` will drop a service into debug logging.
- `systemctl kill -s SIGUSR1` will bring a service up to info logging.

Replace the use of tracing with this crate in all applicable services.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1818)
<!-- Reviewable:end -->
