### PR TITLE
Allow vagrants clients to have thier lnet provisioned

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -790,6 +790,8 @@ Vagrant.configure('2') do |config|
 
       configure_docker_network c
 
+      configure_lustre_network c
+
       c.vm.provision 'install-iml-local',
             type: 'shell',
             run: 'never',

--- a/vagrant/scripts/configure_lustre_network.sh
+++ b/vagrant/scripts/configure_lustre_network.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+DEV=$(ip r get 10.73.20.1|awk '/dev/{ print $3 }')
+
 modprobe lnet
 lnetctl lnet configure
-lnetctl net add --net tcp0 --if eth1
+lnetctl net add --net tcp0 --if $DEV
 lnetctl net show --net tcp > /etc/lnet.conf
 systemctl enable lnet.service


### PR DESCRIPTION
Provisioning ordering needs to be install-lustre-client then configure-lustre-network

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1940)
<!-- Reviewable:end -->
