### PR TITLE
Update Vagrant to use upstream CentOS 7.8

### DIFF
--- a/iml-system-test-utils/src/vagrant.rs
+++ b/iml-system-test-utils/src/vagrant.rs
@@ -611,7 +611,7 @@ impl Default for ClusterConfig {
             client: vec!["c1"],
             client_ips: vec!["10.73.10.31"],
             iscsi: "iscsi",
-            lustre_version: "2.12.4",
+            lustre_version: "2.12.5",
             server_map: vec![
                 ("adm", "10.73.10.10"),
                 ("mds1", "10.73.10.11"),

--- a/lustre-client-mlnx.repo
+++ b/lustre-client-mlnx.repo
@@ -1,6 +1,6 @@
 [lustre-client-mlnx]
 name=Lustre Client with Mellanox Support
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4-ib/MOFED-4.7-3.2.9.0/el$releasever/client/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.5-ib/MOFED-4.9-0.1.7.0/el$releasever/client/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/lustre-client.repo
+++ b/lustre-client.repo
@@ -1,6 +1,6 @@
 [lustre-client]
 name=Lustre Client
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4/el$releasever/client/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.5/el$releasever/client/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/lustre-server-mlnx.repo
+++ b/lustre-server-mlnx.repo
@@ -1,6 +1,6 @@
 [lustre]
 name=Lustre Server
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4-ib/MOFED-4.7-3.2.9.0/el$releasever/server/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.5-ib/MOFED-4.9-0.1.7.0/el$releasever/server/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/lustre-server-patchless.repo
+++ b/lustre-server-patchless.repo
@@ -1,6 +1,6 @@
 [lustre]
 name=Lustre Server
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4/el7/patchless-ldiskfs-server/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.5/el7/patchless-ldiskfs-server/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/lustre-server.repo
+++ b/lustre-server.repo
@@ -1,6 +1,6 @@
 [lustre]
 name=Lustre Server
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4/el$releasever/server/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.5/el$releasever/server/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -18,7 +18,7 @@ VBOX_PASSWD = (ENV['VBOX_PASSWD'] || "").freeze
 VBOX_SSHKEY = (ENV['VBOX_SSHKEY'] || "").freeze
 
 # Lustre version
-LUSTRE = (ENV['LUSTRE'] || "2.12.4").freeze
+LUSTRE = (ENV['LUSTRE'] || "2.12.5").freeze
 
 REPO_URI = (ENV['REPO_URI'] || '').freeze
 
@@ -39,10 +39,7 @@ ISCI_IP = "#{SUBNET_PREFIX}.40.10".freeze
 ISCI_IP2 = "#{SUBNET_PREFIX}.50.10".freeze
 
 Vagrant.configure('2') do |config|
-  config.vm.box = 'centos/7.7'
-  config.vm.box_url = 'http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-2001_01.VirtualBox.box'
-  config.vm.box_download_checksum = 'e1a26038fb036ab8e76a6a4dfcd49856'
-  config.vm.box_download_checksum_type = 'md5'
+  config.vm.box = 'centos/7'
 
   config.vm.provider 'virtualbox' do |vbx|
     vbx.linked_clone = true


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1944)
<!-- Reviewable:end -->
