### PR TITLE
Always run sosreport at the end of any integration test

### DIFF
--- a/iml-system-test-utils/src/lib.rs
+++ b/iml-system-test-utils/src/lib.rs
@@ -148,9 +148,7 @@ pub trait WithSos {
 #[async_trait]
 impl<T: Into<SystemTestError> + Send> WithSos for Result<(), T> {
     async fn handle_test_result(self, hosts: &[&str], prefix: &str) -> Result<(), SystemTestError> {
-        if self.is_err() {
-            create_iml_diagnostics(hosts, prefix).await?;
-        }
+        create_iml_diagnostics(hosts, prefix).await?;
 
         self.map_err(|e| e.into())
     }

--- a/iml-system-test-utils/src/ssh.rs
+++ b/iml-system-test-utils/src/ssh.rs
@@ -21,6 +21,8 @@ pub async fn scp(from: String, to: String) -> Result<(), CmdError> {
 
     x.arg("-o")
         .arg("StrictHostKeyChecking=no")
+        .arg("-o")
+        .arg("UserKnownHostsFile=/dev/null")
         .arg("-i")
         .arg("./id_rsa")
         .arg(from)
@@ -51,6 +53,8 @@ pub async fn ssh_exec<'a, 'b>(host: &'a str, cmd: &'b str) -> Result<(&'a str, O
 
     x.arg("-o")
         .arg("StrictHostKeyChecking=no")
+        .arg("-o")
+        .arg("UserKnownHostsFile=/dev/null")
         .arg("-i")
         .arg("id_rsa")
         .arg("-o")
@@ -102,6 +106,8 @@ pub async fn ssh_script<'a, 'b>(
         .arg("id_rsa")
         .arg("-o")
         .arg("StrictHostKeyChecking=no")
+        .arg("-o")
+        .arg("UserKnownHostsFile=/dev/null")
         .arg(host)
         .arg("bash -s")
         .args(args)

--- a/iml-system-test-utils/src/ssh.rs
+++ b/iml-system-test-utils/src/ssh.rs
@@ -19,7 +19,9 @@ pub async fn scp(from: String, to: String) -> Result<(), CmdError> {
     let mut x = Command::new("scp");
     x.current_dir(path);
 
-    x.arg("-i")
+    x.arg("-o")
+        .arg("StrictHostKeyChecking=no")
+        .arg("-i")
         .arg("./id_rsa")
         .arg(from)
         .arg(to)
@@ -47,7 +49,9 @@ pub async fn ssh_exec<'a, 'b>(host: &'a str, cmd: &'b str) -> Result<(&'a str, O
     let mut x = Command::new("ssh");
     x.current_dir(path);
 
-    x.arg("-i")
+    x.arg("-o")
+        .arg("StrictHostKeyChecking=no")
+        .arg("-i")
         .arg("id_rsa")
         .arg("-o")
         .arg("StrictHostKeyChecking=no")

--- a/vagrant/scripts/create_iml_diagnostics.sh
+++ b/vagrant/scripts/create_iml_diagnostics.sh
@@ -3,7 +3,8 @@
 PREFIX=$1
 
 # Clean out any existing sos reports on this node
+yum install -y sos
 rm -f /var/tmp/*sosreport*
-iml-diagnostics
+sosreport --batch
 cd /var/tmp || exit 1
 for f in *sosreport*.tar.xz; do mv "$f" "$PREFIX"_"$f"; done


### PR DESCRIPTION
sosreport should be run after every integration test. In addition, it
should be changed from `iml-diagnostics` to `sosreport --batch`.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1840)
<!-- Reviewable:end -->
