### PR TITLE
Use experimental build cache for rust-base.dockerfile

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,15 +6,11 @@ clean:
 	docker system prune -f --all --volumes
 	rm -rf iml-images.tar.gz
 
-build: clean
-	DOCKER_BUILDKIT=1 docker build -t imlteam/python-service-base:6.2.0-dev -f python-service-base.dockerfile ../
-	DOCKER_BUILDKIT=1 docker build -t imlteam/systemd-base:6.2.0-dev -f systemd-base.dockerfile ../
-	DOCKER_BUILDKIT=1 docker build -t rust-iml-base -f rust-base.dockerfile ../
-	DOCKER_BUILDKIT=1 docker build -t rust-iml-gui -f iml-gui.dockerfile ../
-	DOCKER_BUILDKIT=1 docker build -t imlteam/rust-service-base:6.2.0-dev -f rust-service-base.dockerfile ../
-	COMPOSE_DOCKER_CLI_BUILD=1 docker-compose build
+build:
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx bake -f compose-deps.hcl
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx bake -f docker-compose.yml
+	COMPOSE_DOCKER_CLI_BUILD=1 docker-compose pull postgres update-handler
 
 save: build
-	COMPOSE_DOCKER_CLI_BUILD=1 docker-compose pull postgres update-handler
 	docker save -o iml-images.tar $(COMPOSE_IMAGES)
 	gzip -9 < iml-images.tar > iml-images.tgz

--- a/docker/compose-deps.hcl
+++ b/docker/compose-deps.hcl
@@ -1,0 +1,34 @@
+group "default" {
+  targets = ["python-service-base", "systemd-base", "rust-base", "rust-service-base", "iml-gui"]
+}
+
+
+target "python-service-base" {
+  dockerfile = "docker/python-service-base.dockerfile"
+  context = "../"
+  tags = ["imlteam/python-service-base:6.2.0-dev"]
+}
+
+target "systemd-base" {
+  dockerfile = "docker/systemd-base.dockerfile"
+  context = "../"
+  tags = ["imlteam/systemd-base:6.2.0-dev"]
+}
+
+target "rust-base" {
+  dockerfile = "docker/rust-base.dockerfile"
+  context = "../"
+  tags = ["rust-iml-base"]
+}
+
+target "rust-service-base" {
+  dockerfile = "docker/rust-service-base.dockerfile"
+  context = "../"
+  tags = ["imlteam/rust-service-base:6.2.0-dev"]
+}
+
+target "iml-gui" {
+  dockerfile = "docker/iml-gui.dockerfile"
+  context = "../"
+  tags = ["rust-iml-gui"]
+}

--- a/docker/iml-gui.dockerfile
+++ b/docker/iml-gui.dockerfile
@@ -1,4 +1,6 @@
-FROM rust:1.44 as builder
+# syntax=docker/dockerfile:experimental
+
+FROM rust:1.45 as builder
 WORKDIR /build
 COPY . .
 RUN rustup target add wasm32-unknown-unknown && \
@@ -9,10 +11,19 @@ RUN rustup target add wasm32-unknown-unknown && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update -y && \
-    apt-get install -y yarn nodejs && \
-    cd /build/iml-gui && \
-    yarn install && \
-    yarn build:release;
+    apt-get install -y yarn nodejs
+
+ENV SCCACHE_CACHE_SIZE="40G"
+ENV SCCACHE_DIR /.cache/sccache
+ENV RUSTC_WRAPPER="sccache"
+
+RUN wget https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz \
+    && tar -xzvf sccache-*-x86_64-unknown-linux-musl.tar.gz \
+    && mv sccache-*-x86_64-unknown-linux-musl/sccache /usr/bin \
+    && rm -rf sccache-*-x86_64-unknown-linux-musl*
+RUN --mount=type=cache,dst=/.cache/sccache cd /build/iml-gui \
+    && yarn install \
+    && yarn build:release
 
 FROM ubuntu
 COPY --from=builder /build/iml-gui/dist /usr/share/iml-manager/rust-iml-gui

--- a/docker/rust-base.dockerfile
+++ b/docker/rust-base.dockerfile
@@ -1,17 +1,27 @@
+# syntax=docker/dockerfile:experimental
+
 FROM centos:7
 WORKDIR /build
-ARG toolchain=stable
 RUN yum update -y \
   && yum install -y gcc openssl openssl-devel epel-release https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
   && yum clean all \
-  && yum install -y postgresql96-devel \
-  && yum clean all \
-  && cd /root \
-  && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $toolchain
+  && yum install -y postgresql96-devel cargo wget \
+  && yum clean all
+RUN wget https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz \
+  && tar -xzvf sccache-*-x86_64-unknown-linux-musl.tar.gz \
+  && mv sccache-*-x86_64-unknown-linux-musl/sccache /usr/bin \
+  && rm -rf sccache-*-x86_64-unknown-linux-musl*
 
+ENV PQ_LIB_DIR=/usr/pgsql-9.6/lib
 ENV PATH $PATH:/root/.cargo/bin
 ENV CARGO_HOME /root/.cargo
 ENV RUSTUP_HOME /root/.rustup
-ENV PQ_LIB_DIR=/usr/pgsql-9.6/lib
+ENV SCCACHE_CACHE_SIZE="40G"
+ENV SCCACHE_DIR /.cache/sccache
+ENV RUSTC_WRAPPER="sccache"
+
 COPY . .
-RUN cargo build --release
+RUN --mount=type=cache,dst=/.cache/sccache \
+  cargo build --release --target-dir=/root/target \
+  && mkdir -p /build/target/release \
+  && cp -R /root/target/release/* /build/target/release/


### PR DESCRIPTION
Use the experimental build cache for the `rust-base.dockerfile`.

This will reuse caches between builds, allow for incremental
compilation, and should speed up Jenkins builds a bit.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1893)
<!-- Reviewable:end -->
