### PR TITLE
Update how vm's are destroyed

### DIFF
--- a/iml-system-docker-tests/src/lib.rs
+++ b/iml-system-docker-tests/src/lib.rs
@@ -10,7 +10,7 @@ use tokio::time::delay_for;
 use tracing::Level;
 use tracing_subscriber::fmt::Subscriber;
 
-pub async fn setup() -> Result<(), SystemdError> {
+pub async fn setup(config: &vagrant::ClusterConfig) -> Result<(), SystemdError> {
     Subscriber::builder().with_max_level(Level::DEBUG).init();
 
     // remove the stack if it is running and clean up volumes and network
@@ -25,7 +25,7 @@ pub async fn setup() -> Result<(), SystemdError> {
     docker::set_password().await?;
 
     // Destroy any vagrant nodes that are currently running
-    vagrant::destroy().await?;
+    vagrant::destroy(config).await?;
     vagrant::global_prune().await?;
     vagrant::poweroff_running_vms().await?;
     vagrant::unregister_vms().await?;
@@ -40,7 +40,7 @@ pub async fn run_fs_test<S: std::hash::BuildHasher>(
     server_map: HashMap<String, &[&str], S>,
     fs_type: vagrant::FsType,
 ) -> Result<(), SystemdError> {
-    setup().await?;
+    setup(config).await?;
     docker::configure_docker_setup(&docker_setup).await?;
 
     docker::deploy_iml_stack().await?;

--- a/iml-system-rpm-tests/src/lib.rs
+++ b/iml-system-rpm-tests/src/lib.rs
@@ -9,10 +9,10 @@ use tokio::time::delay_for;
 use tracing::Level;
 use tracing_subscriber::fmt::Subscriber;
 
-pub async fn setup() -> Result<(), CmdError> {
+pub async fn setup(config: &vagrant::ClusterConfig) -> Result<(), CmdError> {
     Subscriber::builder().with_max_level(Level::DEBUG).init();
 
-    vagrant::destroy().await?;
+    vagrant::destroy(config).await?;
     vagrant::global_prune().await?;
     vagrant::poweroff_running_vms().await?;
     vagrant::unregister_vms().await?;
@@ -27,7 +27,7 @@ pub async fn run_fs_test<S: std::hash::BuildHasher>(
     server_map: HashMap<String, &[&str], S>,
     fs_type: vagrant::FsType,
 ) -> Result<(), CmdError> {
-    setup().await?;
+    setup(config).await?;
 
     vagrant::setup_deploy_servers(&config, &setup_config, server_map).await?;
 

--- a/iml-system-test-utils/src/vagrant.rs
+++ b/iml-system-test-utils/src/vagrant.rs
@@ -59,10 +59,10 @@ pub async fn destroy<'a>(config: &ClusterConfig) -> Result<(), CmdError> {
     nodes.reverse();
 
     for node in &nodes {
-        let mut halt_cmd = halt().await?;
-        halt_cmd.arg(node);
+        let mut suspend_cmd = suspend().await?;
+        suspend_cmd.arg(node);
 
-        try_command_n_times(3, 1, &mut halt_cmd).await?;
+        try_command_n_times(3, 1, &mut suspend_cmd).await?;
     }
 
     for node in &nodes {
@@ -78,6 +78,13 @@ pub async fn destroy<'a>(config: &ClusterConfig) -> Result<(), CmdError> {
 pub async fn halt() -> Result<Command, CmdError> {
     let mut x = vagrant().await?;
     x.arg("halt");
+
+    Ok(x)
+}
+
+pub async fn suspend() -> Result<Command, CmdError> {
+    let mut x = vagrant().await?;
+    x.arg("suspend");
 
     Ok(x)
 }

--- a/iml-system-test-utils/src/vagrant.rs
+++ b/iml-system-test-utils/src/vagrant.rs
@@ -55,8 +55,7 @@ pub async fn up<'a>() -> Result<Command, CmdError> {
 }
 
 pub async fn destroy<'a>(config: &ClusterConfig) -> Result<(), CmdError> {
-    let mut nodes = config.all();
-    nodes.reverse();
+    let nodes = config.destroy_list();
 
     for node in &nodes {
         let mut suspend_cmd = suspend().await?;
@@ -635,6 +634,12 @@ impl ClusterConfig {
         xs.extend(&self.client);
 
         xs
+    }
+    pub fn destroy_list(&self) -> Vec<&str> {
+        let mut to_destroy = self.all();
+        to_destroy.reverse();
+
+        to_destroy
     }
     pub fn all_but_adm(&self) -> Vec<&str> {
         let mut xs = vec![self.iscsi];

--- a/iml-system-test-utils/src/vagrant.rs
+++ b/iml-system-test-utils/src/vagrant.rs
@@ -54,12 +54,25 @@ pub async fn up<'a>() -> Result<Command, CmdError> {
     Ok(x)
 }
 
-pub async fn destroy<'a>() -> Result<(), CmdError> {
-    let mut x = vagrant().await?;
+pub async fn destroy<'a>(config: &ClusterConfig) -> Result<(), CmdError> {
+    let mut nodes = config.all();
+    nodes.reverse();
 
-    x.arg("destroy").arg("-f");
+    for node in &nodes {
+        let mut halt_cmd = halt().await?;
+        halt_cmd.arg(node);
 
-    try_command_n_times(3, 1, &mut x).await
+        try_command_n_times(3, 1, &mut halt_cmd).await?;
+    }
+
+    for node in &nodes {
+        let mut destroy_cmd = vagrant().await?;
+        destroy_cmd.arg("destroy").arg("-f").arg(node);
+
+        try_command_n_times(3, 1, &mut destroy_cmd).await?;
+    }
+
+    Ok(())
 }
 
 pub async fn halt() -> Result<Command, CmdError> {


### PR DESCRIPTION
Fixes #1907.

Halt all nodes and destroy one by one to prevent resource from hanging
on iscsi.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1909)
<!-- Reviewable:end -->
