### PR TITLE
Fix GUI clippy issues

### DIFF
--- a/iml-gui/crate/src/components/action_dropdown/mod.rs
+++ b/iml-gui/crate/src/components/action_dropdown/mod.rs
@@ -246,7 +246,7 @@ fn group_actions_by_label(xs: Vec<Arc<AvailableAction>>, cache: &ArcCache) -> Ac
     let mut x = xs.into_iter().fold(BTreeMap::new(), |mut x, action| {
         match cache.get_erased_record(&action.composite_id) {
             Some(r) => {
-                let xs = x.entry(r.label().to_string()).or_insert_with(|| vec![]);
+                let xs = x.entry(r.label().to_string()).or_insert_with(Vec::new);
 
                 xs.push((action, r));
             }

--- a/iml-gui/crate/src/page/servers.rs
+++ b/iml-gui/crate/src/page/servers.rs
@@ -203,10 +203,8 @@ pub fn view(
                                 .merge_attrs(class![C.text_center]),
                                 table::td_view(date_view(sd, &x.boot_time)).merge_attrs(class![C.text_center]),
                                 table::td_view(span![x.server_profile.ui_name]).merge_attrs(class![C.text_center]),
-                                table::td_view(
-                                    div![lnet_by_server_view(x, cache, all_locks).unwrap_or_else(|| vec![])]
-                                )
-                                .merge_attrs(class![C.text_center]),
+                                table::td_view(div![lnet_by_server_view(x, cache, all_locks).unwrap_or_else(Vec::new)])
+                                    .merge_attrs(class![C.text_center]),
                                 td![
                                     class![C.p_3, C.text_center],
                                     action_dropdown::view(x.id, &row.dropdown, all_locks, session)


### PR DESCRIPTION
Rust 1.44 made `vec![]` expand to `Vec::new()` (rust-lang/rust#70632).

As such clippy is now (somewhat correctly) interpreting that the macro could be used points-free.

clippy should be smart enough to not substitute the expanded macro, but
for now we can silence the errors by using a points-free constructor.

Fixes #1949.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1953)
<!-- Reviewable:end -->
