### PR TITLE
Update iml-request-retry to pass iteration index

### DIFF
--- a/iml-manager-client/src/lib.rs
+++ b/iml-manager-client/src/lib.rs
@@ -173,7 +173,7 @@ pub async fn get_retry<T: DeserializeOwned + Debug>(
     let query = &query;
 
     retry_future(
-        move || get(client2.clone(), path.to_string(), query),
+        move |_| get(client2.clone(), path.to_string(), query),
         &mut policy,
     )
     .await

--- a/iml-request-retry/examples/demo-server-client.rs
+++ b/iml-request-retry/examples/demo-server-client.rs
@@ -60,7 +60,7 @@ async fn retry_client_obj(addr: &SocketAddr, client_id: u32) -> Result<String, r
         _ => RetryAction::ReturnError(e),
     };
 
-    retry_future(|| http_call(addr, client_id), &mut policy_1).await
+    retry_future(|_| http_call(addr, client_id), &mut policy_1).await
 }
 
 async fn retry_client_fun(addr: &SocketAddr, client_id: u32) -> Result<String, reqwest::Error> {
@@ -71,7 +71,7 @@ async fn retry_client_fun(addr: &SocketAddr, client_id: u32) -> Result<String, r
             RetryAction::WaitFor(Duration::from_secs(5))
         }
     }
-    retry_future_gen(|| http_call(addr, client_id), policy_2).await
+    retry_future_gen(|_| http_call(addr, client_id), policy_2).await
 }
 
 async fn server_reply(mut hello: Hello) -> Result<Box<dyn warp::Reply>, warp::Rejection> {

--- a/iml-request-retry/src/lib.rs
+++ b/iml-request-retry/src/lib.rs
@@ -186,13 +186,16 @@ mod tests {
 
     #[test]
     fn dynamic_future_generation() {
-        let mut policy = |_, _|  RetryAction::RetryNow;
+        let mut policy = |_, _| RetryAction::RetryNow;
 
-        let fut = retry_future(|c| match c {
-            0 => futures::future::err(100),
-            1 => futures::future::ok(c),
-            _ => futures::future::err(200),
-        }, &mut policy);
+        let fut = retry_future(
+            |c| match c {
+                0 => futures::future::err(100),
+                1 => futures::future::ok(c),
+                _ => futures::future::err(200),
+            },
+            &mut policy,
+        );
 
         assert_eq!(Ok(1), block_on(fut));
     }


### PR DESCRIPTION
There may be a case in which the future factory may need to generate a
different future based on the incremented tries. For example, if there
are two url's that can be fetched for the same information but the first
url fails, we should retry using the second url. If both of the urls are
stored in a vec, then this becomes trivial to fetch using the
incrementing index.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1959)
<!-- Reviewable:end -->
