### PR TITLE
Optimize local builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,5 +1,6 @@
 BUILDROOT:=$(shell [ -d "/build" ] && echo "/build" || echo ".")
 TMPDIR:=$(shell mktemp -d)
+TARGET:=target
 
 MFL_COPR_REPO=managerforlustre/manager-for-lustre-devel
 MFL_REPO_OWNER := $(firstword $(subst /, ,$(MFL_COPR_REPO)))
@@ -41,7 +42,7 @@ srpm:
 	mkdir -p ${TMPDIR}/_topdir/{SOURCES,SPECS}
 	mkdir -p ${TMPDIR}/release/rust-iml
 	PQ_LIB_DIR=/usr/pgsql-9.6/lib cargo build --release
-	cp target/release/iml-{action-runner,agent,agent-comms,agent-daemon,api,mailbox,ntp,ostpool,postoffice,stats,device,warp-drive} \
+	cp ${TARGET}/release/iml-{action-runner,agent,agent-comms,agent-daemon,api,mailbox,ntp,ostpool,postoffice,stats,device,warp-drive} \
 		iml-agent-comms.service \
 		iml-mailbox.service \
 		iml-postoffice.service \
@@ -56,7 +57,7 @@ srpm:
 		iml-mailbox.conf \
 		iml-ntp.service \
 		${TMPDIR}/release/rust-iml
-	cp target/release/iml ${TMPDIR}/release/rust-iml
+	cp ${TARGET}/release/iml ${TMPDIR}/release/rust-iml
 	tar -czvf ${TMPDIR}/_topdir/SOURCES/rust-iml.tar.gz -C ${TMPDIR}/release/rust-iml .
 	cp rust-iml.spec ${TMPDIR}/_topdir/SPECS/
 	rpmbuild -bs -D "_topdir ${TMPDIR}/_topdir" ${TMPDIR}/_topdir/SPECS/rust-iml.spec

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,6 +1,6 @@
 BUILDROOT:=$(shell [ -d "/build" ] && echo "/build" || echo ".")
 TMPDIR:=$(shell mktemp -d)
-TARGET:=target
+TARGET:=$(or $(CARGO_TARGET_DIR),target)
 
 MFL_COPR_REPO=managerforlustre/manager-for-lustre-devel
 MFL_REPO_OWNER := $(firstword $(subst /, ,$(MFL_COPR_REPO)))

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -1,7 +1,6 @@
 set -x
 
-# Install both architectures of nosync per docs
-yum install -y mock-1.2.17 nosync.x86_64 nosync.i686
+yum install -y mock-1.2.17 nosync.x86_64
 
 set +e
 

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -121,7 +121,7 @@ su -l mocker << EOF
 mock -r /etc/mock/iml.cfg --init
 mock -r /etc/mock/iml.cfg --copyin /integrated-manager-for-lustre /iml
 mock -r /etc/mock/iml.cfg -i cargo git ed epel-release python-setuptools gcc openssl-devel postgresql96-devel python2-devel python2-setuptools ed
-mock -r /etc/mock/iml.cfg --shell 'export CARGO_HOME=/tmp/.cargo CARGO_TARGET_DIR=/tmp/target && cd /iml && make local TARGET=/tmp/target'
+mock -r /etc/mock/iml.cfg --shell 'export CARGO_HOME=/tmp/.cargo CARGO_TARGET_DIR=/tmp/target && cd /iml && make local'
 mock -r /etc/mock/iml.cfg --copyout /iml/_topdir /tmp/iml/_topdir
 mock -r /etc/mock/iml.cfg --copyout /iml/chroma_support.repo /tmp/iml/
 EOF

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -112,7 +112,7 @@ enabled_metadata=1
 """
 EOF
 
-if (! [ -f $old ]) || (! cmp --silent $old $new); then
+if { ! [ -f $old ]; } || { ! cmp --silent $old $new; } ; then
     mv $new $old;
 fi
 

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -1,6 +1,7 @@
 set -x
 
-yum install -y mock-1.2.17
+# Install both architectures of nosync per docs
+yum install -y mock-1.2.17 nosync.x86_64 nosync.i686
 
 set +e
 
@@ -26,6 +27,7 @@ config_opts['releasever'] = '7'
 config_opts['plugin_conf']['bind_mount_enable'] = True
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/home/mocker/.cargo', '/tmp/.cargo' ))
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/home/mocker/target', '/tmp/target' ))
+config_opts['nosync'] = True
 
 config_opts['yum.conf'] = """
 [main]

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -12,7 +12,10 @@ mkdir -p /home/mocker/target
 
 set -e
 
-cat << EOF > /etc/mock/iml.cfg
+new=/etc/mock/iml.cfg.new
+old=/etc/mock/iml.cfg
+
+cat << EOF > $new
 config_opts['root'] = 'epel-7-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
@@ -106,6 +109,10 @@ enabled=1
 enabled_metadata=1
 """
 EOF
+
+if (! [ -f $old ]) || (! cmp --silent $old $new); then
+    mv $new $old;
+fi
 
 rm -rf /tmp/iml/_topdir/
 

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -1,6 +1,6 @@
 set -x
 
-yum install -y mock-1.2.17 nosync.x86_64
+yum install -y mock-1.2.17 nosync
 
 set +e
 
@@ -111,7 +111,7 @@ enabled_metadata=1
 """
 EOF
 
-if { ! [ -f $old ]; } || { ! cmp --silent $old $new; } ; then
+if ! cmp --silent $old $new; then
     mv $new $old;
 fi
 


### PR DESCRIPTION
Bring down `install-iml-local` with hot no-op rebuild to ~4 minutes instead of ~13 minutes.

Fixes #1873 
Fixes #1880

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1881)
<!-- Reviewable:end -->
