### PR TITLE
Make settings populator call atomic

### DIFF
--- a/iml-settings-populator.service
+++ b/iml-settings-populator.service
@@ -5,5 +5,7 @@ After=postgresql-9.6.service
 
 [Service]
 WorkingDirectory=/usr/share/chroma-manager
-ExecStart=/bin/bash -c "exec /bin/python ./manage.py print-settings > /var/lib/chroma/iml-settings.conf"
+ExecStart=/bin/bash -c "exec /bin/python ./manage.py print-settings > /tmp/temp-settings.conf"
+ExecStart=mv /tmp/temp-settings.conf /var/lib/chroma/iml-settings.conf
+ExecStart=rm /tmp/temp-settings.conf
 Type=oneshot

--- a/iml-settings-populator.service
+++ b/iml-settings-populator.service
@@ -5,7 +5,5 @@ After=postgresql-9.6.service
 
 [Service]
 WorkingDirectory=/usr/share/chroma-manager
-ExecStart=/bin/bash -c "exec /bin/python ./manage.py print-settings > /tmp/temp-settings.conf"
-ExecStart=mv /tmp/temp-settings.conf /var/lib/chroma/iml-settings.conf
-ExecStart=rm /tmp/temp-settings.conf
+ExecStart=/bin/bash -c "/bin/python ./manage.py print-settings > /tmp/temp-settings.conf && mv /tmp/temp-settings.conf /var/lib/chroma/iml-settings.conf"
 Type=oneshot


### PR DESCRIPTION
The iml-settings file should be generated in a way that is atomic.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1847)
<!-- Reviewable:end -->
