### PR TITLE
Extract the pool filter to iml-orm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,9 +318,9 @@ checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "cc"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
+checksum = "404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c"
 
 [[package]]
 name = "cexpr"
@@ -780,9 +780,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -1435,13 +1435,17 @@ version = "0.2.0"
 dependencies = [
  "chrono",
  "diesel",
+ "futures",
  "iml-manager-env",
  "iml-wire-types",
  "ipnetwork",
  "r2d2",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio-diesel",
+ "tracing",
+ "warp",
 ]
 
 [[package]]
@@ -2218,9 +2222,9 @@ checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 
 [[package]]
 name = "once_cell"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 
 [[package]]
 name = "opaque-debug"
@@ -3628,9 +3632,9 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1721cc8cf7d770cc4257872507180f35a4797272f5962f24c806af9e7faf52ab"
+checksum = "a7c6b59d116d218cb2d990eb06b77b64043e0268ef7323aae63d8b30ae462923"
 dependencies = [
  "cfg-if",
  "tracing-attributes",
@@ -3639,10 +3643,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
+checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
 dependencies = [
+ "proc-macro2 1.0.12",
  "quote 1.0.5",
  "syn 1.0.21",
 ]

--- a/iml-api/Cargo.toml
+++ b/iml-api/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 futures = "0.3"
 iml-job-scheduler-rpc = { path = "../iml-job-scheduler-rpc", version = "0.2" }
 iml-manager-env = { path = "../iml-manager-env", version = "0.2" }
-iml-orm = { path = "../iml-orm", version = "0.2" }
+iml-orm = { path = "../iml-orm", version = "0.2", features = ["warp-filters"] }
 iml-rabbit = { path = "../iml-rabbit", version = "0.2.0", features = ["warp-filters"] }
 iml-tracing = { version = "0.1", path="../iml-tracing"}
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }

--- a/iml-api/src/error.rs
+++ b/iml-api/src/error.rs
@@ -4,6 +4,7 @@
 
 use futures::channel::oneshot;
 use iml_job_scheduler_rpc::ImlJobSchedulerRpcError;
+use iml_orm::ImlOrmError;
 use iml_rabbit::{self, ImlRabbitError};
 use warp::reject;
 
@@ -11,7 +12,7 @@ use warp::reject;
 pub enum ImlApiError {
     ImlDieselAsyncError(iml_orm::tokio_diesel::AsyncError),
     ImlJobSchedulerRpcError(ImlJobSchedulerRpcError),
-    ImlR2D2Error(iml_orm::r2d2::Error),
+    ImlOrmError(ImlOrmError),
     ImlRabbitError(ImlRabbitError),
     NoneError,
     OneshotCanceled(oneshot::Canceled),
@@ -25,7 +26,7 @@ impl std::fmt::Display for ImlApiError {
         match *self {
             ImlApiError::ImlDieselAsyncError(ref err) => write!(f, "{}", err),
             ImlApiError::ImlJobSchedulerRpcError(ref err) => write!(f, "{}", err),
-            ImlApiError::ImlR2D2Error(ref err) => write!(f, "{}", err),
+            ImlApiError::ImlOrmError(ref err) => write!(f, "{}", err),
             ImlApiError::ImlRabbitError(ref err) => write!(f, "{}", err),
             ImlApiError::NoneError => write!(f, "Not Found"),
             ImlApiError::OneshotCanceled(ref err) => write!(f, "{}", err),
@@ -39,7 +40,7 @@ impl std::error::Error for ImlApiError {
         match *self {
             ImlApiError::ImlDieselAsyncError(ref err) => Some(err),
             ImlApiError::ImlJobSchedulerRpcError(ref err) => Some(err),
-            ImlApiError::ImlR2D2Error(ref err) => Some(err),
+            ImlApiError::ImlOrmError(ref err) => Some(err),
             ImlApiError::ImlRabbitError(ref err) => Some(err),
             ImlApiError::NoneError => None,
             ImlApiError::OneshotCanceled(ref err) => Some(err),
@@ -51,12 +52,6 @@ impl std::error::Error for ImlApiError {
 impl From<iml_orm::tokio_diesel::AsyncError> for ImlApiError {
     fn from(err: iml_orm::tokio_diesel::AsyncError) -> Self {
         ImlApiError::ImlDieselAsyncError(err)
-    }
-}
-
-impl From<iml_orm::r2d2::Error> for ImlApiError {
-    fn from(err: iml_orm::r2d2::Error) -> Self {
-        ImlApiError::ImlR2D2Error(err)
     }
 }
 
@@ -75,6 +70,12 @@ impl From<serde_json::error::Error> for ImlApiError {
 impl From<oneshot::Canceled> for ImlApiError {
     fn from(err: oneshot::Canceled) -> Self {
         ImlApiError::OneshotCanceled(err)
+    }
+}
+
+impl From<ImlOrmError> for ImlApiError {
+    fn from(err: ImlOrmError) -> Self {
+        ImlApiError::ImlOrmError(err)
     }
 }
 

--- a/iml-manager-cli/src/error.rs
+++ b/iml-manager-cli/src/error.rs
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use iml_orm::{r2d2, tokio_diesel};
+use iml_orm::tokio_diesel;
 use iml_wire_types::Command;
 use thiserror::Error;
 
@@ -63,10 +63,10 @@ pub enum ImlManagerCliError {
     CombineEasyError(combine::stream::easy::Errors<char, &'static str, usize>),
     DoesNotExist(&'static str),
     FailedCommandError(Vec<Command>),
+    ImlOrmError(#[from] iml_orm::ImlOrmError),
     IntParseError(#[from] std::num::ParseIntError),
     IoError(#[from] std::io::Error),
     ParseDurationError(#[from] DurationParseError),
-    R2D2Error(#[from] r2d2::Error),
     ReqwestError(#[from] reqwest::Error),
     RunStratagemValidationError(#[from] RunStratagemValidationError),
     SerdeJsonError(#[from] serde_json::error::Error),
@@ -90,7 +90,7 @@ impl std::fmt::Display for ImlManagerCliError {
 
                 write!(f, "{}", failed_msg)
             }
-            ImlManagerCliError::R2D2Error(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::ImlOrmError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::IntParseError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::IoError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::ParseDurationError(ref err) => write!(f, "{}", err),

--- a/iml-orm/Cargo.toml
+++ b/iml-orm/Cargo.toml
@@ -7,14 +7,19 @@ edition = "2018"
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "1.4", default_features = false, features = ["postgres", "r2d2", "chrono", "serde_json"], optional = true }
+futures = "0.3"
 iml-manager-env = { path = "../iml-manager-env", version = "0.2.0", optional = true }
 iml-wire-types = { path = "../iml-wire-types", version = "0.2" }
 ipnetwork = "0.16"
 r2d2 = {version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "1.0"
 tokio-diesel = { git = "https://github.com/jgrund/tokio-diesel", optional = true }
+tracing = { version = "0.1", optional = true }
+warp = { version = "0.2", optional = true }
 
 [features]
 postgres-interop = ["diesel", "iml-manager-env", "r2d2", "tokio-diesel"]
 wasm = ["chrono/wasmbind"]
+warp-filters = ["tracing", "warp"]

--- a/iml-orm/src/fidtaskqueue.rs
+++ b/iml-orm/src/fidtaskqueue.rs
@@ -22,7 +22,7 @@ pub async fn insert(
     data: serde_json::Value,
     task: &ChromaCoreTask,
     pool: &DbPool,
-) -> Result<(), tokio_diesel::AsyncError> {
+) -> Result<(), crate::ImlOrmError> {
     diesel::insert_into(chroma_core_fidtaskqueue::table)
         .values(NewFidTask {
             fid,

--- a/iml-orm/src/job.rs
+++ b/iml-orm/src/job.rs
@@ -49,10 +49,12 @@ impl ChromaCoreJob {
 pub async fn get_jobs_by_cmd(
     id: i32,
     pool: &DbPool,
-) -> Result<Vec<ChromaCoreJob>, tokio_diesel::AsyncError> {
+) -> Result<Vec<ChromaCoreJob>, crate::ImlOrmError> {
     let jobs: Vec<i32> = ChromaCoreCommandJob::jobs_by_cmd(id)
         .get_results_async(&pool)
         .await?;
 
-    ChromaCoreJob::by_ids(jobs).get_results_async(&pool).await
+    let x = ChromaCoreJob::by_ids(jobs).get_results_async(&pool).await?;
+
+    Ok(x)
 }

--- a/iml-orm/src/lib.rs
+++ b/iml-orm/src/lib.rs
@@ -42,6 +42,14 @@ pub mod step;
 #[cfg(feature = "postgres-interop")]
 pub mod task;
 
+use futures::channel::oneshot;
+use thiserror::Error;
+
+#[cfg(feature = "warp-filters")]
+use futures::{channel::mpsc, future, Future, StreamExt, TryFutureExt};
+#[cfg(feature = "warp-filters")]
+use warp::Filter;
+
 #[cfg(feature = "postgres-interop")]
 use diesel::{
     prelude::RunQueryDsl,
@@ -75,10 +83,71 @@ pub use tokio_diesel;
 #[cfg(feature = "postgres-interop")]
 pub use r2d2;
 
+#[derive(Debug, Error)]
+pub enum ImlOrmError {
+    #[error(transparent)]
+    R2D2Error(#[from] r2d2::Error),
+    #[error(transparent)]
+    OneshotCanceled(#[from] oneshot::Canceled),
+    #[error(transparent)]
+    AsyncError(#[from] tokio_diesel::AsyncError),
+}
+
+#[cfg(feature = "warp-filters")]
+impl warp::reject::Reject for ImlOrmError {}
+
 #[cfg(feature = "postgres-interop")]
 /// Get a new connection pool based on the envs connection string.
-pub fn pool() -> Result<DbPool, r2d2::Error> {
+pub fn pool() -> Result<DbPool, ImlOrmError> {
     let manager = ConnectionManager::<PgConnection>::new(get_db_conn_string());
 
-    Pool::builder().build(manager)
+    Pool::builder()
+        .build(manager)
+        .map_err(ImlOrmError::R2D2Error)
+}
+
+#[cfg(feature = "warp-filters")]
+type PoolSender = oneshot::Sender<DbPool>;
+
+#[cfg(feature = "warp-filters")]
+pub fn get_cloned_pool(
+    pool: DbPool,
+) -> (mpsc::UnboundedSender<PoolSender>, impl Future<Output = ()>) {
+    let (tx, rx) = mpsc::unbounded();
+
+    let fut = rx.for_each(move |sender: PoolSender| {
+        let _ = sender
+            .send(pool.clone())
+            .map_err(|_| tracing::info!("channel recv dropped before we could hand out a pool"));
+
+        future::ready(())
+    });
+
+    (tx, fut)
+}
+
+/// Creates a warp `Filter` that will hand out
+/// a cloned `DbPool` handle for each request.
+#[cfg(feature = "warp-filters")]
+pub async fn create_pool_filter() -> Result<
+    (
+        impl Future<Output = ()>,
+        impl Filter<Extract = (DbPool,), Error = warp::Rejection> + Clone,
+    ),
+    ImlOrmError,
+> {
+    let conn = pool()?;
+
+    let (tx, fut) = get_cloned_pool(conn);
+
+    let filter = warp::any().and_then(move || {
+        let (tx2, rx2) = oneshot::channel();
+
+        tx.unbounded_send(tx2).unwrap();
+
+        rx2.map_err(ImlOrmError::OneshotCanceled)
+            .map_err(warp::reject::custom)
+    });
+
+    Ok((fut, filter))
 }


### PR DESCRIPTION
Extract the warp pool filter to the iml-orm crate and put behind a
feature flag.

This way, we can use the filter in other crates that need a db pool
connection per request.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1904)
<!-- Reviewable:end -->
