### PR TITLE
Implement ResizeObserver Bindings

### DIFF
--- a/iml-gui/crate/Cargo.toml
+++ b/iml-gui/crate/Cargo.toml
@@ -46,6 +46,7 @@ features = ["std", "unicode-perl"]
 version = "^0.3"
 features = [
   "DomRect",
+  "DomRectReadOnly",
   "Element",
   "EventSource",
   "HtmlDocument",
@@ -55,7 +56,6 @@ features = [
   "NotificationOptions",
   "NotificationPermission",
   "ServiceWorkerContainer",
-
   "ServiceWorkerRegistration",
   "Window",
 ]

--- a/iml-gui/crate/src/event_source.rs
+++ b/iml-gui/crate/src/event_source.rs
@@ -9,13 +9,13 @@ use wasm_bindgen::{closure::Closure, JsCast};
 use web_sys::EventSource;
 
 pub fn init(orders: &mut impl Orders<Msg, GMsg>) {
+    //FIXME: This should be proxied via webpack dev-server but there is an issue with buffering contents of SSE.
     let uri = if *crate::IS_PRODUCTION {
         "/messaging"
     } else {
         "https://localhost:8443/messaging"
     };
 
-    // FIXME: This should be proxied via webpack dev-server but there is an issue with buffering contents of SSE.
     let es = EventSource::new(uri).unwrap();
 
     register_eventsource_handle(EventSource::set_onopen, Msg::EventSourceConnect, &es, orders);

--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -10,6 +10,7 @@ pub mod components;
 pub mod dependency_tree;
 pub mod key_codes;
 pub mod page;
+pub mod resize_observer;
 
 mod auth;
 mod breakpoints;

--- a/iml-gui/crate/src/resize_observer.rs
+++ b/iml-gui/crate/src/resize_observer.rs
@@ -1,0 +1,106 @@
+use crate::{GMsg, Orders};
+use js_sys::Array;
+use seed::browser::util::ClosureNew;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::{closure::Closure, JsCast};
+use web_sys::{DomRectReadOnly, Element};
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends=js_sys::Object, js_name=ResizeObserver, typescript_type="ResizeObserver")]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[doc = "The `ResizeObserver` class."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)"]
+    pub type ResizeObserver;
+    #[wasm_bindgen(catch, constructor, js_class = "ResizeObserver")]
+    #[doc = "The `new ResizeObserver(..)` constructor, creating a new instance of `ResizeObserver`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver)"]
+    pub fn new(resize_callback: &js_sys::Function) -> Result<ResizeObserver, JsValue>;
+    #[wasm_bindgen(method, structural, js_class="ResizeObserver" , js_name=disconnect)]
+    #[doc = "The `disconnect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/disconnect)"]
+    pub fn disconnect(this: &ResizeObserver);
+    #[wasm_bindgen(method, structural, js_class="ResizeObserver", js_name=observe)]
+    #[doc = "The `observe()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe)"]
+    pub fn observe(this: &ResizeObserver, target: &Element);
+    #[wasm_bindgen( method , structural , js_class = "ResizeObserver" , js_name = unobserve )]
+    #[doc = "The `unobserve()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/unobserve)"]
+    #[doc = ""]
+    pub fn unobserve(this: &ResizeObserver, target: &Element);
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends=js_sys::Object, js_name=ResizeObserverEntry, typescript_type = "ResizeObserverEntry")]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[doc = "The `ResizeObserverEntry` class."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry)"]
+    pub type ResizeObserverEntry;
+    #[wasm_bindgen(structural, method, getter, js_class="ResizeObserverEntry", js_name=contentRect)]
+    #[doc = "Getter for the `contentRect` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/contentRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DomRectReadOnly`*"]
+    pub fn content_rect(this: &ResizeObserverEntry) -> Option<DomRectReadOnly>;
+    #[wasm_bindgen(structural, method, getter, js_class = "ResizeObserverEntry", js_name=target)]
+    #[doc = "Getter for the `target` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/target)"]
+    #[doc = ""]
+    pub fn target(this: &ResizeObserverEntry) -> Element;
+}
+
+/// Wraps a `ResizeObserver` instance and it's closure.
+///
+/// The Closure must live as long as the Observer, so we keep it alive by adding it
+/// as an "unused" field.
+pub struct ResizeObserverWrapper {
+    inner: ResizeObserver,
+    #[allow(dead_code)]
+    closure: Closure<dyn FnMut(Array)>,
+}
+
+impl ResizeObserverWrapper {
+    pub fn disconnect(&self) {
+        self.inner.disconnect()
+    }
+    pub fn observe(&self, target: &Element) {
+        self.inner.observe(target);
+    }
+    pub fn unobserve(&self, target: &Element) {
+        self.inner.unobserve(target);
+    }
+}
+
+impl Drop for ResizeObserverWrapper {
+    fn drop(&mut self) {
+        self.disconnect()
+    }
+}
+
+pub fn init<F, T>(orders: &mut impl Orders<T, GMsg>, msg: F) -> ResizeObserverWrapper
+where
+    T: 'static,
+    F: Fn(Vec<ResizeObserverEntry>) -> T + 'static,
+{
+    let (app, msg_mapper) = (orders.clone_app(), orders.msg_mapper());
+
+    let closure = Closure::new(move |entries: Array| {
+        let xs = entries.iter().map(JsCast::unchecked_into).collect();
+
+        app.update(msg_mapper(msg(xs)));
+    });
+
+    let inner = ResizeObserver::new(closure.as_ref().unchecked_ref()).unwrap();
+
+    ResizeObserverWrapper { inner, closure }
+}


### PR DESCRIPTION
Implement wasm-bindgen bindings to the [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) API.

This will allow us to observe size changes to an Element independent of the
overall viewport, which is particularly useful for elements effected by
sidebar width changes.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1956)
<!-- Reviewable:end -->
