### PR TITLE
Service Queue: print debug string instead of vec

### DIFF
--- a/iml-services/iml-service-queue/src/service_queue.rs
+++ b/iml-services/iml-service-queue/src/service_queue.rs
@@ -78,7 +78,7 @@ pub fn consume_service_queue(
         .map_ok(|s| s.map_err(ImlServiceQueueError::from))
         .try_flatten_stream()
         .and_then(|m| {
-            tracing::debug!("Incoming message: {:?}", m.data);
+            tracing::debug!("Incoming message: {}", String::from_utf8_lossy(&m.data));
 
             future::ready(serde_json::from_slice(&m.data).map_err(ImlServiceQueueError::from))
         })


### PR DESCRIPTION
**BEFORE::**
```
DEBUG iml_service_queue::service_queue: Incoming message: [123, 34, 116, 121, 112, 101, 34, 58, 34, 83, 69, 83, 83, 73, 79, 78, 95, 67, 82, 69, 65, 84, 69, 34, 44, 34, 102, 113, 100, 110, 34, 58, 34, 111, 115, 115, 49, 46, 108, 111, 99, 97, 108, 34, 44, 34, 112, 108, 117, 103, 105, 110, 34, 58, 34, 100, 101, 118, 105, 99, 101, 34, 44, 34, 115, 101, 115, 115, 105, 111, 110, 95, 105, 100, 34, 58, 34, 54, 100, 52, 51, 98, 48, 48, 99, 45, 100, 54, 56, 53, 45, 52, 98, 55, 50, 45, 57, 99, 57, 50, 45, 53, 100, 49, 54, 100, 53, 99, 48, 99, 56, 99, 99, 34, 125]
```

**AFTER::**
```
DEBUG iml_service_queue::service_queue: Incoming message: {"type":"SESSION_CREATE","fqdn":"oss1.local","plugin":"device","session_id":"56973095-4bdc-490c-a6fe-16706531d580"}
```

Signed-off-by: Igor Pashev <pashev.igor@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1874)
<!-- Reviewable:end -->
