### PR TITLE
Increase max body size for Rust agent

### DIFF
--- a/chroma-manager.conf.template
+++ b/chroma-manager.conf.template
@@ -302,6 +302,9 @@ server {
     }
 
     location /agent2/message {
+        client_body_buffer_size 1m;
+        client_max_body_size 8m;
+
         if ($ssl_client_verify != SUCCESS) {
             return 401;
         }


### PR DESCRIPTION
Allow big device trees to be sent w/o issues.

Currently ~10 device trees with 10 zpools and datasets hit 1MB limit, so we're increasing this for production where much more devices are expected.

Fix #1939 

Signed-off-by: Michael Pankov <work@michaelpankov.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1947)
<!-- Reviewable:end -->
