### PR TITLE
Always show the command_details button for commands

### DIFF
--- a/iml-gui/crate/src/page/activity.rs
+++ b/iml-gui/crate/src/page/activity.rs
@@ -318,19 +318,15 @@ fn alert_item_view(
                 empty![]
             }
         ],
-        if let Some(end) = alert.end.as_ref() {
-            vec![
-                div![
-                    class![C.row_span_1, C.col_span_2, C.whitespace_no_wrap],
-                    "Ended",
-                    " ",
-                    date_view(sd, end)
-                ],
-                command_details_button(alert),
-            ]
-        } else {
-            vec![]
-        }
+        div![
+            class![C.row_span_1, C.col_span_2, C.whitespace_no_wrap],
+            if let Some(end) = alert.end.as_ref() {
+                span!["Ended ", date_view(sd, end)]
+            } else {
+                empty![]
+            }
+        ],
+        command_details_button(alert),
     ]
 }
 


### PR DESCRIPTION
When a command is active we should be able to click the button in the
activity sidebar to see it's status.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1856)
<!-- Reviewable:end -->
