### PR TITLE
Race between agent and manager to resolve action

### DIFF
--- a/iml-services/iml-action-runner/src/data.rs
+++ b/iml-services/iml-action-runner/src/data.rs
@@ -104,6 +104,12 @@ pub fn insert_action_in_flight(
     action: ActionInFlight,
     session_to_rpcs: &mut SessionToRpcs,
 ) {
+    tracing::debug!(
+        "Inserting new ActionInFlight with id {:?} and action_id {:?}",
+        id,
+        action_id
+    );
+
     let rpcs = session_to_rpcs.entry(id).or_insert_with(HashMap::new);
 
     rpcs.insert(action_id, action);
@@ -133,6 +139,12 @@ pub fn remove_action_in_flight<'a>(
     action_id: &ActionId,
     session_to_rpcs: &'a mut SessionToRpcs,
 ) -> Option<ActionInFlight> {
+    tracing::debug!(
+        "Removing ActionInFlight with id {:?} and action_id {:?}",
+        id,
+        action_id
+    );
+
     session_to_rpcs
         .get_mut(id)
         .and_then(|rpcs| rpcs.remove(action_id))


### PR DESCRIPTION
The `iml-action-runner` service will put a new message onto the queue
before adding it to the internal bookkeeping table of RPCs in flight.

This opens the very small possibility that the RPC can complete before
the action runner can add it to the internal RPC table.

When this occurs, the RPC is never resolved to the caller and ends up
hanging since it looks like like an unknown response to the
action-runner.

Fixes #1870.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1894)
<!-- Reviewable:end -->
