### PR TITLE
Properly handle SFA object deletions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.31"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
+checksum = "8f1c13101a3224fb178860ae372a031ce350bbd92d39968518f016744dde0bf7"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.6",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byte-tools"
@@ -984,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba758d094d31274eb49d15da6f326b96bf3185239a6359bf684f3d5321148900"
+checksum = "b37819efea9045a64bf9e40983ee62e20b4e9f0b14aa293e53dde8ac7c517f91"
 dependencies = [
  "log 0.4.8",
  "pest",
@@ -1684,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
  "autocfg 1.0.0",
 ]
@@ -1705,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "influx_db_client"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb07ff51996cb7e72ac11e0f4a03e1d30038998979762be74da7f3b94c2ebd9"
+checksum = "39a1922c4401619e9e67144b494966f1313d24b9d0feba24729e10dd4d835086"
 dependencies = [
  "bytes",
  "futures",
@@ -2439,18 +2439,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
+checksum = "ba3a1acf4a3e70849f8a673497ef984f043f95d2d8252dcdf74d54e6a1e47e8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
+checksum = "194e88048b71a3e02eb4ee36a6995fed9b8236c11a7bb9f7247a9d9835b3f265"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.6",
@@ -3641,9 +3641,9 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c6b59d116d218cb2d990eb06b77b64043e0268ef7323aae63d8b30ae462923"
+checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
 dependencies = [
  "cfg-if",
  "tracing-attributes",

--- a/iml-orm/src/lib.rs
+++ b/iml-orm/src/lib.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "postgres-interop")]
 #[macro_use]
-extern crate diesel;
+pub extern crate diesel;
 
 #[cfg(feature = "postgres-interop")]
 pub mod models;
@@ -56,24 +56,39 @@ use warp::Filter;
 
 #[cfg(feature = "postgres-interop")]
 use diesel::{
-    query_builder::{QueryFragment, QueryId},
+    query_builder::QueryFragment,
+    query_dsl::load_dsl::ExecuteDsl,
     r2d2::{ConnectionManager, Pool},
     PgConnection,
 };
 #[cfg(feature = "postgres-interop")]
 use iml_manager_env::get_db_conn_string;
+#[cfg(feature = "postgres-interop")]
+use tokio_diesel::AsyncRunQueryDsl;
+
+#[cfg(feature = "postgres-interop")]
+pub trait PgQueryFragment: QueryFragment<diesel::pg::Pg> {}
+
+#[cfg(feature = "postgres-interop")]
+impl<T> PgQueryFragment for T where T: QueryFragment<diesel::pg::Pg> {}
+
+#[cfg(feature = "postgres-interop")]
+pub trait AsyncRunQueryDslPostgres: AsyncRunQueryDsl<diesel::PgConnection, DbPool> {}
+
+#[cfg(feature = "postgres-interop")]
+impl<T> AsyncRunQueryDslPostgres for T where T: AsyncRunQueryDsl<diesel::PgConnection, DbPool> {}
 
 #[cfg(feature = "postgres-interop")]
 /// Allows for a generic return type for Insert statements, that can be used in either a sync or async
 /// context.
 pub trait Executable:
-    RunQueryDsl<diesel::PgConnection> + QueryFragment<diesel::pg::Pg> + QueryId
+    RunQueryDsl<diesel::PgConnection> + ExecuteDsl<diesel::PgConnection, diesel::pg::Pg>
 {
 }
 
 #[cfg(feature = "postgres-interop")]
 impl<T> Executable for T where
-    T: RunQueryDsl<diesel::PgConnection> + QueryFragment<diesel::pg::Pg> + QueryId
+    T: RunQueryDsl<diesel::PgConnection> + ExecuteDsl<diesel::PgConnection, diesel::pg::Pg>
 {
 }
 

--- a/iml-orm/src/sfa/disk_drive.rs
+++ b/iml-orm/src/sfa/disk_drive.rs
@@ -7,10 +7,20 @@ use crate::sfa::{HealthState, MemberState};
 use crate::{schema::chroma_core_sfadiskdrive as sd, Executable, Upserts};
 #[cfg(feature = "postgres-interop")]
 use diesel::{
-    self,
+    self, dsl,
     pg::{upsert::excluded, Pg},
-    ExpressionMethods as _, Queryable,
+    prelude::*,
+    Queryable,
 };
+
+#[cfg(feature = "postgres-interop")]
+pub type Table = sd::table;
+#[cfg(feature = "postgres-interop")]
+pub type WithIndexes = dsl::EqAny<sd::index, Vec<i32>>;
+#[cfg(feature = "postgres-interop")]
+pub type WithStorageSystem<'a> = dsl::EqAny<sd::storage_system, Vec<&'a str>>;
+#[cfg(feature = "postgres-interop")]
+pub type ByRecords<'a> = dsl::Filter<Table, dsl::And<WithIndexes, WithStorageSystem<'a>>>;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 #[cfg_attr(feature = "postgres-interop", derive(Insertable, AsChangeset))]
@@ -70,7 +80,7 @@ impl Queryable<sd::SqlType, Pg> for SfaDiskDrive {
 
 #[cfg(feature = "postgres-interop")]
 impl SfaDiskDrive {
-    pub fn all() -> sd::table {
+    pub fn all() -> Table {
         sd::table
     }
     pub fn batch_upsert(x: Upserts<&Self>) -> impl Executable + '_ {
@@ -87,7 +97,19 @@ impl SfaDiskDrive {
                 sd::enclosure_index.eq(excluded(sd::enclosure_index)),
             ))
     }
-    pub fn batch_remove(xs: Vec<i32>) -> impl Executable {
-        diesel::delete(Self::all()).filter(sd::index.eq_any(xs))
+    fn batch_delete_filter<'a>(xs: Vec<&'a Self>) -> ByRecords<'a> {
+        let (indexes, storage_systems): (Vec<_>, Vec<_>) = xs
+            .into_iter()
+            .map(|x| (x.index, x.storage_system.as_str()))
+            .unzip();
+
+        Self::all().filter(
+            sd::index
+                .eq_any(indexes)
+                .and(sd::storage_system.eq_any(storage_systems)),
+        )
+    }
+    pub fn batch_delete<'a>(xs: Vec<&'a Self>) -> impl Executable + 'a {
+        diesel::delete(SfaDiskDrive::batch_delete_filter(xs))
     }
 }


### PR DESCRIPTION
Since SFA objects can come from multiple appliances, it's not sufficient
to delete just by index. Instead, we need to delete by using the primary
keys + the SfaEnclosure uuid.

In addition, make diffing objects a bit more generic.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1941)
<!-- Reviewable:end -->
