### PR TITLE
Use Signed 32 bit integer type for ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0f3e2e8d7dba335e913b97f9e1992c86c4399d54f8be1d31c8727d0652064"
+checksum = "8c0994e656bba7b922d8dd1245db90672ffb701e684e45be58f20719d69abc5a"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -566,7 +566,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4aa86af7b19b40ef9cbef761ed411a49f0afa06b7b6dcd3dfe2f96a3c546138"
 dependencies = [
- "console 0.11.2",
+ "console 0.11.3",
  "lazy_static",
  "tempfile",
 ]
@@ -592,9 +592,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -752,9 +752,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9db393664b0e6c6230a14115e7e798f80b70f54038dc21165db24c6b7f28fc"
 dependencies = [
  "proc-macro-error 0.4.12",
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -876,9 +876,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
+checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "libc",
 ]
@@ -1200,7 +1200,7 @@ dependencies = [
  "byte-unit",
  "bytes",
  "chrono",
- "console 0.11.2",
+ "console 0.11.3",
  "dns-lookup",
  "dotenv",
  "elementtree",
@@ -1373,7 +1373,7 @@ name = "iml-manager-cli"
 version = "0.2.0"
 dependencies = [
  "combine",
- "console 0.11.2",
+ "console 0.11.3",
  "dialoguer",
  "dotenv",
  "futures",
@@ -1661,7 +1661,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a68371cf417889c9d7f98235b7102ea7c54fc59bcbd22f3dea785be9d27e40"
 dependencies = [
- "console 0.11.2",
+ "console 0.11.3",
  "lazy_static",
  "number_prefix",
  "regex",
@@ -2328,9 +2328,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -2403,22 +2403,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d480cb4e89522ccda96d0eed9af94180b7a5f93fb28f66e1fd7d68431663d1"
+checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82996f11efccb19b685b14b5df818de31c1edcee3daa256ab5775dd98e72feb"
+checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -2481,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "pq-sys"
@@ -2521,9 +2521,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
 dependencies = [
  "proc-macro-error-attr 0.4.12",
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
  "version_check 0.9.1",
 ]
 
@@ -2534,9 +2534,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr 1.0.2",
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
  "version_check 0.9.1",
 ]
 
@@ -2546,9 +2546,9 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
  "syn-mid",
  "version_check 0.9.1",
 ]
@@ -2559,9 +2559,9 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
  "syn-mid",
  "version_check 0.9.1",
 ]
@@ -2589,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -2629,11 +2629,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
- "proc-macro2 1.0.12",
+ "proc-macro2 1.0.13",
 ]
 
 [[package]]
@@ -3047,9 +3047,9 @@ version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -3069,9 +3069,9 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -3296,9 +3296,9 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error 1.0.2",
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -3336,12 +3336,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4696caa4048ac7ce2bcd2e484b3cef88c1004e41b8e945a277e2c25dc0b72060"
+checksum = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
  "unicode-xid 0.2.0",
 ]
 
@@ -3351,9 +3351,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -3460,22 +3460,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467e5ff447618a916519a4e0d62772ab14f434897f3d63f05d8700ef1e9b22c1"
+checksum = "5976891d6950b4f68477850b5b9e5aa64d955961466f9e174363f573e54e8ca7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63c1091225b9834089b429bc4a2e01223470e3183e891582909e9d1c4cb55d9"
+checksum = "ab81dbd1cd69cd2ce22ecfbdd3bdb73334ba25350649408cc6c085f46d89573d"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -3539,9 +3539,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -3647,9 +3647,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -3947,9 +3947,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.8",
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
  "wasm-bindgen-shared",
 ]
 
@@ -3971,7 +3971,7 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.5",
+ "quote 1.0.6",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3981,9 +3981,9 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/iml-api/src/command.rs
+++ b/iml-api/src/command.rs
@@ -31,7 +31,7 @@ pub(crate) async fn get_command(pool: &DbPool, id: i32) -> Result<Command, ImlAp
         complete: cmd.complete,
         created_at: format!("{}", cmd.created_at),
         errored: cmd.errored,
-        id: cmd.id as u32,
+        id: cmd.id,
         message: cmd.message,
         resource_uri: format!("/api/{}/{}/", Command::endpoint_name(), cmd.id),
         jobs: jobs

--- a/iml-gui/crate/Cargo.lock
+++ b/iml-gui/crate/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -33,11 +33,11 @@ name = "chrono"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -54,7 +54,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ name = "cookie"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -86,81 +86,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-executor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-executor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures-io"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-task"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-macro 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-hack 0.5.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-nested 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -179,11 +183,11 @@ name = "gloo-timers"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -214,7 +218,7 @@ dependencies = [
  "bitmaps 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "sized-chunks 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -225,7 +229,7 @@ name = "iml-api-utils"
 version = "0.2.0"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -234,27 +238,27 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono-humanize 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gloo-timers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "im 14.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-api-utils 0.2.0",
  "iml-influx 0.1.0",
  "iml-wire-types 0.2.1",
- "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "number-formatter 0.1.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "seed 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -262,7 +266,7 @@ name = "iml-influx"
 version = "0.1.0"
 dependencies = [
  "iml-wire-types 0.2.1",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -271,8 +275,8 @@ version = "0.2.1"
 dependencies = [
  "im 14.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-api-utils 0.2.0",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -291,10 +295,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -304,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -352,6 +356,11 @@ name = "number-formatter"
 version = "0.1.0"
 
 [[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,8 +371,26 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pin-project"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pin-project-internal 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pin-utils"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -378,7 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -397,10 +424,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -417,13 +444,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.1.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -436,7 +458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -453,45 +475,45 @@ dependencies = [
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbg 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enclose 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gloo-timers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -499,9 +521,9 @@ name = "serde_repr"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -511,7 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -531,26 +553,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -580,7 +601,7 @@ name = "unicode-normalization"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -625,95 +646,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bumpalo 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bumpalo 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test-macro 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test-macro 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -739,7 +760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bitmaps 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-"checksum bumpalo 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+"checksum bumpalo 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 "checksum chrono-humanize 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2ff48a655fe8d2dae9a39e66af7fd8ff32a879e8c4e27422c25596a8b5e90d"
@@ -748,15 +769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dbg 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4677188513e0e9d7adced5997cf9a1e7a3c996c994f90093325c5332c1a8b221"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 "checksum enclose 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1056f553da426e9c025a662efa48b52e62e0a3a7648aa2d15aeaaf7f0d329357"
-"checksum futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
-"checksum futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
-"checksum futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
-"checksum futures-executor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
-"checksum futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
-"checksum futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
-"checksum futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
-"checksum futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
-"checksum futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+"checksum futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+"checksum futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+"checksum futures-core 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+"checksum futures-executor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+"checksum futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+"checksum futures-macro 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+"checksum futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+"checksum futures-task 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+"checksum futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 "checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum gloo-timers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
@@ -764,41 +785,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum im 14.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "696059c87b83c5a258817ecd67c3af915e3ed141891fc35a1e79908801cf0ce7"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
-"checksum js-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+"checksum js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)" = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)" = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+"checksum libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)" = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+"checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-"checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+"checksum pin-project 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
+"checksum pin-project-internal 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
+"checksum pin-utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 "checksum proc-macro-hack 0.5.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
 "checksum proc-macro-nested 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
-"checksum proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+"checksum proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
 "checksum pulldown-cmark 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1c205cc82214f3594e2d50686730314f817c67ffa80fe800cf0db78c3c2b9d9e"
-"checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+"checksum quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
-"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+"checksum regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
-"checksum ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+"checksum ryu 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 "checksum seed 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5d8fd7f12f565f639caf4b6d74a3853d5d7234d0543ec3beae81311492623e"
-"checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
-"checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
-"checksum serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)" = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+"checksum serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)" = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+"checksum serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)" = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
+"checksum serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 "checksum serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sized-chunks 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d59044ea371ad781ff976f7b06480b9f0180e834eda94114f2afb4afc12b7718"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum smallvec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
-"checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
-"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+"checksum syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
+"checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 "checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 "checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
@@ -809,15 +832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
-"checksum wasm-bindgen 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
-"checksum wasm-bindgen-backend 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
-"checksum wasm-bindgen-futures 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
-"checksum wasm-bindgen-macro 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
-"checksum wasm-bindgen-macro-support 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
-"checksum wasm-bindgen-shared 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
-"checksum wasm-bindgen-test 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "648da3460c6d2aa04b715a936329e2e311180efe650b2127d6267f4193ccac14"
-"checksum wasm-bindgen-test-macro 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cf2f86cd78a2aa7b1fb4bb6ed854eccb7f9263089c79542dca1576a1518a8467"
-"checksum web-sys 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+"checksum wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
+"checksum wasm-bindgen-backend 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
+"checksum wasm-bindgen-futures 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
+"checksum wasm-bindgen-macro 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
+"checksum wasm-bindgen-macro-support 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
+"checksum wasm-bindgen-shared 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
+"checksum wasm-bindgen-test 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "fd8e9dad8040e378f0696b017570c6bc929aac373180e06b3d67ac5059c52da3"
+"checksum wasm-bindgen-test-macro 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "c358c8d2507c1bae25efa069e62ea907aa28700b25c8c33dafb0b15ba4603627"
+"checksum web-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)" = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/iml-gui/crate/src/components/action_dropdown/mod.rs
+++ b/iml-gui/crate/src/components/action_dropdown/mod.rs
@@ -119,7 +119,7 @@ impl Drop for Model {
 }
 
 #[derive(Clone, Debug)]
-pub struct IdMsg(pub u32, pub Msg);
+pub struct IdMsg(pub i32, pub Msg);
 
 #[derive(Clone, Debug)]
 pub enum Msg {
@@ -268,7 +268,7 @@ fn sort_actions<T>(actions: &mut Vec<(Arc<AvailableAction>, T)>) {
     actions.sort_by(|a, b| a.0.display_order.cmp(&b.0.display_order));
 }
 
-pub fn view<'a>(id: u32, model: &Model, all_locks: &Locks, session: impl Into<Option<&'a Session>>) -> Node<IdMsg> {
+pub fn view<'a>(id: i32, model: &Model, all_locks: &Locks, session: impl Into<Option<&'a Session>>) -> Node<IdMsg> {
     unstyled_view(
         id,
         model,
@@ -279,7 +279,7 @@ pub fn view<'a>(id: u32, model: &Model, all_locks: &Locks, session: impl Into<Op
 }
 
 pub fn unstyled_view<'a>(
-    id: u32,
+    id: i32,
     model: &Model,
     all_locks: &Locks,
     session: impl Into<Option<&'a Session>>,
@@ -363,7 +363,7 @@ pub fn unstyled_view<'a>(
     }
 }
 
-fn items_view(id: u32, x: &ActionMap) -> impl View<IdMsg> {
+fn items_view(id: i32, x: &ActionMap) -> impl View<IdMsg> {
     let xs = x
         .iter()
         .flat_map(|(label, actions)| {

--- a/iml-gui/crate/src/components/activity_indicator.rs
+++ b/iml-gui/crate/src/components/activity_indicator.rs
@@ -8,7 +8,7 @@ use iml_wire_types::{warp_drive::ArcValuesExt, Alert, AlertSeverity};
 use seed::{prelude::*, *};
 use std::{cmp::max, sync::Arc};
 
-pub fn update_activity_health(active_alert: &HashMap<u32, Arc<Alert>>) -> ActivityHealth {
+pub fn update_activity_health(active_alert: &HashMap<i32, Arc<Alert>>) -> ActivityHealth {
     active_alert
         .arc_values()
         .filter(|x: &&Alert| x.severity > AlertSeverity::INFO)

--- a/iml-gui/crate/src/components/alert_indicator.rs
+++ b/iml-gui/crate/src/components/alert_indicator.rs
@@ -12,7 +12,7 @@ use seed::{prelude::*, *};
 use std::{cmp::max, collections::BTreeSet, iter::FromIterator, sync::Arc};
 
 pub(crate) fn alert_indicator<T>(
-    alerts: &HashMap<u32, Arc<Alert>>,
+    alerts: &HashMap<i32, Arc<Alert>>,
     x: &dyn ToCompositeId,
     compact: bool,
     tt_placement: Placement,

--- a/iml-gui/crate/src/components/command_modal.rs
+++ b/iml-gui/crate/src/components/command_modal.rs
@@ -26,23 +26,23 @@ const POLL_INTERVAL: Duration = Duration::from_millis(1000);
 
 type Job0 = Job<Option<serde_json::Value>>;
 
-type RichCommand = Rich<u32, Arc<Command>>;
-type RichJob = Rich<u32, Arc<Job0>>;
-type RichStep = Rich<u32, Arc<Step>>;
+type RichCommand = Rich<i32, Arc<Command>>;
+type RichJob = Rich<i32, Arc<Job0>>;
+type RichStep = Rich<i32, Arc<Step>>;
 
-type JobsGraph = DependencyDAG<u32, RichJob>;
-
-#[derive(Copy, Clone, Hash, PartialEq, Eq, Ord, PartialOrd, Debug)]
-pub struct CmdId(u32);
+type JobsGraph = DependencyDAG<i32, RichJob>;
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq, Ord, PartialOrd, Debug)]
-pub struct JobId(u32);
+pub struct CmdId(i32);
+
+#[derive(Copy, Clone, Hash, PartialEq, Eq, Ord, PartialOrd, Debug)]
+pub struct JobId(i32);
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
 pub enum TypedId {
-    Command(u32),
-    Job(u32),
-    Step(u32),
+    Command(i32),
+    Job(i32),
+    Step(i32),
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
@@ -58,8 +58,8 @@ impl Select {
     fn contains(&self, id: TypedId) -> bool {
         self.0.contains(&id)
     }
-    fn split(&self) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
-        fn insert_in_sorted(ids: &mut Vec<u32>, id: u32) {
+    fn split(&self) -> (Vec<i32>, Vec<i32>, Vec<i32>) {
+        fn insert_in_sorted(ids: &mut Vec<i32>, id: i32) {
             match ids.binary_search(&id) {
                 Ok(_) => {}
                 Err(pos) => ids.insert(pos, id),
@@ -88,7 +88,7 @@ pub struct Context<'a> {
 #[derive(Clone, Debug)]
 pub enum Input {
     Commands(Vec<Arc<Command>>),
-    Ids(Vec<u32>),
+    Ids(Vec<i32>),
 }
 
 #[derive(Default, Debug)]
@@ -96,13 +96,13 @@ pub struct Model {
     pub tree_cancel: Option<oneshot::Sender<()>>,
 
     pub commands_loading: bool,
-    pub commands: HashMap<u32, Arc<RichCommand>>,
+    pub commands: HashMap<i32, Arc<RichCommand>>,
     pub commands_view: Vec<Arc<RichCommand>>,
 
-    pub jobs: HashMap<u32, Arc<RichJob>>,
+    pub jobs: HashMap<i32, Arc<RichJob>>,
     pub jobs_graphs: HashMap<CmdId, JobsGraph>, // cmd_id -> JobsGraph
 
-    pub steps: HashMap<u32, Arc<RichStep>>,
+    pub steps: HashMap<i32, Arc<RichStep>>,
     pub steps_view: HashMap<JobId, Vec<Arc<RichStep>>>, // job_id -> [Step]
 
     pub select: Select,
@@ -206,13 +206,13 @@ fn schedule_fetch_tree(model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
         .filter(|id| model.commands.contains_key(id))
         .flat_map(|id| model.commands[id].deps())
         .copied()
-        .collect::<Vec<u32>>();
+        .collect::<Vec<i32>>();
     let load_step_ids = job_ids
         .iter()
         .filter(|id| model.jobs.contains_key(id))
         .flat_map(|id| model.jobs[id].deps())
         .copied()
-        .collect::<Vec<u32>>();
+        .collect::<Vec<i32>>();
 
     orders.skip();
     if !load_cmd_ids.is_empty() {
@@ -539,7 +539,7 @@ fn close_button() -> Node<Msg> {
     .map_msg(Msg::Modal)
 }
 
-async fn fetch_the_batch<T, F, U>(ids: Vec<u32>, data_to_msg: F) -> Result<U, U>
+async fn fetch_the_batch<T, F, U>(ids: Vec<i32>, data_to_msg: F) -> Result<U, U>
 where
     T: DeserializeOwned + EndpointName + 'static,
     F: FnOnce(ResponseDataResult<ApiList<T>>) -> U,
@@ -551,13 +551,13 @@ where
     match Request::api_query(T::endpoint_name(), &ids) {
         Ok(req) => req.fetch_json_data(data_to_msg).await,
         Err(_) => {
-            // we always can url encode a vector of u32-s
+            // we always can url encode a vector of i32-s
             unreachable!("Cannot encode request for {} with params {:?}", T::endpoint_name(), ids)
         }
     }
 }
 
-fn extract_uri_id<T: EndpointName>(input: &str) -> Option<u32> {
+fn extract_uri_id<T: EndpointName>(input: &str) -> Option<i32> {
     lazy_static::lazy_static! {
         static ref RE: Regex = Regex::new(r"/api/(\w+)/(\d+)/").unwrap();
     }
@@ -565,7 +565,7 @@ fn extract_uri_id<T: EndpointName>(input: &str) -> Option<u32> {
         let s = cap.get(1).unwrap().as_str();
         let t = cap.get(2).unwrap().as_str();
         if s == T::endpoint_name() {
-            t.parse::<u32>().ok()
+            t.parse::<i32>().ok()
         } else {
             None
         }
@@ -576,7 +576,7 @@ fn is_finished(cmd: &RichCommand) -> bool {
     cmd.complete
 }
 
-fn is_all_finished(cmds: &HashMap<u32, Arc<RichCommand>>) -> bool {
+fn is_all_finished(cmds: &HashMap<i32, Arc<RichCommand>>) -> bool {
     cmds.values().all(|c| is_finished(c))
 }
 
@@ -588,38 +588,38 @@ fn perform_click(select: &mut Select, id: TypedId) -> bool {
     }
 }
 
-fn extract_children_from_cmd(cmd: &Arc<Command>) -> (u32, Vec<u32>) {
+fn extract_children_from_cmd(cmd: &Arc<Command>) -> (i32, Vec<i32>) {
     let mut deps = cmd
         .jobs
         .iter()
         .filter_map(|s| extract_uri_id::<Job0>(s))
-        .collect::<Vec<u32>>();
+        .collect::<Vec<i32>>();
     deps.sort();
     (cmd.id, deps)
 }
 
-fn extract_children_from_job(job: &Arc<Job0>) -> (u32, Vec<u32>) {
+fn extract_children_from_job(job: &Arc<Job0>) -> (i32, Vec<i32>) {
     let mut deps = job
         .steps
         .iter()
         .filter_map(|s| extract_uri_id::<Step>(s))
-        .collect::<Vec<u32>>();
+        .collect::<Vec<i32>>();
     deps.sort();
     (job.id, deps)
 }
 
-fn extract_children_from_step(step: &Arc<Step>) -> (u32, Vec<u32>) {
+fn extract_children_from_step(step: &Arc<Step>) -> (i32, Vec<i32>) {
     (step.id, Vec::new()) // steps have no descendants
 }
 
-fn extract_wait_fors_from_job(job: &Job0, jobs: &HashMap<u32, Arc<RichJob>>) -> (u32, Vec<u32>) {
+fn extract_wait_fors_from_job(job: &Job0, jobs: &HashMap<i32, Arc<RichJob>>) -> (i32, Vec<i32>) {
     // Extract the interdependencies between jobs.
     // See [command_modal::tests::test_jobs_ordering]
     let mut deps = job
         .wait_for
         .iter()
         .filter_map(|s| extract_uri_id::<Job0>(s))
-        .collect::<Vec<u32>>();
+        .collect::<Vec<i32>>();
     deps.sort_by(|i1, i2| {
         let t1 = jobs
             .get(i1)
@@ -634,20 +634,20 @@ fn extract_wait_fors_from_job(job: &Job0, jobs: &HashMap<u32, Arc<RichJob>>) -> 
     (job.id, deps)
 }
 
-fn extract_sorted_keys<T>(hm: &HashMap<u32, T>) -> Vec<u32> {
+fn extract_sorted_keys<T>(hm: &HashMap<i32, T>) -> Vec<i32> {
     let mut ids = hm.keys().copied().collect::<Vec<_>>();
     ids.sort();
     ids
 }
 
-fn convert_to_sorted_vec<T>(hm: &HashMap<u32, Arc<T>>) -> Vec<Arc<T>> {
+fn convert_to_sorted_vec<T>(hm: &HashMap<i32, Arc<T>>) -> Vec<Arc<T>> {
     extract_sorted_keys(hm)
         .into_iter()
         .map(|k| Arc::clone(&hm[&k]))
         .collect()
 }
 
-fn convert_to_rich_hashmap<T>(ts: Vec<T>, extract: impl Fn(&T) -> (u32, Vec<u32>)) -> HashMap<u32, Arc<Rich<u32, T>>> {
+fn convert_to_rich_hashmap<T>(ts: Vec<T>, extract: impl Fn(&T) -> (i32, Vec<i32>)) -> HashMap<i32, Arc<Rich<i32, T>>> {
     ts.into_iter()
         .map(|t| {
             let (id, deps) = extract(&t);
@@ -793,21 +793,21 @@ mod tests {
     }
 
     impl Db {
-        fn select_cmds(&self, is: &[u32]) -> Vec<Arc<Command>> {
+        fn select_cmds(&self, is: &[i32]) -> Vec<Arc<Command>> {
             self.all_cmds
                 .iter()
                 .filter(|x| is.contains(&x.id))
                 .map(|x| Arc::clone(x))
                 .collect()
         }
-        fn select_jobs(&self, is: &[u32]) -> Vec<Arc<Job0>> {
+        fn select_jobs(&self, is: &[i32]) -> Vec<Arc<Job0>> {
             self.all_jobs
                 .iter()
                 .filter(|x| is.contains(&x.id))
                 .map(|x| Arc::clone(x))
                 .collect()
         }
-        fn select_steps(&self, is: &[u32]) -> Vec<Arc<Step>> {
+        fn select_steps(&self, is: &[i32]) -> Vec<Arc<Step>> {
             self.all_steps
                 .iter()
                 .filter(|x| is.contains(&x.id))
@@ -867,7 +867,7 @@ mod tests {
 
     #[test]
     fn test_jobs_ordering() {
-        // The jobs' dependencies (vector of u32) are sorted in special order so that the
+        // The jobs' dependencies (vector of i32) are sorted in special order so that the
         // jobs with more dependencies come first. If the number of dependencies are equal,
         // they are sorted by alphabetical order by the description.
         // If the description is the same, then the jobs are ordered by id.
@@ -953,7 +953,7 @@ mod tests {
         hm.into_iter().map(|(k, v)| (k, format!("{:?}", v))).collect()
     }
 
-    fn make_command(id: u32, jobs: &[u32], msg: &str) -> Arc<Command> {
+    fn make_command(id: i32, jobs: &[i32], msg: &str) -> Arc<Command> {
         Arc::new(Command {
             cancelled: false,
             complete: false,
@@ -967,7 +967,7 @@ mod tests {
         })
     }
 
-    fn make_job(id: u32, cmd_id: CmdId, steps: &[u32], wait_for: &[u32], descr: &str) -> Arc<Job0> {
+    fn make_job(id: i32, cmd_id: CmdId, steps: &[i32], wait_for: &[i32], descr: &str) -> Arc<Job0> {
         Arc::new(Job0 {
             available_transitions: vec![],
             cancelled: false,
@@ -990,7 +990,7 @@ mod tests {
         })
     }
 
-    fn make_step(id: u32, class_name: &str) -> Arc<Step> {
+    fn make_step(id: i32, class_name: &str) -> Arc<Step> {
         Arc::new(Step {
             args: Default::default(),
             backtrace: "".to_string(),
@@ -1087,29 +1087,29 @@ mod tests {
         }
     }
 
-    fn prepare_subset(db: &Db, cmd_ids: &[u32]) -> (Vec<Arc<Command>>, Vec<Arc<Job0>>, Vec<Arc<Step>>) {
+    fn prepare_subset(db: &Db, cmd_ids: &[i32]) -> (Vec<Arc<Command>>, Vec<Arc<Job0>>, Vec<Arc<Step>>) {
         let cmds = db.select_cmds(&cmd_ids);
         let c_ids = cmds
             .iter()
             .map(|x| extract_ids::<Job0>(&x.jobs))
             .flatten()
-            .collect::<Vec<u32>>();
+            .collect::<Vec<i32>>();
         let jobs = db.select_jobs(&c_ids);
         let j_ids = jobs
             .iter()
             .map(|x| extract_ids::<Step>(&x.steps))
             .flatten()
-            .collect::<Vec<u32>>();
+            .collect::<Vec<i32>>();
         let steps = db.select_steps(&j_ids);
         let cmds = db.all_cmds.clone(); // use all roots
         (cmds, jobs, steps)
     }
 
-    fn generate_random_selects<R: RngCore>(db: &Db, rng: &mut R, n: u32) -> Vec<Select> {
+    fn generate_random_selects<R: RngCore>(db: &Db, rng: &mut R, n: i32) -> Vec<Select> {
         let cmd_ids = db.all_cmds.iter().map(|x| x.id).collect::<Vec<_>>();
         let job_ids = db.all_jobs.iter().map(|x| x.id).collect::<Vec<_>>();
         let step_ids = db.all_steps.iter().map(|x| x.id).collect::<Vec<_>>();
-        fn sample<R: RngCore>(rng: &mut R, ids: &[u32], m: usize) -> Vec<u32> {
+        fn sample<R: RngCore>(rng: &mut R, ids: &[i32], m: usize) -> Vec<i32> {
             let mut hs = HashSet::with_capacity(m);
             let n = ids.len();
             if n < m {
@@ -1147,7 +1147,7 @@ mod tests {
             .collect()
     }
 
-    fn extract_ids<T: EndpointName>(uris: &[String]) -> Vec<u32> {
+    fn extract_ids<T: EndpointName>(uris: &[String]) -> Vec<i32> {
         // uris is the slice of strings like ["/api/step/123/", .. , "/api/step/234/"]
         uris.iter().filter_map(|s| extract_uri_id::<T>(s)).collect()
     }

--- a/iml-gui/crate/src/components/resource_links.rs
+++ b/iml-gui/crate/src/components/resource_links.rs
@@ -31,7 +31,7 @@ pub fn server_link<T>(uri: Option<&String>, txt: &str) -> Node<T> {
 
 pub fn volume_link<T>(t: &Target<TargetConfParam>) -> Node<T> {
     // let vol_id = match &t.volume {
-    //     VolumeOrResourceUri::ResourceUri(url) => extract_id(url).unwrap().parse::<u32>().unwrap(),
+    //     VolumeOrResourceUri::ResourceUri(url) => extract_id(url).unwrap().parse::<i32>().unwrap(),
     //     VolumeOrResourceUri::Volume(v) => v.id,
     // };
 

--- a/iml-gui/crate/src/components/stratagem/delete_stratagem_button.rs
+++ b/iml-gui/crate/src/components/stratagem/delete_stratagem_button.rs
@@ -11,7 +11,7 @@ use iml_wire_types::{EndpointName, StratagemConfiguration};
 use seed::{prelude::*, *};
 
 pub async fn delete_stratagem<T: serde::de::DeserializeOwned + 'static>(
-    config_id: u32,
+    config_id: i32,
 ) -> Result<fetch::FetchObject<T>, fetch::FetchObject<T>> {
     Request::api_item(StratagemConfiguration::endpoint_name(), config_id)
         .method(fetch::Method::Delete)

--- a/iml-gui/crate/src/components/stratagem/mod.rs
+++ b/iml-gui/crate/src/components/stratagem/mod.rs
@@ -32,8 +32,8 @@ pub struct TargetConfig {
 
 #[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct StratagemUpdate {
-    pub id: u32,
-    pub filesystem: u32,
+    pub id: i32,
+    pub filesystem: i32,
     pub interval: u64,
     pub report_duration: Option<u64>,
     pub purge_duration: Option<u64>,
@@ -41,7 +41,7 @@ pub struct StratagemUpdate {
 
 #[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct StratagemEnable {
-    pub filesystem: u32,
+    pub filesystem: i32,
     pub interval: u64,
     pub report_duration: Option<u64>,
     pub purge_duration: Option<u64>,
@@ -49,7 +49,7 @@ pub struct StratagemEnable {
 
 #[derive(Debug, serde::Serialize)]
 pub struct StratagemScan {
-    pub filesystem: u32,
+    pub filesystem: i32,
     pub report_duration: Option<u64>,
     pub purge_duration: Option<u64>,
 }
@@ -92,7 +92,7 @@ pub struct Config {
     pub scan_duration_picker: duration_picker::Model,
     pub report_duration_picker: duration_picker::Model,
     pub purge_duration_picker: duration_picker::Model,
-    pub id: Option<u32>,
+    pub id: Option<i32>,
     pub destroyed: bool,
     pub disabled: bool,
     pub target_config: TargetConfig,
@@ -105,7 +105,7 @@ impl Config {
             && self.report_duration_picker.validation_message.is_none()
             && self.purge_duration_picker.validation_message.is_none()
     }
-    fn get_stratagem_update_config(&self, fs_id: u32) -> Option<StratagemUpdate> {
+    fn get_stratagem_update_config(&self, fs_id: i32) -> Option<StratagemUpdate> {
         Some(StratagemUpdate {
             id: self.id?,
             filesystem: fs_id,
@@ -115,7 +115,7 @@ impl Config {
         })
     }
 
-    fn create_enable_stratagem_model(&self, fs_id: u32) -> Option<StratagemEnable> {
+    fn create_enable_stratagem_model(&self, fs_id: i32) -> Option<StratagemEnable> {
         Some(StratagemEnable {
             filesystem: fs_id,
             interval: self.scan_duration_picker.value_as_ms()?,

--- a/iml-gui/crate/src/components/stratagem/scan_stratagem_button.rs
+++ b/iml-gui/crate/src/components/stratagem/scan_stratagem_button.rs
@@ -14,12 +14,12 @@ use seed::{prelude::*, *};
 pub struct Model {
     pub disabled: bool,
     pub locked: bool,
-    pub fs_id: u32,
+    pub fs_id: i32,
     pub scan_stratagem_modal: scan_stratagem_modal::Model,
 }
 
 impl Model {
-    pub fn new(fs_id: u32) -> Self {
+    pub fn new(fs_id: i32) -> Self {
         Self {
             fs_id,
             scan_stratagem_modal: scan_stratagem_modal::Model::new(fs_id),

--- a/iml-gui/crate/src/components/stratagem/scan_stratagem_modal.rs
+++ b/iml-gui/crate/src/components/stratagem/scan_stratagem_modal.rs
@@ -20,12 +20,12 @@ pub struct Model {
     pub modal: modal::Model,
     pub report_duration: duration_picker::Model,
     pub purge_duration: duration_picker::Model,
-    pub fs_id: u32,
+    pub fs_id: i32,
     pub scanning: bool,
 }
 
 impl Model {
-    pub fn new(fs_id: u32) -> Self {
+    pub fn new(fs_id: i32) -> Self {
         Self {
             fs_id,
             ..Default::default()

--- a/iml-gui/crate/src/components/tree.rs
+++ b/iml-gui/crate/src/components/tree.rs
@@ -25,11 +25,11 @@ fn sort_by_label(xs: &mut Vec<impl Label>) {
     xs.sort_by(|a, b| natord::compare(a.label(), b.label()));
 }
 
-pub fn slice_page<'a>(paging: &paging::Model, xs: &'a BTreeSet<u32>) -> impl Iterator<Item = &'a u32> {
+pub fn slice_page<'a>(paging: &paging::Model, xs: &'a BTreeSet<i32>) -> impl Iterator<Item = &'a i32> {
     xs.iter().skip(paging.offset()).take(paging.end())
 }
 
-fn sorted_cache<'a>(x: &'a im::HashMap<u32, Arc<impl Label + Id>>) -> impl Iterator<Item = u32> + 'a {
+fn sorted_cache<'a>(x: &'a im::HashMap<i32, Arc<impl Label + Id>>) -> impl Iterator<Item = i32> + 'a {
     let mut xs: Vec<_> = x.values().collect();
 
     xs.sort_by(|a, b| natord::compare(a.label(), b.label()));
@@ -37,11 +37,11 @@ fn sorted_cache<'a>(x: &'a im::HashMap<u32, Arc<impl Label + Id>>) -> impl Itera
     xs.into_iter().map(|x| x.id())
 }
 
-fn get_volume_nodes_by_host_id(xs: &im::HashMap<u32, Arc<VolumeNodeRecord>>, host_id: u32) -> Vec<&VolumeNodeRecord> {
+fn get_volume_nodes_by_host_id(xs: &im::HashMap<i32, Arc<VolumeNodeRecord>>, host_id: i32) -> Vec<&VolumeNodeRecord> {
     xs.arc_values().filter(|v| v.host_id == host_id).collect()
 }
 
-fn get_ost_pools_by_fs_id(xs: &im::HashMap<u32, Arc<OstPoolRecord>>, fs_id: u32) -> Vec<&OstPoolRecord> {
+fn get_ost_pools_by_fs_id(xs: &im::HashMap<i32, Arc<OstPoolRecord>>, fs_id: i32) -> Vec<&OstPoolRecord> {
     xs.arc_values().filter(|v| v.filesystem_id == fs_id).collect()
 }
 
@@ -57,7 +57,7 @@ fn get_targets_by_parent_resource(
     }
 }
 
-fn get_targets_by_pool_id(cache: &ArcCache, ostpool_id: u32) -> Vec<&Target<TargetConfParam>> {
+fn get_targets_by_pool_id(cache: &ArcCache, ostpool_id: i32) -> Vec<&Target<TargetConfParam>> {
     let target_ids: Vec<_> = cache
         .ost_pool_osts
         .arc_values()
@@ -73,8 +73,8 @@ fn get_targets_by_pool_id(cache: &ArcCache, ostpool_id: u32) -> Vec<&Target<Targ
 }
 
 fn get_targets_by_fs_id(
-    xs: &im::HashMap<u32, Arc<Target<TargetConfParam>>>,
-    fs_id: u32,
+    xs: &im::HashMap<i32, Arc<Target<TargetConfParam>>>,
+    fs_id: i32,
     kind: TargetKind,
 ) -> Vec<&Target<TargetConfParam>> {
     let it = xs.arc_values().filter(|t| t.kind == kind);
@@ -92,7 +92,7 @@ fn get_targets_by_fs_id(
     }
 }
 
-fn get_target_fs_ids(x: &Target<TargetConfParam>) -> Vec<u32> {
+fn get_target_fs_ids(x: &Target<TargetConfParam>) -> Vec<i32> {
     match x.kind {
         TargetKind::Mgt => x.filesystems.iter().flatten().map(|x| x.id).collect(),
         TargetKind::Mdt | TargetKind::Ost => x.filesystem_id.map(|x| vec![x]).unwrap_or_default(),
@@ -104,14 +104,14 @@ fn get_target_fs_ids(x: &Target<TargetConfParam>) -> Vec<u32> {
 #[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Ord, Clone, Copy)]
 pub enum Step {
     HostCollection,
-    Host(u32),
+    Host(i32),
     VolumeCollection,
     FsCollection,
-    Fs(u32),
+    Fs(i32),
     MgtCollection,
     MdtCollection,
     OstPoolCollection,
-    OstPool(u32),
+    OstPool(i32),
     OstCollection,
 }
 
@@ -157,12 +157,12 @@ impl From<Vec<Step>> for Address {
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct TreeNode {
     open: bool,
-    items: BTreeSet<u32>,
+    items: BTreeSet<i32>,
     paging: paging::Model,
 }
 
 impl TreeNode {
-    fn from_items(xs: impl IntoIterator<Item = u32>) -> Self {
+    fn from_items(xs: impl IntoIterator<Item = i32>) -> Self {
         let items = BTreeSet::from_iter(xs);
 
         Self {
@@ -194,7 +194,7 @@ impl Model {
     fn reset(&mut self) {
         self.0 = HashMap::new();
     }
-    fn remove_item(&mut self, addr: &Address, id: u32) {
+    fn remove_item(&mut self, addr: &Address, id: i32) {
         if let Some(tree_node) = self.get_mut(addr) {
             tree_node.items.remove(&id);
             tree_node.paging.total -= 1;

--- a/iml-gui/crate/src/page/activity.rs
+++ b/iml-gui/crate/src/page/activity.rs
@@ -20,7 +20,7 @@ use std::{collections::HashMap, mem, time::Duration};
 enum State {
     Loading,
     Fetching,
-    Loaded(ApiList<Alert>, HashMap<u32, Row>),
+    Loaded(ApiList<Alert>, HashMap<i32, Row>),
 }
 
 struct Row {
@@ -47,7 +47,7 @@ impl Default for Model {
 pub enum Msg {
     ActionDropdown(Box<action_dropdown::IdMsg>),
     ActionsFetched(Box<fetch::ResponseDataResult<ApiList<Alert>>>),
-    OpenCommandModal(u32),
+    OpenCommandModal(i32),
     FetchOffset,
     Loop,
     Page(paging::Msg),
@@ -162,7 +162,7 @@ pub(crate) fn init(orders: &mut impl Orders<Msg, GMsg>) {
     orders.send_msg(Msg::FetchOffset);
 }
 
-fn update_rows(alerts: &mut ApiList<Alert>, rows: &mut HashMap<u32, Row>) {
+fn update_rows(alerts: &mut ApiList<Alert>, rows: &mut HashMap<i32, Row>) {
     let (add, remove): (Vec<_>, Vec<_>) = alerts
         .objects
         .iter_mut()

--- a/iml-gui/crate/src/page/filesystem.rs
+++ b/iml-gui/crate/src/page/filesystem.rs
@@ -33,7 +33,7 @@ pub struct Model {
     mgt: Vec<Arc<Target<TargetConfParam>>>,
     osts: Vec<Arc<Target<TargetConfParam>>>,
     ost_paging: paging::Model,
-    rows: HashMap<u32, Row>,
+    rows: HashMap<i32, Row>,
     stratagem: stratagem::Model,
     stats: iml_influx::filesystem::Response,
     stats_cancel: Option<oneshot::Sender<()>>,
@@ -64,7 +64,7 @@ pub enum Msg {
     StatsFetched(Box<fetch::ResponseDataResult<iml_influx::filesystem::InfluxResponse>>),
     ActionDropdown(Box<action_dropdown::IdMsg>),
     AddTarget(Arc<Target<TargetConfParam>>),
-    RemoveTarget(u32),
+    RemoveTarget(i32),
     SetTargets(Vec<Arc<Target<TargetConfParam>>>),
     OstPaging(paging::Msg),
     MdtPaging(paging::Msg),
@@ -321,7 +321,7 @@ fn targets(
     cache: &ArcCache,
     all_locks: &Locks,
     session: Option<&Session>,
-    rows: &HashMap<u32, Row>,
+    rows: &HashMap<i32, Row>,
     tgts: &[Arc<Target<TargetConfParam>>],
     pager: impl Into<Option<Node<Msg>>>,
 ) -> Node<Msg> {
@@ -416,7 +416,7 @@ pub(crate) fn clients_view<T>(cc: impl Into<Option<u64>>) -> Node<T> {
     plain![cc.into().map(|c| c.to_string()).unwrap_or_else(|| "---".to_string())]
 }
 
-fn is_fs_target(fs_id: u32, t: &Target<TargetConfParam>) -> bool {
+fn is_fs_target(fs_id: i32, t: &Target<TargetConfParam>) -> bool {
     t.filesystem_id == Some(fs_id)
         || t.filesystems
             .as_ref()

--- a/iml-gui/crate/src/page/filesystems.rs
+++ b/iml-gui/crate/src/page/filesystems.rs
@@ -28,7 +28,7 @@ pub struct Model {
     filesystems: Vec<Arc<Filesystem>>,
     stats: iml_influx::filesystems::Response,
     pager: paging::Model,
-    rows: HashMap<u32, Row>,
+    rows: HashMap<i32, Row>,
     stats_cancel: Option<oneshot::Sender<()>>,
 }
 
@@ -39,7 +39,7 @@ pub enum Msg {
     ActionDropdown(Box<action_dropdown::IdMsg>),
     AddFilesystem(Arc<Filesystem>),
     Page(paging::Msg),
-    RemoveFilesystem(u32),
+    RemoveFilesystem(i32),
     SetFilesystems(Vec<Arc<Filesystem>>),
     Noop,
 }

--- a/iml-gui/crate/src/page/logs.rs
+++ b/iml-gui/crate/src/page/logs.rs
@@ -201,7 +201,7 @@ fn log_item_view(log: &Log, cache: &ArcCache) -> Node<Msg> {
     ]
 }
 
-fn server_link<T>(fqdn: &str, hosts: &im::HashMap<u32, Arc<Host>>) -> Node<T> {
+fn server_link<T>(fqdn: &str, hosts: &im::HashMap<i32, Arc<Host>>) -> Node<T> {
     let x = hosts.values().find(|x| x.fqdn == fqdn);
 
     match x {

--- a/iml-gui/crate/src/page/mgts.rs
+++ b/iml-gui/crate/src/page/mgts.rs
@@ -23,7 +23,7 @@ pub struct Row {
 
 #[derive(Default)]
 pub struct Model {
-    pub rows: HashMap<u32, Row>,
+    pub rows: HashMap<i32, Row>,
     pub mgts: Vec<Arc<Target<TargetConfParam>>>,
 }
 
@@ -31,7 +31,7 @@ pub struct Model {
 pub enum Msg {
     ActionDropdown(Box<action_dropdown::IdMsg>),
     SetTargets(Vec<Arc<Target<TargetConfParam>>>),
-    RemoveTarget(u32),
+    RemoveTarget(i32),
     AddTarget(Arc<Target<TargetConfParam>>),
 }
 
@@ -121,7 +121,7 @@ pub fn view(cache: &ArcCache, model: &Model, all_locks: &Locks, session: Option<
                     Some(row) => {
                         let fs = cache.filesystem.arc_values().filter(|y| {
                             extract_id(&y.mgt)
-                                .and_then(|y| y.parse::<u32>().ok())
+                                .and_then(|y| y.parse::<i32>().ok())
                                 .filter(|y| y == &x.id)
                                 .is_some()
                         });

--- a/iml-gui/crate/src/page/ostpool.rs
+++ b/iml-gui/crate/src/page/ostpool.rs
@@ -8,7 +8,7 @@ use seed::prelude::*;
 pub enum Msg {}
 
 pub struct Model {
-    pub id: u32,
+    pub id: i32,
 }
 
 pub fn view(_model: &Model) -> impl View<Msg> {

--- a/iml-gui/crate/src/page/servers.rs
+++ b/iml-gui/crate/src/page/servers.rs
@@ -36,7 +36,7 @@ struct Row {
 #[derive(Default)]
 pub struct Model {
     hosts: Vec<Arc<Host>>,
-    rows: HashMap<u32, Row>,
+    rows: HashMap<i32, Row>,
     pager: paging::Model,
     sort: (SortField, paging::Dir),
 }
@@ -45,9 +45,9 @@ pub struct Model {
 pub enum Msg {
     SetHosts(
         Vec<Arc<Host>>,
-        im::HashMap<u32, Arc<LnetConfigurationRecord>>,
-        im::HashMap<u32, Arc<PacemakerConfigurationRecord>>,
-        im::HashMap<u32, Arc<CorosyncConfigurationRecord>>,
+        im::HashMap<i32, Arc<LnetConfigurationRecord>>,
+        im::HashMap<i32, Arc<PacemakerConfigurationRecord>>,
+        im::HashMap<i32, Arc<CorosyncConfigurationRecord>>,
     ), // @FIXME: This should be more granular so row state isn't lost.
     Page(paging::Msg),
     Sort,

--- a/iml-gui/crate/src/page/volume.rs
+++ b/iml-gui/crate/src/page/volume.rs
@@ -8,7 +8,7 @@ use seed::prelude::*;
 pub enum Msg {}
 
 pub struct Model {
-    pub id: u32,
+    pub id: i32,
 }
 
 pub fn view(_model: &Model) -> impl View<Msg> {

--- a/iml-gui/crate/src/page/volumes.rs
+++ b/iml-gui/crate/src/page/volumes.rs
@@ -84,7 +84,7 @@ impl From<&Arc<Host>> for Model {
 }
 
 fn build_rows(cache: &ArcCache, host: &Option<Arc<Host>>) -> Vec<Row> {
-    let x: im::HashMap<u32, Vec<_>> = cache.volume_node.values().fold(im::hashmap! {}, |mut acc, x| {
+    let x: im::HashMap<i32, Vec<_>> = cache.volume_node.values().fold(im::hashmap! {}, |mut acc, x| {
         acc.entry(x.volume_id)
             .and_modify(|xs| {
                 xs.push(Arc::clone(x));

--- a/iml-gui/crate/src/route.rs
+++ b/iml-gui/crate/src/route.rs
@@ -9,14 +9,14 @@ use std::{borrow::Cow, ops::Deref};
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct RouteId<'a>(Cow<'a, str>);
 
-impl<'a> From<u32> for RouteId<'a> {
-    fn from(n: u32) -> Self {
+impl<'a> From<i32> for RouteId<'a> {
+    fn from(n: i32) -> Self {
         RouteId(Cow::from(n.to_string()))
     }
 }
 
-impl<'a> From<&u32> for RouteId<'a> {
-    fn from(n: &u32) -> Self {
+impl<'a> From<&i32> for RouteId<'a> {
+    fn from(n: &i32) -> Self {
         RouteId(Cow::from(n.to_string()))
     }
 }

--- a/iml-manager-cli/src/server.rs
+++ b/iml-manager-cli/src/server.rs
@@ -160,7 +160,7 @@ struct StateChange {
 
 #[derive(serde::Serialize)]
 struct HostProfileConfig<'a> {
-    host: u32,
+    host: i32,
     profile: &'a str,
 }
 
@@ -252,7 +252,7 @@ async fn wait_till_agent_starts(
             return Err(ImlManagerCliError::ApiError(x.error.take().unwrap()));
         };
 
-        let profile_checks: HashMap<u32, Vec<ProfileTest>> = objects
+        let profile_checks: HashMap<i32, Vec<ProfileTest>> = objects
             .iter_mut()
             .filter_map(|x| x.host_profiles.take())
             .map(|mut x| {
@@ -266,7 +266,7 @@ async fn wait_till_agent_starts(
                         ))
                     })
             })
-            .collect::<Result<HashMap<u32, Vec<ProfileTest>>, ImlManagerCliError>>()?;
+            .collect::<Result<HashMap<i32, Vec<ProfileTest>>, ImlManagerCliError>>()?;
 
         let waiting_for_agent: Vec<_> = profile_checks
             .iter()
@@ -467,7 +467,7 @@ fn get_host_ids(hosts: &[Host]) -> Vec<[String; 2]> {
         .collect()
 }
 
-fn filter_host_profiles<I>(profile: &ServerProfile, objects: I) -> Vec<(u32, Vec<ProfileTest>)>
+fn filter_host_profiles<I>(profile: &ServerProfile, objects: I) -> Vec<(i32, Vec<ProfileTest>)>
 where
     I: IntoIterator<Item = HostProfileWrapper>,
 {
@@ -478,7 +478,7 @@ where
         .collect()
 }
 
-fn filter_profile_tests(objects: &[(u32, Vec<ProfileTest>)]) -> Vec<(&u32, Vec<&ProfileTest>)> {
+fn filter_profile_tests(objects: &[(i32, Vec<ProfileTest>)]) -> Vec<(&i32, Vec<&ProfileTest>)> {
     objects
         .iter()
         .map(|(k, tests)| (k, tests.iter().filter(|y| !y.pass).collect::<Vec<_>>()))
@@ -491,7 +491,7 @@ fn handle_invalid_profile_tests(
     config: &AddHosts,
     profile: &ServerProfile,
     hosts: &[Host],
-    invalid: Vec<(&u32, Vec<&ProfileTest>)>,
+    invalid: Vec<(&i32, Vec<&ProfileTest>)>,
 ) -> Result<(), ImlManagerCliError> {
     if !invalid.is_empty() {
         display_error(format!("Profile {} is invalid:\n\n", profile.name));
@@ -525,7 +525,7 @@ fn handle_invalid_profile_tests(
 
 fn get_host_profile_configs<'a>(
     profile: &'a ServerProfile,
-    objects: &[(u32, Vec<ProfileTest>)],
+    objects: &[(i32, Vec<ProfileTest>)],
 ) -> Vec<HostProfileConfig<'a>> {
     objects
         .iter()

--- a/iml-manager-cli/src/update_repo_file.rs
+++ b/iml-manager-cli/src/update_repo_file.rs
@@ -36,7 +36,7 @@ fn has_host(api_hosts: &[&Host], host: &str) -> bool {
 
 #[derive(serde::Serialize)]
 pub struct HostId {
-    host_id: u32,
+    host_id: i32,
 }
 
 pub async fn update_repo_file_cli(config: UpdateRepoFileHosts) -> Result<(), ImlManagerCliError> {

--- a/iml-warp-drive/src/cache.rs
+++ b/iml-warp-drive/src/cache.rs
@@ -46,7 +46,7 @@ async fn converter<T>(
     msg_type: MessageType,
     x: impl ToApiRecord + NotDeleted,
     record_fn: fn(T) -> Record,
-    record_id_fn: fn(u32) -> RecordId,
+    record_id_fn: fn(i32) -> RecordId,
 ) -> Result<RecordChange, ImlManagerClientError>
 where
     T: std::fmt::Debug
@@ -269,13 +269,13 @@ pub async fn populate_from_api(shared_api_cache: SharedCache) -> Result<(), ImlM
 
 async fn into_row<T>(
     s: impl Stream<Item = Result<iml_postgres::Row, iml_postgres::Error>>,
-) -> Result<HashMap<u32, T>, iml_postgres::Error>
+) -> Result<HashMap<i32, T>, iml_postgres::Error>
 where
     T: From<iml_postgres::Row> + Name + Id + Clone,
 {
     s.map_ok(T::from)
         .map_ok(|record| (record.id(), record))
-        .try_collect::<HashMap<u32, T>>()
+        .try_collect::<HashMap<i32, T>>()
         .await
 }
 

--- a/iml-wire-types/src/db.rs
+++ b/iml-wire-types/src/db.rs
@@ -17,8 +17,8 @@ use std::io;
 use tokio_postgres::Row;
 
 pub trait Id {
-    /// Returns the `Id` (`u32`).
-    fn id(&self) -> u32;
+    /// Returns the `Id` (`i32`).
+    fn id(&self) -> i32;
 }
 
 pub trait NotDeleted {
@@ -53,13 +53,13 @@ pub trait Name {
 /// Record from the `django_content_type` table
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct ContentTypeRecord {
-    pub id: u32,
+    pub id: i32,
     pub app_label: String,
     pub model: String,
 }
 
 impl Id for ContentTypeRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -76,7 +76,7 @@ impl Name for ContentTypeRecord {
 impl From<Row> for ContentTypeRecord {
     fn from(row: Row) -> Self {
         ContentTypeRecord {
-            id: row.get::<_, i32>("id") as u32,
+            id: row.get::<_, i32>("id"),
             app_label: row.get("app_label"),
             model: row.get("model"),
         }
@@ -86,20 +86,20 @@ impl From<Row> for ContentTypeRecord {
 /// Record from the `chroma_core_managedfilesystem` table
 #[derive(serde::Deserialize, Debug)]
 pub struct FsRecord {
-    id: u32,
+    id: i32,
     state_modified_at: String,
     state: String,
     immutable_state: bool,
     name: String,
-    mgs_id: u32,
-    mdt_next_index: u32,
-    ost_next_index: u32,
+    mgs_id: i32,
+    mdt_next_index: i32,
+    ost_next_index: i32,
     not_deleted: Option<bool>,
-    content_type_id: Option<u32>,
+    content_type_id: Option<i32>,
 }
 
 impl Id for FsRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -121,8 +121,8 @@ impl Name for FsRecord {
 /// Record from the `chroma_core_volume` table
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct VolumeRecord {
-    pub id: u32,
-    pub storage_resource_id: Option<u32>,
+    pub id: i32,
+    pub storage_resource_id: Option<i32>,
     pub size: Option<u64>,
     pub label: String,
     pub filesystem_type: Option<String>,
@@ -131,7 +131,7 @@ pub struct VolumeRecord {
 }
 
 impl Id for VolumeRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -154,15 +154,13 @@ impl Name for VolumeRecord {
 impl From<Row> for VolumeRecord {
     fn from(row: Row) -> Self {
         VolumeRecord {
-            id: row.get::<_, i32>("id") as u32,
+            id: row.get::<_, i32>("id"),
             size: row.get::<_, Option<i64>>("size").map(|x| x as u64),
             label: row.get("label"),
             filesystem_type: row.get("filesystem_type"),
             usable_for_lustre: row.get("usable_for_lustre"),
             not_deleted: row.get("not_deleted"),
-            storage_resource_id: row
-                .get::<_, Option<i32>>("storage_resource_id")
-                .map(|x| x as u32),
+            storage_resource_id: row.get::<_, Option<i32>>("storage_resource_id"),
         }
     }
 }
@@ -170,11 +168,11 @@ impl From<Row> for VolumeRecord {
 /// Record from the `chroma_core_volumenode` table
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct VolumeNodeRecord {
-    pub id: u32,
-    pub volume_id: u32,
-    pub host_id: u32,
+    pub id: i32,
+    pub volume_id: i32,
+    pub host_id: i32,
     pub path: String,
-    pub storage_resource_id: Option<u32>,
+    pub storage_resource_id: Option<i32>,
     pub primary: bool,
     #[serde(rename = "use")]
     pub _use: bool,
@@ -182,13 +180,13 @@ pub struct VolumeNodeRecord {
 }
 
 impl Id for VolumeNodeRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
 
 impl Id for &VolumeNodeRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -223,13 +221,11 @@ impl Name for VolumeNodeRecord {
 impl From<Row> for VolumeNodeRecord {
     fn from(row: Row) -> Self {
         VolumeNodeRecord {
-            id: row.get::<_, i32>("id") as u32,
-            volume_id: row.get::<_, i32>("volume_id") as u32,
-            host_id: row.get::<_, i32>("host_id") as u32,
+            id: row.get::<_, i32>("id"),
+            volume_id: row.get::<_, i32>("volume_id"),
+            host_id: row.get::<_, i32>("host_id"),
             path: row.get("path"),
-            storage_resource_id: row
-                .get::<_, Option<i32>>("storage_resource_id")
-                .map(|x| x as u32),
+            storage_resource_id: row.get::<_, Option<i32>>("storage_resource_id"),
             primary: row.get("primary"),
             _use: row.get("use"),
             not_deleted: row.get("not_deleted"),
@@ -240,17 +236,17 @@ impl From<Row> for VolumeNodeRecord {
 /// Record from the `chroma_core_managedtargetmount` table
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct ManagedTargetMountRecord {
-    pub id: u32,
-    pub host_id: u32,
+    pub id: i32,
+    pub host_id: i32,
     pub mount_point: Option<String>,
-    pub volume_node_id: u32,
+    pub volume_node_id: i32,
     pub primary: bool,
-    pub target_id: u32,
+    pub target_id: i32,
     pub not_deleted: Option<bool>,
 }
 
 impl Id for ManagedTargetMountRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -265,12 +261,12 @@ impl NotDeleted for ManagedTargetMountRecord {
 impl From<Row> for ManagedTargetMountRecord {
     fn from(row: Row) -> Self {
         ManagedTargetMountRecord {
-            id: row.get::<_, i32>("id") as u32,
-            host_id: row.get::<_, i32>("host_id") as u32,
+            id: row.get::<_, i32>("id"),
+            host_id: row.get::<_, i32>("host_id"),
             mount_point: row.get("mount_point"),
-            volume_node_id: row.get::<_, i32>("volume_node_id") as u32,
+            volume_node_id: row.get::<_, i32>("volume_node_id"),
             primary: row.get("primary"),
-            target_id: row.get::<_, i32>("target_id") as u32,
+            target_id: row.get::<_, i32>("target_id"),
             not_deleted: row.get("not_deleted"),
         }
     }
@@ -287,25 +283,25 @@ impl Name for ManagedTargetMountRecord {
 /// Record from the `chroma_core_managedtarget` table
 #[derive(serde::Deserialize, Debug)]
 pub struct ManagedTargetRecord {
-    id: u32,
+    id: i32,
     state_modified_at: String,
     state: String,
     immutable_state: bool,
     name: Option<String>,
     uuid: Option<String>,
     ha_label: Option<String>,
-    volume_id: u32,
-    inode_size: Option<u32>,
-    bytes_per_inode: Option<u32>,
+    volume_id: i32,
+    inode_size: Option<i32>,
+    bytes_per_inode: Option<i32>,
     inode_count: Option<u64>,
     reformat: bool,
-    active_mount_id: Option<u32>,
+    active_mount_id: Option<i32>,
     not_deleted: Option<bool>,
-    content_type_id: Option<u32>,
+    content_type_id: Option<i32>,
 }
 
 impl Id for ManagedTargetRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -327,21 +323,21 @@ impl Name for ManagedTargetRecord {
 /// Record from the `chroma_core_ostpool` table
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct OstPoolRecord {
-    pub id: u32,
+    pub id: i32,
     pub name: String,
-    pub filesystem_id: u32,
+    pub filesystem_id: i32,
     pub not_deleted: Option<bool>,
-    pub content_type_id: Option<u32>,
+    pub content_type_id: Option<i32>,
 }
 
 impl Id for OstPoolRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
 
 impl Id for &OstPoolRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -356,13 +352,11 @@ impl NotDeleted for OstPoolRecord {
 impl From<Row> for OstPoolRecord {
     fn from(row: Row) -> Self {
         OstPoolRecord {
-            id: row.get::<_, i32>("id") as u32,
+            id: row.get::<_, i32>("id"),
             name: row.get("name"),
-            filesystem_id: row.get::<_, i32>("filesystem_id") as u32,
+            filesystem_id: row.get::<_, i32>("filesystem_id"),
             not_deleted: row.get("not_deleted"),
-            content_type_id: row
-                .get::<_, Option<i32>>("content_type_id")
-                .map(|x| x as u32),
+            content_type_id: row.get::<_, Option<i32>>("content_type_id"),
         }
     }
 }
@@ -390,13 +384,13 @@ impl Label for &OstPoolRecord {
 /// Record from the `chroma_core_ostpool_osts` table
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct OstPoolOstsRecord {
-    pub id: u32,
-    pub ostpool_id: u32,
-    pub managedost_id: u32,
+    pub id: i32,
+    pub ostpool_id: i32,
+    pub managedost_id: i32,
 }
 
 impl Id for OstPoolOstsRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -405,9 +399,9 @@ impl Id for OstPoolOstsRecord {
 impl From<Row> for OstPoolOstsRecord {
     fn from(row: Row) -> Self {
         OstPoolOstsRecord {
-            id: row.get::<_, i32>("id") as u32,
-            ostpool_id: row.get::<_, i32>("ostpool_id") as u32,
-            managedost_id: row.get::<_, i32>("managedost_id") as u32,
+            id: row.get::<_, i32>("id"),
+            ostpool_id: row.get::<_, i32>("ostpool_id"),
+            managedost_id: row.get::<_, i32>("managedost_id"),
         }
     }
 }
@@ -423,13 +417,13 @@ impl Name for OstPoolOstsRecord {
 /// Record from the `chroma_core_managedost` table
 #[derive(serde::Deserialize, Debug)]
 pub struct ManagedOstRecord {
-    managedtarget_ptr_id: u32,
-    index: u32,
-    filesystem_id: u32,
+    managedtarget_ptr_id: i32,
+    index: i32,
+    filesystem_id: i32,
 }
 
 impl Id for ManagedOstRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.managedtarget_ptr_id
     }
 }
@@ -451,13 +445,13 @@ impl Name for ManagedOstRecord {
 /// Record from the `chroma_core_managedmdt` table
 #[derive(serde::Deserialize, Debug)]
 pub struct ManagedMdtRecord {
-    managedtarget_ptr_id: u32,
-    index: u32,
-    filesystem_id: u32,
+    managedtarget_ptr_id: i32,
+    index: i32,
+    filesystem_id: i32,
 }
 
 impl Id for ManagedMdtRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.managedtarget_ptr_id
     }
 }
@@ -479,12 +473,12 @@ impl Name for ManagedMdtRecord {
 /// Record from the `chroma_core_managedhost` table
 #[derive(serde::Deserialize, Debug)]
 pub struct ManagedHostRecord {
-    id: u32,
+    id: i32,
     state_modified_at: String,
     state: String,
     immutable_state: bool,
     not_deleted: Option<bool>,
-    content_type_id: Option<u32>,
+    content_type_id: Option<i32>,
     address: String,
     fqdn: String,
     nodename: String,
@@ -497,7 +491,7 @@ pub struct ManagedHostRecord {
 }
 
 impl Id for ManagedHostRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -519,18 +513,18 @@ impl Name for ManagedHostRecord {
 /// Record from the `chroma_core_alertstate` table
 #[derive(serde::Deserialize, Debug)]
 pub struct AlertStateRecord {
-    id: u32,
-    alert_item_type_id: Option<u32>,
-    alert_item_id: Option<u32>,
+    id: i32,
+    alert_item_type_id: Option<i32>,
+    alert_item_id: Option<i32>,
     alert_type: String,
     begin: String,
     end: Option<String>,
     active: Option<bool>,
     dismissed: bool,
-    severity: u32,
+    severity: i32,
     record_type: String,
     variant: Option<String>,
-    lustre_pid: Option<u32>,
+    lustre_pid: Option<i32>,
     message: Option<String>,
 }
 
@@ -541,7 +535,7 @@ impl AlertStateRecord {
 }
 
 impl Id for AlertStateRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -557,8 +551,8 @@ impl Name for AlertStateRecord {
 /// Record from the `chroma_core_stratagemconfiguration` table
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct StratagemConfiguration {
-    pub id: u32,
-    pub filesystem_id: u32,
+    pub id: i32,
+    pub filesystem_id: i32,
     pub interval: u64,
     pub report_duration: Option<u64>,
     pub purge_duration: Option<u64>,
@@ -571,8 +565,8 @@ pub struct StratagemConfiguration {
 impl From<Row> for StratagemConfiguration {
     fn from(row: Row) -> Self {
         StratagemConfiguration {
-            id: row.get::<_, i32>("id") as u32,
-            filesystem_id: row.get::<_, i32>("filesystem_id") as u32,
+            id: row.get::<_, i32>("id"),
+            filesystem_id: row.get::<_, i32>("filesystem_id"),
             interval: row.get::<_, i64>("interval") as u64,
             report_duration: row
                 .get::<_, Option<i64>>("report_duration")
@@ -588,7 +582,7 @@ impl From<Row> for StratagemConfiguration {
 }
 
 impl Id for StratagemConfiguration {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -623,32 +617,30 @@ impl EndpointName for StratagemConfiguration {
 /// Record from the `chroma_core_lnetconfiguration` table
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct LnetConfigurationRecord {
-    pub id: u32,
+    pub id: i32,
     pub state: String,
-    pub host_id: u32,
+    pub host_id: i32,
     pub immutable_state: bool,
     pub not_deleted: Option<bool>,
-    pub content_type_id: Option<u32>,
+    pub content_type_id: Option<i32>,
 }
 
 #[cfg(feature = "postgres-interop")]
 impl From<Row> for LnetConfigurationRecord {
     fn from(row: Row) -> Self {
         LnetConfigurationRecord {
-            id: row.get::<_, i32>("id") as u32,
+            id: row.get::<_, i32>("id"),
             state: row.get("state"),
-            host_id: row.get::<_, i32>("host_id") as u32,
+            host_id: row.get::<_, i32>("host_id"),
             immutable_state: row.get("immutable_state"),
             not_deleted: row.get("not_deleted"),
-            content_type_id: row
-                .get::<_, Option<i32>>("content_type_id")
-                .map(|x| x as u32),
+            content_type_id: row.get::<_, Option<i32>>("content_type_id"),
         }
     }
 }
 
 impl Id for LnetConfigurationRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -1047,7 +1039,7 @@ impl From<Row> for DeviceHost {
 /// Record from the `auth_user` table
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct AuthUserRecord {
-    pub id: u32,
+    pub id: i32,
     pub is_superuser: bool,
     pub username: String,
     pub first_name: String,
@@ -1066,7 +1058,7 @@ impl Name for AuthUserRecord {
 }
 
 impl Id for AuthUserRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -1075,7 +1067,7 @@ impl Id for AuthUserRecord {
 impl From<Row> for AuthUserRecord {
     fn from(row: Row) -> Self {
         Self {
-            id: row.get::<_, i32>("id") as u32,
+            id: row.get::<_, i32>("id"),
             is_superuser: row.get("is_superuser"),
             username: row.get("username"),
             first_name: row.get("first_name"),
@@ -1090,9 +1082,9 @@ impl From<Row> for AuthUserRecord {
 /// Record from the `auth_user_groups` table
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct AuthUserGroupRecord {
-    pub id: u32,
-    pub user_id: u32,
-    pub group_id: u32,
+    pub id: i32,
+    pub user_id: i32,
+    pub group_id: i32,
 }
 
 pub const AUTH_USER_GROUP_TABLE_NAME: TableName = TableName("auth_user_groups");
@@ -1104,7 +1096,7 @@ impl Name for AuthUserGroupRecord {
 }
 
 impl Id for AuthUserGroupRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -1113,9 +1105,9 @@ impl Id for AuthUserGroupRecord {
 impl From<Row> for AuthUserGroupRecord {
     fn from(row: Row) -> Self {
         Self {
-            id: row.get::<_, i32>("id") as u32,
-            user_id: row.get::<_, i32>("user_id") as u32,
-            group_id: row.get::<_, i32>("group_id") as u32,
+            id: row.get::<_, i32>("id"),
+            user_id: row.get::<_, i32>("user_id"),
+            group_id: row.get::<_, i32>("group_id"),
         }
     }
 }
@@ -1123,7 +1115,7 @@ impl From<Row> for AuthUserGroupRecord {
 /// Record from the `auth_group` table
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct AuthGroupRecord {
-    pub id: u32,
+    pub id: i32,
     pub name: String,
 }
 
@@ -1136,7 +1128,7 @@ impl Name for AuthGroupRecord {
 }
 
 impl Id for AuthGroupRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -1145,7 +1137,7 @@ impl Id for AuthGroupRecord {
 impl From<Row> for AuthGroupRecord {
     fn from(row: Row) -> Self {
         Self {
-            id: row.get::<_, i32>("id") as u32,
+            id: row.get::<_, i32>("id"),
             name: row.get("name"),
         }
     }
@@ -1154,12 +1146,12 @@ impl From<Row> for AuthGroupRecord {
 /// Record from the `chroma_core_pacemakerconfiguration` table
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct PacemakerConfigurationRecord {
-    pub id: u32,
+    pub id: i32,
     pub state: String,
     pub immutable_state: bool,
     pub not_deleted: Option<bool>,
-    pub content_type_id: Option<u32>,
-    pub host_id: u32,
+    pub content_type_id: Option<i32>,
+    pub host_id: i32,
 }
 
 pub const PACEMAKER_CONFIGURATION_TABLE_NAME: TableName =
@@ -1172,7 +1164,7 @@ impl Name for PacemakerConfigurationRecord {
 }
 
 impl Id for PacemakerConfigurationRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -1211,14 +1203,12 @@ impl ToCompositeId for &PacemakerConfigurationRecord {
 impl From<Row> for PacemakerConfigurationRecord {
     fn from(row: Row) -> Self {
         Self {
-            id: row.get::<_, i32>("id") as u32,
+            id: row.get::<_, i32>("id"),
             state: row.get("state"),
             immutable_state: row.get("immutable_state"),
             not_deleted: row.get("not_deleted"),
-            content_type_id: row
-                .get::<_, Option<i32>>("content_type_id")
-                .map(|x| x as u32),
-            host_id: row.get::<_, i32>("host_id") as u32,
+            content_type_id: row.get::<_, Option<i32>>("content_type_id"),
+            host_id: row.get::<_, i32>("host_id"),
         }
     }
 }
@@ -1226,14 +1216,14 @@ impl From<Row> for PacemakerConfigurationRecord {
 /// Record from the `chroma_core_corosyncconfiguration` table
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CorosyncConfigurationRecord {
-    pub id: u32,
+    pub id: i32,
     pub state: String,
     pub immutable_state: bool,
     pub not_deleted: Option<bool>,
-    pub mcast_port: Option<u32>,
+    pub mcast_port: Option<i32>,
     pub corosync_reported_up: bool,
-    pub content_type_id: Option<u32>,
-    pub host_id: u32,
+    pub content_type_id: Option<i32>,
+    pub host_id: i32,
 }
 
 pub const COROSYNC_CONFIGURATION_TABLE_NAME: TableName =
@@ -1246,7 +1236,7 @@ impl Name for CorosyncConfigurationRecord {
 }
 
 impl Id for CorosyncConfigurationRecord {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -1285,16 +1275,14 @@ impl ToCompositeId for &CorosyncConfigurationRecord {
 impl From<Row> for CorosyncConfigurationRecord {
     fn from(row: Row) -> Self {
         Self {
-            id: row.get::<_, i32>("id") as u32,
+            id: row.get::<_, i32>("id"),
             state: row.get("state"),
             immutable_state: row.get("immutable_state"),
             not_deleted: row.get("not_deleted"),
-            mcast_port: row.get::<_, Option<i32>>("mcast_port").map(|x| x as u32),
+            mcast_port: row.get::<_, Option<i32>>("mcast_port"),
             corosync_reported_up: row.get("corosync_reported_up"),
-            content_type_id: row
-                .get::<_, Option<i32>>("content_type_id")
-                .map(|x| x as u32),
-            host_id: row.get::<_, i32>("host_id") as u32,
+            content_type_id: row.get::<_, Option<i32>>("content_type_id"),
+            host_id: row.get::<_, i32>("host_id"),
         }
     }
 }

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -280,7 +280,7 @@ impl<T: serde::Serialize> ToBytes for T {
 )]
 #[serde(try_from = "String")]
 #[serde(into = "String")]
-pub struct CompositeId(pub u32, pub u32);
+pub struct CompositeId(pub i32, pub i32);
 
 impl fmt::Display for CompositeId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -304,8 +304,8 @@ impl TryFrom<String> for CompositeId {
             return Err("Could not convert to CompositeId, String did not contain 2 parts.".into());
         }
 
-        let x = xs[0].parse::<u32>()?;
-        let y = xs[1].parse::<u32>()?;
+        let x = xs[0].parse::<i32>()?;
+        let y = xs[1].parse::<i32>()?;
 
         Ok(Self(x, y))
     }
@@ -370,8 +370,8 @@ pub enum LockAction {
 pub struct LockChange {
     pub uuid: String,
     pub job_id: u64,
-    pub content_type_id: u32,
-    pub item_id: u32,
+    pub content_type_id: i32,
+    pub item_id: i32,
     pub description: String,
     pub lock_type: LockType,
     pub action: LockAction,
@@ -467,8 +467,8 @@ impl EndpointName for AvailableAction {
 /// A `NtpConfiguration` record from `/api/ntp_configuration/`
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct NtpConfiguration {
-    pub content_type_id: u32,
-    pub id: u32,
+    pub content_type_id: i32,
+    pub id: i32,
     pub immutable_state: bool,
     pub label: String,
     pub not_deleted: Option<bool>,
@@ -496,11 +496,11 @@ pub struct Host {
     pub address: String,
     pub boot_time: Option<String>,
     pub client_mounts: Option<Vec<ClientMount>>,
-    pub content_type_id: u32,
+    pub content_type_id: i32,
     pub corosync_configuration: Option<String>,
     pub corosync_ring0: String,
     pub fqdn: String,
-    pub id: u32,
+    pub id: i32,
     pub immutable_state: bool,
     pub install_method: String,
     pub label: String,
@@ -522,22 +522,22 @@ pub struct Host {
 
 impl Host {
     /// Get associated LNet configuration id
-    pub fn lnet_id(&self) -> Option<u32> {
+    pub fn lnet_id(&self) -> Option<i32> {
         let id = iml_api_utils::extract_id(&self.lnet_configuration)?;
 
-        id.parse::<u32>().ok()
+        id.parse::<i32>().ok()
     }
     /// Get associated Corosync configuration id
-    pub fn corosync_id(&self) -> Option<u32> {
+    pub fn corosync_id(&self) -> Option<i32> {
         let id = iml_api_utils::extract_id(self.corosync_configuration.as_ref()?)?;
 
-        id.parse::<u32>().ok()
+        id.parse::<i32>().ok()
     }
     /// Get associated Pacemaker configuration id
-    pub fn pacemaker_id(&self) -> Option<u32> {
+    pub fn pacemaker_id(&self) -> Option<i32> {
         let id = iml_api_utils::extract_id(self.pacemaker_configuration.as_ref()?)?;
 
-        id.parse::<u32>().ok()
+        id.parse::<i32>().ok()
     }
 }
 
@@ -568,13 +568,13 @@ impl Label for &Host {
 }
 
 impl db::Id for Host {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
 
 impl db::Id for &Host {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -622,7 +622,7 @@ pub struct HostProfileWrapper {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct HostProfile {
     pub address: String,
-    pub host: u32,
+    pub host: i32,
     pub profiles: HashMap<String, Vec<ProfileTest>>,
     pub profiles_valid: bool,
     pub resource_uri: String,
@@ -653,7 +653,7 @@ pub struct Command {
     pub complete: bool,
     pub created_at: String,
     pub errored: bool,
-    pub id: u32,
+    pub id: i32,
     pub jobs: Vec<String>,
     pub logs: String,
     pub message: String,
@@ -668,8 +668,8 @@ impl EndpointName for Command {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct JobLock {
-    pub locked_item_content_type_id: u32,
-    pub locked_item_id: u32,
+    pub locked_item_content_type_id: i32,
+    pub locked_item_id: i32,
     pub locked_item_uri: String,
     pub resource_uri: String,
 }
@@ -689,7 +689,7 @@ pub struct Job<T> {
     pub created_at: String,
     pub description: String,
     pub errored: bool,
-    pub id: u32,
+    pub id: i32,
     pub modified_at: String,
     pub read_locks: Vec<JobLock>,
     pub resource_uri: String,
@@ -729,14 +729,14 @@ pub struct Step {
     pub console: String,
     pub created_at: String,
     pub description: String,
-    pub id: u32,
+    pub id: i32,
     pub log: String,
     pub modified_at: String,
     pub resource_uri: String,
     pub result: Option<String>,
     pub state: String,
-    pub step_count: u32,
-    pub step_index: u32,
+    pub step_count: i32,
+    pub step_index: i32,
 }
 
 impl EndpointName for Step {
@@ -835,7 +835,7 @@ pub struct OstConfParams {
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct Volume {
     pub filesystem_type: Option<String>,
-    pub id: u32,
+    pub id: i32,
     pub kind: String,
     pub label: String,
     pub resource_uri: String,
@@ -861,13 +861,13 @@ impl Label for &Volume {
 }
 
 impl db::Id for Volume {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
 
 impl db::Id for &Volume {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -881,15 +881,15 @@ impl EndpointName for Volume {
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct VolumeNode {
     pub host: String,
-    pub host_id: u32,
+    pub host_id: i32,
     pub host_label: String,
-    pub id: u32,
+    pub id: i32,
     pub path: String,
     pub primary: bool,
     pub resource_uri: String,
     #[serde(rename = "use")]
     pub _use: bool,
-    pub volume_id: u32,
+    pub volume_id: i32,
 }
 
 impl FlatQuery for VolumeNode {}
@@ -928,19 +928,19 @@ pub struct Target<T> {
     pub active_host: Option<String>,
     pub active_host_name: String,
     pub conf_params: Option<T>,
-    pub content_type_id: u32,
+    pub content_type_id: i32,
     pub failover_server_name: String,
     pub failover_servers: Vec<String>,
     pub filesystem: Option<String>,
-    pub filesystem_id: Option<u32>,
+    pub filesystem_id: Option<i32>,
     pub filesystem_name: Option<String>,
     pub filesystems: Option<Vec<FilesystemShort>>,
     pub ha_label: Option<String>,
-    pub id: u32,
+    pub id: i32,
     pub immutable_state: bool,
-    pub index: Option<u32>,
+    pub index: Option<i32>,
     pub inode_count: Option<u64>,
-    pub inode_size: Option<u32>,
+    pub inode_size: Option<i32>,
     pub kind: TargetKind,
     pub label: String,
     pub name: String,
@@ -991,7 +991,7 @@ impl<T> EndpointName for Target<T> {
 }
 
 impl<T> db::Id for Target<T> {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -1027,11 +1027,11 @@ pub struct Filesystem {
     pub cdt_status: Option<String>,
     pub client_count: Option<u64>,
     pub conf_params: FilesystemConfParams,
-    pub content_type_id: u32,
+    pub content_type_id: i32,
     pub files_free: Option<u64>,
     pub files_total: Option<u64>,
     pub hsm_control_params: Option<Vec<HsmControlParam>>,
-    pub id: u32,
+    pub id: i32,
     pub immutable_state: bool,
     pub label: String,
     pub mdts: Vec<Mdt>,
@@ -1076,13 +1076,13 @@ impl Label for &Filesystem {
 }
 
 impl db::Id for Filesystem {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
 
 impl db::Id for &Filesystem {
-    fn id(&self) -> u32 {
+    fn id(&self) -> i32 {
         self.id
     }
 }
@@ -1095,7 +1095,7 @@ impl EndpointName for Filesystem {
 
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct FilesystemShort {
-    pub id: u32,
+    pub id: i32,
     pub name: String,
 }
 
@@ -1168,7 +1168,7 @@ pub struct Alert {
     pub begin: String,
     pub dismissed: bool,
     pub end: Option<String>,
-    pub id: u32,
+    pub id: i32,
     pub lustre_pid: Option<i32>,
     pub message: String,
     pub record_type: AlertRecordType,
@@ -1237,9 +1237,9 @@ pub enum LogSeverity {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Log {
     pub datetime: String,
-    pub facility: u32,
+    pub facility: i32,
     pub fqdn: String,
-    pub id: u32,
+    pub id: i32,
     pub message: String,
     pub message_class: MessageClass,
     pub resource_uri: String,
@@ -1257,9 +1257,9 @@ impl EndpointName for Log {
 /// A `StratagemConfiguration` record from `api/stratagem_configuration`.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct StratagemConfiguration {
-    pub content_type_id: u32,
+    pub content_type_id: i32,
     pub filesystem: String,
-    pub id: u32,
+    pub id: i32,
     pub immutable_state: bool,
     pub interval: u64,
     pub label: String,
@@ -1295,7 +1295,7 @@ impl EndpointName for AlertType {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct AlertSubscription {
     pub alert_type: AlertType,
-    pub id: u32,
+    pub id: i32,
     pub resource_uri: String,
     pub user: String,
 }
@@ -1317,7 +1317,7 @@ pub enum GroupType {
 /// A `Group` record from `api/group`.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Group {
-    pub id: u32,
+    pub id: i32,
     pub name: GroupType,
     pub resource_uri: String,
 }
@@ -1336,7 +1336,7 @@ pub struct User {
     pub first_name: String,
     pub full_name: String,
     pub groups: Option<Vec<Group>>,
-    pub id: u32,
+    pub id: i32,
     pub is_superuser: bool,
     pub last_name: String,
     pub new_password1: Option<String>,
@@ -1527,7 +1527,7 @@ pub struct ComponentState<T: Default> {
 /// An OST Pool record from `/api/ostpool/`
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct OstPoolApi {
-    pub id: u32,
+    pub id: i32,
     pub resource_uri: String,
     #[serde(flatten)]
     pub ost: OstPool,

--- a/iml-wire-types/src/warp_drive.rs
+++ b/iml-wire-types/src/warp_drive.rs
@@ -90,44 +90,44 @@ pub type Locks = HashMap<String, HashSet<LockChange>>;
 
 #[derive(serde::Serialize, serde::Deserialize, Default, PartialEq, Clone, Debug)]
 pub struct Cache {
-    pub content_type: HashMap<u32, ContentTypeRecord>,
-    pub corosync_configuration: HashMap<u32, CorosyncConfigurationRecord>,
-    pub active_alert: HashMap<u32, Alert>,
-    pub filesystem: HashMap<u32, Filesystem>,
-    pub group: HashMap<u32, AuthGroupRecord>,
-    pub host: HashMap<u32, Host>,
-    pub lnet_configuration: HashMap<u32, LnetConfigurationRecord>,
-    pub managed_target_mount: HashMap<u32, ManagedTargetMountRecord>,
-    pub ost_pool: HashMap<u32, OstPoolRecord>,
-    pub ost_pool_osts: HashMap<u32, OstPoolOstsRecord>,
-    pub stratagem_config: HashMap<u32, StratagemConfiguration>,
-    pub target: HashMap<u32, Target<TargetConfParam>>,
-    pub user: HashMap<u32, AuthUserRecord>,
-    pub user_group: HashMap<u32, AuthUserGroupRecord>,
-    pub pacemaker_configuration: HashMap<u32, PacemakerConfigurationRecord>,
-    pub volume: HashMap<u32, VolumeRecord>,
-    pub volume_node: HashMap<u32, VolumeNodeRecord>,
+    pub content_type: HashMap<i32, ContentTypeRecord>,
+    pub corosync_configuration: HashMap<i32, CorosyncConfigurationRecord>,
+    pub active_alert: HashMap<i32, Alert>,
+    pub filesystem: HashMap<i32, Filesystem>,
+    pub group: HashMap<i32, AuthGroupRecord>,
+    pub host: HashMap<i32, Host>,
+    pub lnet_configuration: HashMap<i32, LnetConfigurationRecord>,
+    pub managed_target_mount: HashMap<i32, ManagedTargetMountRecord>,
+    pub ost_pool: HashMap<i32, OstPoolRecord>,
+    pub ost_pool_osts: HashMap<i32, OstPoolOstsRecord>,
+    pub stratagem_config: HashMap<i32, StratagemConfiguration>,
+    pub target: HashMap<i32, Target<TargetConfParam>>,
+    pub user: HashMap<i32, AuthUserRecord>,
+    pub user_group: HashMap<i32, AuthUserGroupRecord>,
+    pub pacemaker_configuration: HashMap<i32, PacemakerConfigurationRecord>,
+    pub volume: HashMap<i32, VolumeRecord>,
+    pub volume_node: HashMap<i32, VolumeNodeRecord>,
 }
 
 #[derive(Default, PartialEq, Clone, Debug)]
 pub struct ArcCache {
-    pub content_type: HashMap<u32, Arc<ContentTypeRecord>>,
-    pub corosync_configuration: HashMap<u32, Arc<CorosyncConfigurationRecord>>,
-    pub active_alert: HashMap<u32, Arc<Alert>>,
-    pub filesystem: HashMap<u32, Arc<Filesystem>>,
-    pub group: HashMap<u32, Arc<AuthGroupRecord>>,
-    pub host: HashMap<u32, Arc<Host>>,
-    pub lnet_configuration: HashMap<u32, Arc<LnetConfigurationRecord>>,
-    pub managed_target_mount: HashMap<u32, Arc<ManagedTargetMountRecord>>,
-    pub ost_pool: HashMap<u32, Arc<OstPoolRecord>>,
-    pub ost_pool_osts: HashMap<u32, Arc<OstPoolOstsRecord>>,
-    pub pacemaker_configuration: HashMap<u32, Arc<PacemakerConfigurationRecord>>,
-    pub stratagem_config: HashMap<u32, Arc<StratagemConfiguration>>,
-    pub target: HashMap<u32, Arc<Target<TargetConfParam>>>,
-    pub user: HashMap<u32, Arc<AuthUserRecord>>,
-    pub user_group: HashMap<u32, Arc<AuthUserGroupRecord>>,
-    pub volume: HashMap<u32, Arc<VolumeRecord>>,
-    pub volume_node: HashMap<u32, Arc<VolumeNodeRecord>>,
+    pub content_type: HashMap<i32, Arc<ContentTypeRecord>>,
+    pub corosync_configuration: HashMap<i32, Arc<CorosyncConfigurationRecord>>,
+    pub active_alert: HashMap<i32, Arc<Alert>>,
+    pub filesystem: HashMap<i32, Arc<Filesystem>>,
+    pub group: HashMap<i32, Arc<AuthGroupRecord>>,
+    pub host: HashMap<i32, Arc<Host>>,
+    pub lnet_configuration: HashMap<i32, Arc<LnetConfigurationRecord>>,
+    pub managed_target_mount: HashMap<i32, Arc<ManagedTargetMountRecord>>,
+    pub ost_pool: HashMap<i32, Arc<OstPoolRecord>>,
+    pub ost_pool_osts: HashMap<i32, Arc<OstPoolOstsRecord>>,
+    pub pacemaker_configuration: HashMap<i32, Arc<PacemakerConfigurationRecord>>,
+    pub stratagem_config: HashMap<i32, Arc<StratagemConfiguration>>,
+    pub target: HashMap<i32, Arc<Target<TargetConfParam>>>,
+    pub user: HashMap<i32, Arc<AuthUserRecord>>,
+    pub user_group: HashMap<i32, Arc<AuthUserGroupRecord>>,
+    pub volume: HashMap<i32, Arc<VolumeRecord>>,
+    pub volume_node: HashMap<i32, Arc<VolumeNodeRecord>>,
 }
 
 impl Cache {
@@ -458,29 +458,29 @@ impl From<Record> for ArcRecord {
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(tag = "tag", content = "payload")]
 pub enum RecordId {
-    ActiveAlert(u32),
-    ContentType(u32),
-    CorosyncConfiguration(u32),
-    Filesystem(u32),
-    Group(u32),
-    Host(u32),
-    LnetConfiguration(u32),
-    ManagedTargetMount(u32),
-    OstPool(u32),
-    OstPoolOsts(u32),
-    PacemakerConfiguration(u32),
-    StratagemConfig(u32),
-    Target(u32),
-    User(u32),
-    UserGroup(u32),
-    Volume(u32),
-    VolumeNode(u32),
+    ActiveAlert(i32),
+    ContentType(i32),
+    CorosyncConfiguration(i32),
+    Filesystem(i32),
+    Group(i32),
+    Host(i32),
+    LnetConfiguration(i32),
+    ManagedTargetMount(i32),
+    OstPool(i32),
+    OstPoolOsts(i32),
+    PacemakerConfiguration(i32),
+    StratagemConfig(i32),
+    Target(i32),
+    User(i32),
+    UserGroup(i32),
+    Volume(i32),
+    VolumeNode(i32),
 }
 
 impl Deref for RecordId {
-    type Target = u32;
+    type Target = i32;
 
-    fn deref(&self) -> &u32 {
+    fn deref(&self) -> &i32 {
         match self {
             Self::ActiveAlert(x)
             | Self::ContentType(x)


### PR DESCRIPTION
Postgres does not support unsigned numbers (besides the oid type).
As such, all ids in IML are actually signed 32 bit ints.

Update the representation of these types in wire-types and other spots to reflect this.

This will pave the way for using diesel struct types instead of
repeating types in both iml-orm and wire-types.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1910)
<!-- Reviewable:end -->
