### PR TITLE
Make dashboard containers fill vertical space

### DIFF
--- a/iml-gui/configs/tailwind.config.js
+++ b/iml-gui/configs/tailwind.config.js
@@ -8,7 +8,7 @@ function* range(start, end, step) {
 // For NodeJS < 12
 Object.fromEntries =
   Object.fromEntries ||
-  (iterable => {
+  ((iterable) => {
     return [...iterable].reduce((obj, [key, val]) => {
       obj[key] = val;
       return obj;
@@ -27,7 +27,7 @@ module.exports = {
       lg: "1025px",
       // => @media (min-width: 1025px) { ... }
 
-      xl: "1701px"
+      xl: "1701px",
       // => @media (min-width: 1701px) { ... }
     },
     fontFamily: {
@@ -47,16 +47,16 @@ module.exports = {
         "Apple Color Emoji",
         "Segoe UI Emoji",
         "Segoe UI Symbol",
-        "Noto Color Emoji"
-      ]
+        "Noto Color Emoji",
+      ],
     },
     fontSize: (() => {
       const x = Object.fromEntries(
         [
           ...range(15, 35, 1),
           ...range(40, 60, 5),
-          ...range(70, 120, 10)
-        ].map(i => [i, `${i}px`])
+          ...range(70, 120, 10),
+        ].map((i) => [i, `${i}px`])
       );
 
       return {
@@ -70,17 +70,19 @@ module.exports = {
         "3xl": "1.875rem",
         "4xl": "2.25rem",
         "5xl": "3rem",
-        "6xl": "4rem"
+        "6xl": "4rem",
       };
     })(),
     opacity: (() => {
-      return Object.fromEntries([...range(0, 100, 10)].map(i => [i, i / 100]));
+      return Object.fromEntries(
+        [...range(0, 100, 10)].map((i) => [i, i / 100])
+      );
     })(),
     extend: {
       boxShadow: {
         "2xl-above":
           "0 25px 50px 15px rgba(0, 0, 0, 0.25), 0 10px 10px 10px rgba(0, 0, 0, 0.25)",
-        glow: "0 0 5px 2px hsl(205, 97%, 85%)"
+        glow: "0 0 5px 2px hsl(205, 97%, 85%)",
       },
       margin: {
         "-10vh": "-10vh",
@@ -109,17 +111,17 @@ module.exports = {
         "3040px": "3040px",
         "3870px": "3870px",
         "5030px": "5030px",
-        "6070px": "6070px"
+        "6070px": "6070px",
       },
       padding: {
         "84": "21rem",
-        "96": "24rem"
+        "96": "24rem",
       },
       inset: {
         "1/2": "50%",
         full: "100%",
         "-full": "-100%",
-        "-50vw": "-50vw"
+        "-50vw": "-50vw",
       },
       width: {
         "36": "9rem",
@@ -148,12 +150,12 @@ module.exports = {
         "2460px": "2460px",
         "2560px": "2560px",
         "50vh": "50vh",
-        "50vw": "50vw"
+        "50vw": "50vw",
       },
       maxWidth: {
         none: "none",
         "8xl": "88rem",
-        "400": "100rem"
+        "400": "100rem",
       },
       height: {
         "main-content": "calc(100vh - 6.6rem)",
@@ -186,7 +188,10 @@ module.exports = {
         "2560px": "2560px",
         "3670px": "3670px",
         "80": "20rem",
-        "96": "24rem"
+        "96": "24rem",
+      },
+      minHeight: {
+        "80": "20rem",
       },
       borderRadius: {
         "28px": "28px",
@@ -196,13 +201,13 @@ module.exports = {
         "110px": "110px",
         "140px": "140px",
         "260px": "260px",
-        "330px": "330px"
+        "330px": "330px",
       },
       textColor: {
-        active: "#3793FF"
+        active: "#3793FF",
       },
       cursor: {
-        "ew-resize": "ew-resize"
+        "ew-resize": "ew-resize",
       },
       colors: {
         black: "#000",
@@ -210,33 +215,36 @@ module.exports = {
         menu: "#344151",
         "menu-active": "#1C2A3C",
         "blue-1000": "#0D1B2C",
-        "throughput-background": "#5350FB"
+        "throughput-background": "#5350FB",
       },
       strokeWidth: {
         "3": "3",
         "4": "4",
         "5": "5",
-        "6": "6"
+        "6": "6",
+        "8": "8",
+        "10": "10",
+        "20": "20",
       },
       transitionProperty: {
-        stroke_dashoffset: "stroke-dashoffset"
-      }
-    }
+        stroke_dashoffset: "stroke-dashoffset",
+      },
+    },
   },
   variants: {
     display: ["group-hover", "group-focus", "responsive"],
     textColor: ["hover", "group-hover", "focus"],
-    borderWidth: ["responsive", "last", "hover", "focus"]
+    borderWidth: ["responsive", "last", "hover", "focus"],
   },
   plugins: [
-    function({ addVariant }) {
+    function ({ addVariant }) {
       addVariant("group-focus", ({ container, separator }) => {
-        container.walkRules(rule => {
+        container.walkRules((rule) => {
           rule.selector = `.group:focus-within .group-focus\\:${rule.selector.slice(
             1
           )}`;
         });
       });
-    }
-  ]
+    },
+  ],
 };

--- a/iml-gui/crate/src/components/dashboard/dashboard_fs_usage.rs
+++ b/iml-gui/crate/src/components/dashboard/dashboard_fs_usage.rs
@@ -14,7 +14,7 @@ pub fn view<T>(model: &fs_usage::Model) -> Node<T> {
         let color = progress_circle::used_to_color(model.percent_used);
 
         let dashboard_chart = div![
-            class![C.grid, C.grid_cols_3, C.gap_2, C.items_center, C.h_full],
+            class![C.grid, C.grid_cols_3, C.gap_2, C.items_center, C.h_full, C.min_h_80],
             div![
                 class![C.justify_self_end, C.p_2],
                 p![class![color], number_formatter::format_bytes(metrics.bytes_used, 1)],

--- a/iml-gui/crate/src/components/dashboard/mod.rs
+++ b/iml-gui/crate/src/components/dashboard/mod.rs
@@ -21,7 +21,7 @@ pub(crate) fn performance_container(
     vars: impl IntoIterator<Item = (impl ToString, impl ToString)> + Clone,
 ) -> Node<datepicker::Msg> {
     div![
-        class![C.h_80, C.px_2],
+        class![C.h_full, C.min_h_80, C.px_2],
         div![
             class![C.text_center],
             p![

--- a/iml-gui/crate/src/page/dashboard.rs
+++ b/iml-gui/crate/src/page/dashboard.rs
@@ -44,7 +44,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
 
 pub fn view(model: &Model) -> Node<Msg> {
     div![
-        class![C.grid, C.lg__grid_cols_2, C.gap_6],
+        class![C.grid, C.lg__grid_cols_2, C.gap_6, C.h_full],
         vec![
             dashboard_fs_usage::view(&model.fs_usage),
             dashboard_container::view(
@@ -72,7 +72,7 @@ pub fn view(model: &Model) -> Node<Msg> {
             dashboard_container::view(
                 "LNET Performance",
                 div![
-                    class![C.h_80, C.p_2],
+                    class![C.h_full, C.min_h_80, C.p_2],
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,

--- a/iml-gui/crate/src/page/fs_dashboard.rs
+++ b/iml-gui/crate/src/page/fs_dashboard.rs
@@ -69,7 +69,7 @@ pub fn view(model: &Model) -> Node<Msg> {
             dashboard_container::view(
                 "Filesystem Usage",
                 div![
-                    class![C.h_80, C.p_2],
+                    class![C.h_full, C.min_h_80, C.p_2],
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
@@ -90,7 +90,7 @@ pub fn view(model: &Model) -> Node<Msg> {
             dashboard_container::view(
                 "OST Balance",
                 div![
-                    class![C.h_80, C.p_2],
+                    class![C.h_full, C.min_h_80, C.p_2],
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
@@ -102,7 +102,7 @@ pub fn view(model: &Model) -> Node<Msg> {
             dashboard_container::view(
                 "MDT Usage",
                 div![
-                    class![C.h_80, C.p_2],
+                    class![C.h_full, C.min_h_80, C.p_2],
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,

--- a/iml-gui/crate/src/page/server_dashboard.rs
+++ b/iml-gui/crate/src/page/server_dashboard.rs
@@ -27,7 +27,7 @@ pub fn view(_: &ArcCache, model: &Model) -> impl View<Msg> {
             dashboard_container::view(
                 "Read/Write Bandwidth",
                 div![
-                    class![C.h_80, C.p_2],
+                    class![C.h_full, C.min_h_80, C.p_2],
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
@@ -39,7 +39,7 @@ pub fn view(_: &ArcCache, model: &Model) -> impl View<Msg> {
             dashboard_container::view(
                 "CPU Usage",
                 div![
-                    class![C.h_80, C.p_2],
+                    class![C.h_full, C.min_h_80, C.p_2],
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
@@ -51,7 +51,7 @@ pub fn view(_: &ArcCache, model: &Model) -> impl View<Msg> {
             dashboard_container::view(
                 "Memory Usage",
                 div![
-                    class![C.h_80, C.p_2],
+                    class![C.h_full, C.min_h_80, C.p_2],
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,
@@ -63,7 +63,7 @@ pub fn view(_: &ArcCache, model: &Model) -> impl View<Msg> {
             dashboard_container::view(
                 "LNET Usage",
                 div![
-                    class![C.h_80, C.p_2],
+                    class![C.h_full, C.min_h_80, C.p_2],
                     grafana_chart::view(
                         IML_METRICS_DASHBOARD_ID,
                         IML_METRICS_DASHBOARD_NAME,

--- a/iml-gui/crate/src/page/target_dashboard.rs
+++ b/iml-gui/crate/src/page/target_dashboard.rs
@@ -58,7 +58,7 @@ pub fn view(_: &ArcCache, model: &Model) -> Node<Msg> {
                 dashboard_container::view(
                     "Metadata Operations",
                     div![
-                        class![C.h_80, C.p_2],
+                        class![C.h_full, C.min_h_80, C.p_2],
                         grafana_chart::view(
                             IML_METRICS_DASHBOARD_ID,
                             IML_METRICS_DASHBOARD_NAME,
@@ -70,7 +70,7 @@ pub fn view(_: &ArcCache, model: &Model) -> Node<Msg> {
                 dashboard_container::view(
                     "Space Usage",
                     div![
-                        class![C.h_80, C.p_2],
+                        class![C.h_full, C.min_h_80, C.p_2],
                         grafana_chart::view(
                             IML_METRICS_DASHBOARD_ID,
                             IML_METRICS_DASHBOARD_NAME,
@@ -82,7 +82,7 @@ pub fn view(_: &ArcCache, model: &Model) -> Node<Msg> {
                 dashboard_container::view(
                     "File Usage",
                     div![
-                        class![C.h_80, C.p_2],
+                        class![C.h_full, C.min_h_80, C.p_2],
                         grafana_chart::view(
                             IML_METRICS_DASHBOARD_ID,
                             IML_METRICS_DASHBOARD_NAME,
@@ -110,7 +110,7 @@ pub fn view(_: &ArcCache, model: &Model) -> Node<Msg> {
                 dashboard_container::view(
                     "Space Usage",
                     div![
-                        class![C.h_80, C.p_2],
+                        class![C.h_full, C.min_h_80, C.p_2],
                         grafana_chart::view(
                             IML_METRICS_DASHBOARD_ID,
                             IML_METRICS_DASHBOARD_NAME,
@@ -122,7 +122,7 @@ pub fn view(_: &ArcCache, model: &Model) -> Node<Msg> {
                 dashboard_container::view(
                     "Object Usage",
                     div![
-                        class![C.h_80, C.p_2],
+                        class![C.h_full, C.min_h_80, C.p_2],
                         grafana_chart::view(
                             IML_METRICS_DASHBOARD_ID,
                             IML_METRICS_DASHBOARD_NAME,


### PR DESCRIPTION
The dashboard charts do not fill the vertical space available to them
(they are hardcoded to 20rem).

This can leave a large vertical gap dependent on screen size.

The charts should default to 100% height and have a minimum height of
20rem (to be consistent in smaller viewports).

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1928)
<!-- Reviewable:end -->
