### PR TITLE
Retry SFA Endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
  "futures",
  "iml-manager-env",
  "iml-orm",
+ "iml-request-retry",
  "iml-tracing",
  "thiserror",
  "tokio",

--- a/iml-sfa/Cargo.toml
+++ b/iml-sfa/Cargo.toml
@@ -9,6 +9,7 @@ async-trait = "0.1"
 futures = "0.3"
 iml-manager-env = { version = "0.3", path = "../iml-manager-env" }
 iml-orm = { path = "../iml-orm", version = "0.3", features = ["postgres-interop", "wbem-interop"] }
+iml-request-retry = { path = "../iml-request-retry", version = "0.3" }
 iml-tracing = { version = "0.2", path = "../iml-tracing" }
 thiserror = "1.0"
 tokio = { version = "0.2", features = [ "macros", "time" ] }

--- a/iml-sfa/src/main.rs
+++ b/iml-sfa/src/main.rs
@@ -14,8 +14,9 @@ use iml_orm::{
     AsyncRunQueryDslPostgres, Changeable, DbPool, Executable, GetChanges as _, Identifiable,
     Upserts,
 };
+use iml_request_retry::{retry_future, RetryAction, RetryPolicy};
 use iml_tracing::tracing;
-use std::{convert::TryInto as _, time::Duration};
+use std::{convert::TryInto as _, fmt::Debug, time::Duration};
 use thiserror::Error;
 use tokio::time;
 use url::Url;
@@ -31,6 +32,13 @@ enum ImlSfaError {
     Async(#[from] AsyncError),
     #[error(transparent)]
     ImlOrm(#[from] iml_orm::ImlOrmError),
+}
+
+fn create_retry_endpoint_policy<E: Debug>() -> impl RetryPolicy<E> + Send {
+    |k: u32, e| match k {
+        0 | 1 => RetryAction::RetryNow,
+        _ => RetryAction::ReturnError(e),
+    }
 }
 
 #[tokio::main]
@@ -75,15 +83,35 @@ async fn main() -> Result<(), ImlSfaError> {
     loop {
         interval.tick().await;
 
-        let fut1 = client.fetch_sfa_enclosures(endpoints[0][0].clone());
+        let mut fut1_policy = create_retry_endpoint_policy();
+        let fut1 = retry_future(
+            |c| client.fetch_sfa_enclosures(endpoints[0][c as usize].clone()),
+            &mut fut1_policy,
+        );
 
-        let fut2 = client.fetch_sfa_storage_system(endpoints[0][0].clone());
+        let mut fut2_policy = create_retry_endpoint_policy();
+        let fut2 = retry_future(
+            |c| client.fetch_sfa_storage_system(endpoints[0][c as usize].clone()),
+            &mut fut2_policy,
+        );
 
-        let fut3 = client.fetch_sfa_disk_drives(endpoints[0][0].clone());
+        let mut fut3_policy = create_retry_endpoint_policy();
+        let fut3 = retry_future(
+            |c| client.fetch_sfa_disk_drives(endpoints[0][c as usize].clone()),
+            &mut fut3_policy,
+        );
 
-        let fut4 = client.fetch_sfa_jobs(endpoints[0][0].clone());
+        let mut fut4_policy = create_retry_endpoint_policy();
+        let fut4 = retry_future(
+            |c| client.fetch_sfa_jobs(endpoints[0][c as usize].clone()),
+            &mut fut4_policy,
+        );
 
-        let fut5 = client.fetch_sfa_power_supply(endpoints[0][0].clone());
+        let mut fut5_policy = create_retry_endpoint_policy();
+        let fut5 = retry_future(
+            |c| client.fetch_sfa_power_supply(endpoints[0][c as usize].clone()),
+            &mut fut5_policy,
+        );
 
         let (new_enclosures, x, new_drives, new_jobs, new_power_supplies) =
             future::try_join5(fut1, fut2, fut3, fut4, fut5).await?;

--- a/iml-sfa/src/main.rs
+++ b/iml-sfa/src/main.rs
@@ -34,10 +34,13 @@ enum ImlSfaError {
     ImlOrm(#[from] iml_orm::ImlOrmError),
 }
 
-fn create_retry_endpoint_policy<E: Debug>() -> impl RetryPolicy<E> + Send {
-    |k: u32, e| match k {
-        0 | 1 => RetryAction::RetryNow,
-        _ => RetryAction::ReturnError(e),
+fn create_retry_endpoint_policy<E: Debug>(len: u32) -> impl RetryPolicy<E> + Send {
+    move |k: u32, e| {
+        if k < len {
+            RetryAction::RetryNow
+        } else {
+            RetryAction::ReturnError(e)
+        }
     }
 }
 
@@ -83,31 +86,31 @@ async fn main() -> Result<(), ImlSfaError> {
     loop {
         interval.tick().await;
 
-        let mut fut1_policy = create_retry_endpoint_policy();
+        let mut fut1_policy = create_retry_endpoint_policy(endpoints[0].len() as u32);
         let fut1 = retry_future(
             |c| client.fetch_sfa_enclosures(endpoints[0][c as usize].clone()),
             &mut fut1_policy,
         );
 
-        let mut fut2_policy = create_retry_endpoint_policy();
+        let mut fut2_policy = create_retry_endpoint_policy(endpoints[0].len() as u32);
         let fut2 = retry_future(
             |c| client.fetch_sfa_storage_system(endpoints[0][c as usize].clone()),
             &mut fut2_policy,
         );
 
-        let mut fut3_policy = create_retry_endpoint_policy();
+        let mut fut3_policy = create_retry_endpoint_policy(endpoints[0].len() as u32);
         let fut3 = retry_future(
             |c| client.fetch_sfa_disk_drives(endpoints[0][c as usize].clone()),
             &mut fut3_policy,
         );
 
-        let mut fut4_policy = create_retry_endpoint_policy();
+        let mut fut4_policy = create_retry_endpoint_policy(endpoints[0].len() as u32);
         let fut4 = retry_future(
             |c| client.fetch_sfa_jobs(endpoints[0][c as usize].clone()),
             &mut fut4_policy,
         );
 
-        let mut fut5_policy = create_retry_endpoint_policy();
+        let mut fut5_policy = create_retry_endpoint_policy(endpoints[0].len() as u32);
         let fut5 = retry_future(
             |c| client.fetch_sfa_power_supply(endpoints[0][c as usize].clone()),
             &mut fut5_policy,


### PR DESCRIPTION
There are currently two controllers, each with an endpoint that provide
access to the same api. We try to hit this api using the first
controller, but it's possible that the endpoint will fail. If it does,
it should retry using the second endpoint. If that also fails, then we
can fail overall.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1960)
<!-- Reviewable:end -->
