### PR TITLE
Add `Executable` trait to iml-orm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,7 +1429,6 @@ version = "0.2.0"
 dependencies = [
  "chrono",
  "diesel",
- "futures",
  "iml-manager-env",
  "iml-wire-types",
  "ipnetwork",

--- a/iml-manager-cli/src/profile.rs
+++ b/iml-manager-cli/src/profile.rs
@@ -80,14 +80,24 @@ pub async fn cmd(cmd: Option<Cmd>) -> Result<(), ImlManagerCliError> {
                 .into());
             }
 
-            profile::upsert_user_profile(profile, &pool).await?;
+            let (e1, e2, e3) = profile::upsert_user_profile(profile);
+
+            e1.execute_async(&pool).await?;
+
+            futures::future::try_join(e2.execute_async(&pool), e3.execute_async(&pool)).await?;
 
             display_success("Profile loaded");
         }
         Some(Cmd::Remove { name }) => {
             let pool = iml_orm::pool()?;
 
-            profile::remove_profile_by_name(name, &pool).await?;
+            let (e1, e2, e3) = profile::remove_profile_by_name(name);
+
+            e1.execute_async(&pool).await?;
+
+            e2.execute_async(&pool).await?;
+
+            e3.execute_async(&pool).await?;
 
             display_success("Profile removed");
         }

--- a/iml-orm/Cargo.toml
+++ b/iml-orm/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "1.4", default_features = false, features = ["postgres", "r2d2", "chrono", "serde_json"], optional = true }
-futures = { version = "0.3", optional = true }
 iml-manager-env = { path = "../iml-manager-env", version = "0.2.0", optional = true }
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
 ipnetwork = "0.16"
@@ -17,5 +16,5 @@ serde_json = "1.0"
 tokio-diesel = { git = "https://github.com/jgrund/tokio-diesel", optional = true }
 
 [features]
-postgres-interop = ["diesel", "iml-manager-env", "r2d2", "tokio-diesel", "futures"]
+postgres-interop = ["diesel", "iml-manager-env", "r2d2", "tokio-diesel"]
 wasm = ["chrono/wasmbind"]

--- a/iml-orm/src/lib.rs
+++ b/iml-orm/src/lib.rs
@@ -29,11 +29,27 @@ pub mod repo;
 
 #[cfg(feature = "postgres-interop")]
 use diesel::{
+    prelude::RunQueryDsl,
+    query_builder::{QueryFragment, QueryId},
     r2d2::{ConnectionManager, Pool},
     PgConnection,
 };
 #[cfg(feature = "postgres-interop")]
 use iml_manager_env::get_db_conn_string;
+
+#[cfg(feature = "postgres-interop")]
+/// Allows for a generic return type for Insert statements, that can be used in either a sync or async
+/// context.
+pub trait Executable:
+    RunQueryDsl<diesel::PgConnection> + QueryFragment<diesel::pg::Pg> + QueryId
+{
+}
+
+#[cfg(feature = "postgres-interop")]
+impl<T> Executable for T where
+    T: RunQueryDsl<diesel::PgConnection> + QueryFragment<diesel::pg::Pg> + QueryId
+{
+}
 
 #[cfg(feature = "postgres-interop")]
 pub type DbPool = Pool<ConnectionManager<diesel::PgConnection>>;

--- a/iml-services/iml-ntp/src/main.rs
+++ b/iml-services/iml-ntp/src/main.rs
@@ -49,8 +49,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         AlertRecordType::UnknownTimeSyncAlert,
                     ],
                     host.id,
-                    &pool,
                 )
+                .execute_async(&pool)
                 .await?;
             }
             State::None => {
@@ -61,18 +61,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         AlertRecordType::UnknownTimeSyncAlert,
                     ],
                     host.id,
-                    &pool,
                 )
+                .execute_async(&pool)
                 .await?;
 
                 if host.is_setup() {
                     alerts::raise(
                         AlertRecordType::NoTimeSyncAlert,
-                        &format!("No running time sync clients found on {}", fqdn),
+                        format!("No running time sync clients found on {}", fqdn),
                         host.content_type_id.expect("Host has no content_type_id"),
                         host.id,
-                        &pool,
                     )
+                    .execute_async(&pool)
                     .await?;
                 }
             }
@@ -84,18 +84,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         AlertRecordType::UnknownTimeSyncAlert,
                     ],
                     host.id,
-                    &pool,
                 )
+                .execute_async(&pool)
                 .await?;
 
                 if host.is_setup() {
                     alerts::raise(
                         AlertRecordType::MultipleTimeSyncAlert,
-                        &format!("Multiple running time sync clients found on {}", fqdn),
+                        format!("Multiple running time sync clients found on {}", fqdn),
                         host.content_type_id.expect("Host has no content_type_id"),
                         host.id,
-                        &pool,
                     )
+                    .execute_async(&pool)
                     .await?;
                 }
             }
@@ -107,18 +107,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         AlertRecordType::UnknownTimeSyncAlert,
                     ],
                     host.id,
-                    &pool,
                 )
+                .execute_async(&pool)
                 .await?;
 
                 if host.is_setup() {
                     alerts::raise(
                         AlertRecordType::TimeOutOfSyncAlert,
-                        &format!("Time is out of sync on server {}", fqdn),
+                        format!("Time is out of sync on server {}", fqdn),
                         host.content_type_id.expect("Host has no content_type_id"),
                         host.id,
-                        &pool,
                     )
+                    .execute_async(&pool)
                     .await?;
                 }
             }
@@ -130,18 +130,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         AlertRecordType::TimeOutOfSyncAlert,
                     ],
                     host.id,
-                    &pool,
                 )
+                .execute_async(&pool)
                 .await?;
 
                 if host.is_setup() {
                     alerts::raise(
                         AlertRecordType::UnknownTimeSyncAlert,
-                        &format!("Unable to determine time sync status on {}", fqdn),
+                        format!("Unable to determine time sync status on {}", fqdn),
                         host.content_type_id.expect("Host has no content_type_id"),
                         host.id,
-                        &pool,
                     )
+                    .execute_async(&pool)
                     .await?;
                 }
             }


### PR DESCRIPTION
Add a new trait `Executable` that can be used as a return for Insert (Upsert)
statements.

This trait allows the execution of the insert to be decoupled from the
actual statement, which means the statements can be reused in both
transactional / non-transactional contexts.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1889)
<!-- Reviewable:end -->
