### PR TITLE
Add device information to integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,7 @@ dependencies = [
  "iml-fs",
  "iml-systemd",
  "iml-wire-types",
+ "serde_json",
  "thiserror",
  "tokio",
 ]

--- a/iml-system-test-utils/Cargo.toml
+++ b/iml-system-test-utils/Cargo.toml
@@ -11,5 +11,6 @@ iml-cmd = { version = "0.2.0", path = "../iml-cmd" }
 iml-fs = { version = "0.2", path = "../iml-fs" }
 iml-systemd = { version = "0.2.0", path = "../iml-systemd" }
 iml-wire-types = { version = "0.2.0", path = "../iml-wire-types" }
+serde_json = "1.0"
 tokio = {version="0.2", features=["process", "macros", "fs"]}
 thiserror = "1.0"


### PR DESCRIPTION
Add device information loaded into IML. This will allow the tests to
verify that the devices have been loaded before attempting to add
servers.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>