### PR TITLE
Use mock to perform local builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -34,7 +34,10 @@ substs: $(SUBSTS)
 	chmod +x $(SUBSTS_SHELL)
 
 srpm:
-	yum install -y postgresql96-devel
+	if ! rpm -q postgresql96-devel 2> /dev/null; then \
+		yum install -y postgresql96-devel; \
+	fi
+
 	mkdir -p ${TMPDIR}/_topdir/{SOURCES,SPECS}
 	mkdir -p ${TMPDIR}/release/rust-iml
 	PQ_LIB_DIR=/usr/pgsql-9.6/lib cargo build --release

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -1,26 +1,123 @@
-#!/bin/bash
+set -x
 
-set -ex
+yum install -y mock-1.2.17
 
-yum copr enable -y managerforlustre/manager-for-lustre-devel
-yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-yum install -y rpm-build git ed epel-release python-setuptools gcc openssl-devel postgresql96-devel
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-source $HOME/.cargo/env
-rustup update
-rustc --version
-cargo --version
-cd /integrated-manager-for-lustre
+set +e
 
-make local
+useradd mocker
+usermod -a -G mock mocker
+
+set -e
+
+cat << EOF > /etc/mock/iml.cfg
+config_opts['root'] = 'epel-7-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
+config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '7'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+mdpolicy=group:primary
+
+# repos
+[base]
+name=BaseOS
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os
+failovermethod=priority
+gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+
+[updates]
+name=updates
+enabled=1
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=updates
+failovermethod=priority
+gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+
+[epel]
+name=epel
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=x86_64
+failovermethod=priority
+gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-EPEL-7
+gpgcheck=1
+
+[extras]
+name=extras
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=extras
+failovermethod=priority
+gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-EPEL-7
+gpgcheck=1
+
+[testing]
+name=epel-testing
+enabled=0
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel7&arch=x86_64
+failovermethod=priority
+
+
+[local]
+name=local
+baseurl=http://kojipkgs.fedoraproject.org/repos/epel7-build/latest/x86_64/
+cost=2000
+enabled=0
+
+[epel-debug]
+name=epel-debug
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-7&arch=x86_64
+failovermethod=priority
+enabled=0
+
+[pgdg96]
+name=PostgreSQL 9.6 for RHEL/CentOS $releasever - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG
+
+[copr:copr.fedorainfracloud.org:managerforlustre:buildtools]
+name=Copr repo for buildtools owned by managerforlustre
+baseurl=https://download.copr.fedorainfracloud.org/results/managerforlustre/buildtools/epel-7-x86_64/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/managerforlustre/buildtools/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+"""
+EOF
+
+rm -rf /tmp/iml/_topdir/
+
+su -l mocker << EOF
+mock -r /etc/mock/iml.cfg --init
+mock -r /etc/mock/iml.cfg --copyin /integrated-manager-for-lustre /iml
+mock -r /etc/mock/iml.cfg -i cargo git ed epel-release python-setuptools gcc openssl-devel postgresql96-devel python2-devel python2-setuptools ed
+mock -r /etc/mock/iml.cfg --shell 'cd /iml && make local'
+mock -r /etc/mock/iml.cfg --copyout /iml/_topdir /tmp/iml/_topdir
+mock -r /etc/mock/iml.cfg --copyout /iml/chroma_support.repo /tmp/iml/
+EOF
 
 rm -rf /tmp/{manager,agent}-rpms
 mkdir -p /tmp/{manager,agent}-rpms
 
-cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-{action-runner,agent-comms,api,cli,mailbox,ntp,ostpool,postoffice,stats,device,warp-drive}-*.rpm /tmp/manager-rpms/
-cp /integrated-manager-for-lustre/_topdir/RPMS/noarch/python2-iml-manager-*.rpm /tmp/manager-rpms/
-cp /integrated-manager-for-lustre/_topdir/RPMS/x86_64/rust-iml-agent-[0-9]*.rpm /tmp/agent-rpms
-cp /integrated-manager-for-lustre/chroma_support.repo /etc/yum.repos.d/
+cp /tmp/iml/_topdir/RPMS/rust-iml-{action-runner,agent-comms,api,cli,mailbox,ntp,ostpool,postoffice,stats,device,warp-drive}-*.rpm /tmp/manager-rpms/
+cp /tmp/iml/_topdir/RPMS/python2-iml-manager-*.rpm /tmp/manager-rpms/
+cp /tmp/iml/_topdir/RPMS/rust-iml-agent-[0-9]*.rpm /tmp/agent-rpms
+cp /tmp/iml/chroma_support.repo /etc/yum.repos.d/
 
 yum install -y /tmp/manager-rpms/*.rpm
 


### PR DESCRIPTION
Instead of building in the "global" namespace on the adm node,
we should build in a chroot to ensure that builds are reproducible
in a clean room env, do not require root, and do not pollute the adm
node.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1868)
<!-- Reviewable:end -->
