### PR TITLE
Fix grafana repo

### DIFF
--- a/tests/framework/chroma_support.repo.in
+++ b/tests/framework/chroma_support.repo.in
@@ -39,6 +39,7 @@ baseurl=https://packages.grafana.com/oss/rpm
 repo_gpgcheck=1
 enabled=1
 gpgcheck=1
+exclude=grafana-enterprise
 gpgkey=https://packages.grafana.com/gpg.key
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/vagrant/scripts/install_iml_repouri.sh
+++ b/vagrant/scripts/install_iml_repouri.sh
@@ -36,6 +36,7 @@ baseurl=https://packages.grafana.com/oss/rpm
 repo_gpgcheck=1
 enabled=1
 gpgcheck=1
+exclude=grafana-enterprise
 gpgkey=https://packages.grafana.com/gpg.key
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
Fixes #1905.

The grafana repo is now adding grafana-enterprise which is breaking IML
Installations. Exclude grafana-enterprise from the repo.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1906)
<!-- Reviewable:end -->
