### PR TITLE
Add CLI commands for loading / removing profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "da71fef07bc806586090247e971229289f64c210a278ee5ae419314eb386b31d"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -318,9 +318,9 @@ checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "cc"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9384ca4b90c0ea47e19a5c996d6643a3e73dedf9b89c65efb67587e34da1bb"
+checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 
 [[package]]
 name = "cexpr"
@@ -578,7 +578,7 @@ checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "dns-lookup"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13988670860b076248c74e1b54444efc4f1dec70c8bb25da4b7c0024396b72bf"
+checksum = "8ea427e983abd535e5ea03dcf395b3a7ae4546f908c8c9e59cca36cf968f82ce"
 dependencies = [
  "libc",
  "socket2",
@@ -738,7 +738,7 @@ dependencies = [
  "proc-macro-error 0.4.12",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -862,7 +862,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1353,6 +1353,7 @@ dependencies = [
  "iml-api-utils",
  "iml-influx",
  "iml-manager-client",
+ "iml-orm",
  "iml-tracing",
  "iml-wire-types",
  "indicatif",
@@ -1363,6 +1364,7 @@ dependencies = [
  "serde_json",
  "spinners",
  "structopt",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -2241,7 +2243,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "winapi 0.3.8",
 ]
 
@@ -2286,7 +2288,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2374,7 +2376,7 @@ checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2479,7 +2481,7 @@ dependencies = [
  "proc-macro-error-attr 0.4.12",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "version_check 0.9.1",
 ]
 
@@ -2492,7 +2494,7 @@ dependencies = [
  "proc-macro-error-attr 1.0.2",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "version_check 0.9.1",
 ]
 
@@ -2504,7 +2506,7 @@ checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "syn-mid",
  "version_check 0.9.1",
 ]
@@ -2517,7 +2519,7 @@ checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "syn-mid",
  "version_check 0.9.1",
 ]
@@ -2909,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "safemem"
@@ -3005,7 +3007,7 @@ checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3027,7 +3029,7 @@ checksum = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3151,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "socket2"
@@ -3263,7 +3265,7 @@ dependencies = [
  "proc-macro-error 1.0.2",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3301,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -3318,7 +3320,7 @@ checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3430,7 +3432,7 @@ checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3496,7 +3498,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3603,7 +3605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3650,7 +3652,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -3735,7 +3737,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -3903,7 +3905,7 @@ dependencies = [
  "log 0.4.8",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -3937,7 +3939,7 @@ checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/iml-fs/src/lib.rs
+++ b/iml-fs/src/lib.rs
@@ -73,7 +73,7 @@ pub fn read_lines<
 /// * `p` - The `Path` to a file.
 pub async fn read_file_to_end<P>(p: P) -> Result<Vec<u8>, io::Error>
 where
-    P: AsRef<Path> + Send + 'static,
+    P: AsRef<Path> + Send,
 {
     let mut file = File::open(p).await?;
 

--- a/iml-manager-cli/Cargo.toml
+++ b/iml-manager-cli/Cargo.toml
@@ -14,6 +14,7 @@ hostlist-parser = "0.1.2"
 iml-api-utils = { path = "../iml-api-utils", version = "0.2" }
 iml-influx = { path = "../iml-influx", version = "0.1" }
 iml-manager-client = { path = "../iml-manager-client", version = "0.2.0" }
+iml-orm = { path = "../iml-orm", version = "0.2.0", features = ["postgres-interop"]}
 iml-tracing = { version = "0.1", path="../iml-tracing"}
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
 indicatif = "0.14"
@@ -24,6 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 spinners = "1.2.0"
 structopt = "0.3"
+thiserror = "1.0"
 tokio = { version = "0.2", features = ["macros", "io-std", "io-util"] }
 tracing = "0.1"
 

--- a/iml-manager-cli/src/error.rs
+++ b/iml-manager-cli/src/error.rs
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+use iml_orm::{r2d2, tokio_diesel};
 use iml_wire_types::Command;
+use thiserror::Error;
 
 #[derive(Debug)]
 pub enum DurationParseError {
@@ -54,21 +56,23 @@ impl std::fmt::Display for DurationParseError {
 
 impl std::error::Error for DurationParseError {}
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ImlManagerCliError {
     ApiError(String),
-    ClientRequestError(iml_manager_client::ImlManagerClientError),
+    ClientRequestError(#[from] iml_manager_client::ImlManagerClientError),
     CombineEasyError(combine::stream::easy::Errors<char, &'static str, usize>),
     DoesNotExist(&'static str),
     FailedCommandError(Vec<Command>),
-    IntParseError(std::num::ParseIntError),
-    IoError(std::io::Error),
-    ParseDurationError(DurationParseError),
-    ReqwestError(reqwest::Error),
-    RunStratagemValidationError(RunStratagemValidationError),
-    SerdeJsonError(serde_json::error::Error),
-    TokioJoinError(tokio::task::JoinError),
-    TokioTimerError(tokio::time::Error),
+    IntParseError(#[from] std::num::ParseIntError),
+    IoError(#[from] std::io::Error),
+    ParseDurationError(#[from] DurationParseError),
+    R2D2Error(#[from] r2d2::Error),
+    ReqwestError(#[from] reqwest::Error),
+    RunStratagemValidationError(#[from] RunStratagemValidationError),
+    SerdeJsonError(#[from] serde_json::error::Error),
+    TokioDieselAsyncError(#[from] tokio_diesel::AsyncError),
+    TokioJoinError(#[from] tokio::task::JoinError),
+    TokioTimerError(#[from] tokio::time::Error),
 }
 
 impl std::fmt::Display for ImlManagerCliError {
@@ -86,12 +90,14 @@ impl std::fmt::Display for ImlManagerCliError {
 
                 write!(f, "{}", failed_msg)
             }
+            ImlManagerCliError::R2D2Error(ref err) => write!(f, "{}", err),
             ImlManagerCliError::IntParseError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::IoError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::ParseDurationError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::ReqwestError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::RunStratagemValidationError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::SerdeJsonError(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::TokioDieselAsyncError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::TokioJoinError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::TokioTimerError(ref err) => write!(f, "{}", err),
         }
@@ -104,77 +110,9 @@ impl std::fmt::Display for RunStratagemValidationError {
     }
 }
 
-impl std::error::Error for ImlManagerCliError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match *self {
-            ImlManagerCliError::ApiError(_) => None,
-            ImlManagerCliError::ClientRequestError(ref err) => Some(err),
-            ImlManagerCliError::CombineEasyError(ref err) => Some(err),
-            ImlManagerCliError::DoesNotExist(_) => None,
-            ImlManagerCliError::FailedCommandError(_) => None,
-            ImlManagerCliError::IntParseError(ref err) => Some(err),
-            ImlManagerCliError::IoError(ref err) => Some(err),
-            ImlManagerCliError::ParseDurationError(ref err) => Some(err),
-            ImlManagerCliError::ReqwestError(ref err) => Some(err),
-            ImlManagerCliError::RunStratagemValidationError(ref err) => Some(err),
-            ImlManagerCliError::SerdeJsonError(ref err) => Some(err),
-            ImlManagerCliError::TokioJoinError(ref err) => Some(err),
-            ImlManagerCliError::TokioTimerError(ref err) => Some(err),
-        }
-    }
-}
-
 impl std::error::Error for RunStratagemValidationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
-    }
-}
-
-impl From<std::num::ParseIntError> for ImlManagerCliError {
-    fn from(err: std::num::ParseIntError) -> Self {
-        ImlManagerCliError::IntParseError(err)
-    }
-}
-
-impl From<DurationParseError> for ImlManagerCliError {
-    fn from(err: DurationParseError) -> Self {
-        ImlManagerCliError::ParseDurationError(err)
-    }
-}
-
-impl From<tokio::time::Error> for ImlManagerCliError {
-    fn from(err: tokio::time::Error) -> Self {
-        ImlManagerCliError::TokioTimerError(err)
-    }
-}
-
-impl From<tokio::task::JoinError> for ImlManagerCliError {
-    fn from(err: tokio::task::JoinError) -> Self {
-        ImlManagerCliError::TokioJoinError(err)
-    }
-}
-
-impl From<iml_manager_client::ImlManagerClientError> for ImlManagerCliError {
-    fn from(err: iml_manager_client::ImlManagerClientError) -> Self {
-        ImlManagerCliError::ClientRequestError(err)
-    }
-}
-
-impl From<RunStratagemValidationError> for ImlManagerCliError {
-    fn from(err: RunStratagemValidationError) -> Self {
-        ImlManagerCliError::RunStratagemValidationError(err)
-    }
-}
-
-impl From<serde_json::error::Error> for ImlManagerCliError {
-    fn from(err: serde_json::error::Error) -> Self {
-        ImlManagerCliError::SerdeJsonError(err)
-    }
-}
-
-impl From<std::io::Error> for ImlManagerCliError {
-    fn from(err: std::io::Error) -> Self {
-        ImlManagerCliError::IoError(err)
     }
 }
 
@@ -187,11 +125,5 @@ impl From<combine::stream::easy::Errors<char, &str, usize>> for ImlManagerCliErr
 impl From<Vec<Command>> for ImlManagerCliError {
     fn from(xs: Vec<Command>) -> Self {
         ImlManagerCliError::FailedCommandError(xs)
-    }
-}
-
-impl From<reqwest::Error> for ImlManagerCliError {
-    fn from(err: reqwest::Error) -> Self {
-        ImlManagerCliError::ReqwestError(err)
     }
 }

--- a/iml-manager-cli/src/lib.rs
+++ b/iml-manager-cli/src/lib.rs
@@ -7,6 +7,7 @@ pub mod display_utils;
 pub mod error;
 pub mod filesystem;
 pub mod ostpool;
+pub mod profile;
 pub mod server;
 pub mod stratagem;
 pub mod update_repo_file;

--- a/iml-manager-cli/src/profile.rs
+++ b/iml-manager-cli/src/profile.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{
+    api_utils::get_all,
+    display_utils::{display_success, generate_table, wrap_fut},
+    error::ImlManagerCliError,
+};
+use iml_orm::{profile, repo, tokio_diesel::AsyncRunQueryDsl as _};
+use iml_wire_types::{ApiList, ServerProfile};
+use std::io::{Error, ErrorKind};
+use structopt::StructOpt;
+use tokio::io::{stdin, AsyncReadExt};
+
+#[derive(Debug, StructOpt)]
+pub enum Cmd {
+    /// List all profiles
+    #[structopt(name = "list")]
+    List,
+    /// Load a new profile from stdin
+    #[structopt(name = "load")]
+    Load,
+    /// Remove an existing profile
+    #[structopt(name = "remove")]
+    Remove { name: String },
+}
+
+pub async fn cmd(cmd: Option<Cmd>) -> Result<(), ImlManagerCliError> {
+    match cmd {
+        None | Some(Cmd::List) => {
+            let profiles: ApiList<ServerProfile> =
+                wrap_fut("Fetching profiles...", get_all()).await?;
+
+            tracing::debug!("profiles: {:?}", profiles);
+
+            let table = generate_table(
+                &["Profile", "Name", "Description"],
+                profiles
+                    .objects
+                    .into_iter()
+                    .filter(|x| x.user_selectable)
+                    .map(|x| vec![x.name, x.ui_name, x.ui_description]),
+            );
+
+            table.printstd();
+        }
+        Some(Cmd::Load) => {
+            let pool = iml_orm::pool()?;
+
+            let mut buf: Vec<u8> = Vec::new();
+            stdin().read_to_end(&mut buf).await?;
+            let s = String::from_utf8_lossy(&buf);
+            let profile: profile::UserProfile = serde_json::from_str(&s)?;
+
+            let xs: Vec<repo::ChromaCoreRepo> = repo::ChromaCoreRepo::by_names(&profile.repolist)
+                .get_results_async(&pool)
+                .await?;
+
+            if &xs.len() != &profile.repolist.len() {
+                return Err(Error::new(
+                    ErrorKind::NotFound,
+                    format!("Repos not found for profile {}", profile.name),
+                )
+                .into());
+            }
+
+            profile::upsert_user_profile(profile, &pool).await?;
+
+            display_success("Profile loaded");
+        }
+        Some(Cmd::Remove { name }) => {
+            let pool = iml_orm::pool()?;
+
+            profile::remove_profile_by_name(name, &pool).await?;
+
+            display_success("Profile removed");
+        }
+    };
+
+    Ok(())
+}

--- a/iml-orm/src/lib.rs
+++ b/iml-orm/src/lib.rs
@@ -22,6 +22,12 @@ pub mod alerts;
 pub mod hosts;
 
 #[cfg(feature = "postgres-interop")]
+pub mod profile;
+
+#[cfg(feature = "postgres-interop")]
+pub mod repo;
+
+#[cfg(feature = "postgres-interop")]
 use diesel::{
     r2d2::{ConnectionManager, Pool},
     PgConnection,
@@ -34,6 +40,9 @@ pub type DbPool = Pool<ConnectionManager<diesel::PgConnection>>;
 
 #[cfg(feature = "postgres-interop")]
 pub use tokio_diesel;
+
+#[cfg(feature = "postgres-interop")]
+pub use r2d2;
 
 #[cfg(feature = "postgres-interop")]
 /// Get a new connection pool based on the envs connection string.

--- a/iml-orm/src/models.rs
+++ b/iml-orm/src/models.rs
@@ -1378,8 +1378,11 @@ pub struct ChromaCoreSendstratagemresultstoclientjob {
     pub filesystem_id: i32,
 }
 
-#[cfg_attr(feature = "postgres-interop", derive(Queryable, Debug, Identifiable))]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[cfg_attr(
+    feature = "postgres-interop",
+    derive(Queryable, Debug, Identifiable, Insertable, AsChangeset)
+)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 #[cfg_attr(feature = "postgres-interop", primary_key(name))]
 #[cfg_attr(feature = "postgres-interop", table_name = "chroma_core_serverprofile")]
 pub struct ChromaCoreServerprofile {

--- a/iml-orm/src/profile.rs
+++ b/iml-orm/src/profile.rs
@@ -1,0 +1,134 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+pub use crate::models::ChromaCoreServerprofile;
+use crate::{
+    schema::{
+        chroma_core_serverprofile as sp, chroma_core_serverprofile_repolist as rl,
+        chroma_core_serverprofilepackage as pl,
+    },
+    DbPool,
+};
+use diesel::{dsl, prelude::*};
+use std::collections::HashSet;
+use tokio_diesel::AsyncRunQueryDsl as _;
+
+pub type Table = sp::table;
+pub type Name = dsl::Eq<sp::name, String>;
+
+impl ChromaCoreServerprofile {
+    pub fn all() -> Table {
+        sp::table
+    }
+    pub fn with_name(name: impl ToString) -> Name {
+        sp::name.eq(name.to_string())
+    }
+}
+
+#[derive(serde::Deserialize)]
+pub struct UserProfile {
+    pub corosync: bool,
+    pub corosync2: bool,
+    pub initial_state: String,
+    pub managed: bool,
+    pub name: String,
+    pub ntp: bool,
+    pub pacemaker: bool,
+    pub packages: HashSet<String>,
+    pub repolist: HashSet<String>,
+    pub ui_description: String,
+    pub ui_name: String,
+    pub worker: bool,
+}
+
+impl From<UserProfile> for ChromaCoreServerprofile {
+    fn from(x: UserProfile) -> Self {
+        Self {
+            name: x.name,
+            ui_name: x.ui_name,
+            ui_description: x.ui_description,
+            managed: x.managed,
+            worker: x.worker,
+            user_selectable: true,
+            initial_state: x.initial_state,
+            ntp: x.ntp,
+            corosync: x.corosync,
+            corosync2: x.corosync2,
+            pacemaker: x.pacemaker,
+            default: false,
+        }
+    }
+}
+
+pub async fn remove_profile_by_name(
+    name: impl ToString,
+    pool: &DbPool,
+) -> Result<(), tokio_diesel::AsyncError> {
+    diesel::delete(rl::table)
+        .filter(rl::serverprofile_id.eq(name.to_string()))
+        .execute_async(&pool)
+        .await?;
+
+    diesel::delete(pl::table)
+        .filter(pl::server_profile_id.eq(name.to_string()))
+        .execute_async(&pool)
+        .await?;
+
+    diesel::delete(sp::table)
+        .filter(ChromaCoreServerprofile::with_name(name.to_string()))
+        .execute_async(&pool)
+        .await?;
+
+    Ok(())
+}
+
+pub async fn upsert_user_profile(
+    u: UserProfile,
+    pool: &DbPool,
+) -> Result<(), tokio_diesel::AsyncError> {
+    let name = u.name.clone();
+
+    let repos: Vec<_> = u
+        .repolist
+        .iter()
+        .cloned()
+        .map(|x| (rl::serverprofile_id.eq(name.clone()), rl::repo_id.eq(x)))
+        .collect();
+
+    let packages: Vec<_> = u
+        .packages
+        .iter()
+        .cloned()
+        .map(|x| {
+            (
+                pl::package_name.eq(x),
+                pl::server_profile_id.eq(name.clone()),
+            )
+        })
+        .collect();
+
+    let x = ChromaCoreServerprofile::from(u);
+
+    diesel::insert_into(sp::table)
+        .values(x.clone())
+        .on_conflict(sp::name)
+        .do_update()
+        .set(x)
+        .execute_async(pool)
+        .await?;
+
+    let repo_insert = diesel::insert_into(rl::table)
+        .values(repos)
+        .on_conflict_do_nothing()
+        .execute_async(pool);
+
+    let package_insert = diesel::insert_into(pl::table)
+        .values(packages)
+        .on_conflict_do_nothing()
+        .execute_async(pool);
+
+    futures::future::try_join(repo_insert, package_insert).await?;
+
+    Ok(())
+}

--- a/iml-orm/src/repo.rs
+++ b/iml-orm/src/repo.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+pub use crate::models::ChromaCoreRepo;
+use crate::schema::chroma_core_repo as r;
+use diesel::{dsl, prelude::*};
+
+pub type Table = r::table;
+pub type WithName = dsl::Eq<r::repo_name, String>;
+pub type WithNames = dsl::EqAny<r::repo_name, Vec<String>>;
+pub type ByName = dsl::Filter<Table, WithName>;
+pub type ByNames = dsl::Filter<Table, WithNames>;
+
+impl ChromaCoreRepo {
+    pub fn all() -> Table {
+        r::table
+    }
+    pub fn with_name(name: impl ToString) -> WithName {
+        r::repo_name.eq(name.to_string())
+    }
+    pub fn with_names<S: ToString>(xs: impl IntoIterator<Item = S>) -> WithNames {
+        let xs: Vec<_> = xs.into_iter().map(|x| x.to_string()).collect();
+
+        r::repo_name.eq_any(xs)
+    }
+    pub fn by_name(name: impl ToString) -> ByName {
+        Self::all().filter(Self::with_name(name))
+    }
+    pub fn by_names<S: ToString>(xs: impl IntoIterator<Item = S>) -> ByNames {
+        Self::all().filter(Self::with_names(xs))
+    }
+}


### PR DESCRIPTION
Add a new CLI command that will enable server profiles to be
loaded / removed post initial setup.

general format is:

```sh
cat profile.json > iml server profile load
```

and 

```sh
iml server profile remove <name>
```

Fixes #1680.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1821)
<!-- Reviewable:end -->
