### PR TITLE
Avoid pg_notify if rows are identical

### DIFF
--- a/chroma_core/migrations/__init__.py
+++ b/chroma_core/migrations/__init__.py
@@ -14,7 +14,9 @@ forward_function_template = fill_template(
     """
 CREATE OR REPLACE FUNCTION table_%(function_name)s_update_notify() RETURNS trigger AS $$
 BEGIN
-    IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    IF TG_OP = 'INSERT' THEN
+        PERFORM pg_notify('table_update', '[ "' || TG_OP || '", "' || TG_TABLE_NAME || '", ' || row_to_json(NEW) || ']');
+    ELSEIF TG_OP = 'UPDATE' AND OLD IS DISTINCT FROM NEW THEN
         PERFORM pg_notify('table_update', '[ "' || TG_OP || '", "' || TG_TABLE_NAME || '", ' || row_to_json(NEW) || ']');
     ELSE
         PERFORM pg_notify('table_update', '[ "' || TG_OP || '", "' || TG_TABLE_NAME || '", ' || row_to_json(OLD) || ']');


### PR DESCRIPTION
There are cases (which are becoming more common with upsert + polling)
where rows have not actually changed.

When this occurs we send a pg_notify event, even though the OLD and NEW
rows are identical.

Add a new if branch that will return early if NEW is equal to OLD.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1913)
<!-- Reviewable:end -->
