### PR TITLE
Install lustre client by default

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -99,7 +99,7 @@ Vagrant.configure('2') do |config|
                        destination: "/tmp/99-external-storage.rules"
 
     iscsi.vm.provision 'udev-trigger', type: 'shell', inline: <<-SHELL
-      mv /tmp/99-external-storage.rules /etc/udev/rules.d/ 
+      mv /tmp/99-external-storage.rules /etc/udev/rules.d/
       udevadm trigger --subsystem-match=block
     SHELL
 
@@ -638,7 +638,7 @@ Vagrant.configure('2') do |config|
                          run: 'never',
                          path: 'scripts/create_ldiskfs_lvm_oss_ha_setup.sh',
                          args: [ "{a..e} {k..o}", 0, VBOX_USER, VBOX_PASSWD, VBOX_SSHKEY ]
-                         
+
       else
         oss.vm.provision 'create-pools',
                          type: 'shell',
@@ -799,7 +799,7 @@ Vagrant.configure('2') do |config|
 
       c.vm.provision 'install-lustre-client',
                      type: 'shell',
-                     run: 'never',
+                     run: 'once',
                      inline: <<-SHELL
                             yum-config-manager --add-repo https://downloads.whamcloud.com/public/lustre/lustre-#{LUSTRE}/el7/client/
                             yum install -y --nogpgcheck lustre-client
@@ -847,7 +847,7 @@ end
 
 def provision_mgmt_net(config, num)
   interface_name = if OS.windows? then 'VirtualBox Host-Only Ethernet Adapter' else 'vboxnet0' end
-  
+
   config.vm.network 'private_network',
                     ip: "#{MGMT_NET_PFX}.#{num}",
                     netmask: '255.255.255.0',


### PR DESCRIPTION
Fix this error in clean deploy:
```
==> c1: Running action triggers before provision ...
==> c1: Running trigger: configure-docker-network-trigger...
==> c1: Running provisioner: configure-lustre-network (shell)...
    c1: Running: /tmp/vagrant-shell20200608-151585-1ht6gox.sh
    c1: modprobe: FATAL: Module lnet not found.
    c1: /tmp/vagrant-shell: line 6: lnetctl: command not found
    c1: /tmp/vagrant-shell: line 7: lnetctl: command not found
    c1: /tmp/vagrant-shell: line 8: lnetctl: command not found
    c1: Failed to execute operation: No such file or directory
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

Re https://github.com/whamcloud/integrated-manager-for-lustre/pull/1940

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1952)
<!-- Reviewable:end -->
