### PR TITLE
Update Lustre to 2.12.4

### DIFF
--- a/lustre-client-mlnx.repo
+++ b/lustre-client-mlnx.repo
@@ -1,6 +1,6 @@
 [lustre-client-mlnx]
 name=Lustre Client with Mellanox Support
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.3-ib/MOFED-4.7-1.0.0.1/el7/client/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4-ib/MOFED-4.7-3.2.9.0/el$releasever/client/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/lustre-client.repo
+++ b/lustre-client.repo
@@ -1,6 +1,6 @@
 [lustre-client]
 name=Lustre Client
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.3/el7/client/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4/el$releasever/client/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/lustre-server-mlnx.repo
+++ b/lustre-server-mlnx.repo
@@ -1,13 +1,13 @@
 [lustre]
 name=Lustre Server
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.3-ib/MOFED-4.7-1.0.0.1/el7/server/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4-ib/MOFED-4.7-3.2.9.0/el$releasever/server/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0
 
 [e2fsprogs]
 name=Lustre e2fsprogs
-baseurl=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
+baseurl=https://downloads.whamcloud.com/public/e2fsprogs/latest/el$releasever/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/lustre-server-patchless.repo
+++ b/lustre-server-patchless.repo
@@ -1,6 +1,6 @@
 [lustre]
 name=Lustre Server
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.3/el7/patchless-ldiskfs-server/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4/el7/patchless-ldiskfs-server/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0
@@ -13,7 +13,7 @@ gpgcheck=0
 repo_gpgcheck=0
 
 [zfs-kmod]
-name=ZFS on Linux for EL7 - kmod
+name=ZFS 0.7.x on Linux for EL7 - kmod
 baseurl=http://download.zfsonlinux.org/epel/7.6/kmod/$basearch/
 enabled=1
 metadata_expire=7d

--- a/lustre-server.repo
+++ b/lustre-server.repo
@@ -1,13 +1,13 @@
 [lustre]
 name=Lustre Server
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.3/el7/server/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4/el$releasever/server/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0
 
 [e2fsprogs]
 name=Lustre e2fsprogs
-baseurl=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
+baseurl=https://downloads.whamcloud.com/public/e2fsprogs/latest/el$releasever/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0


### PR DESCRIPTION
Also set $releasever in place of 7 in most places.
Patchless still NEEDS to be 7, because of ZFS 0.7.x only tracked on 7.6 kmod.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1866)
<!-- Reviewable:end -->
