### PR TITLE
Update state for SFA tooltips

### DIFF
--- a/iml-gui/crate/src/components/datepicker.rs
+++ b/iml-gui/crate/src/components/datepicker.rs
@@ -34,7 +34,6 @@ impl<'a> Default for Model {
 }
 
 pub fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg, GMsg>) {
-
     match msg {
         Msg::SelectDuration(duration) => {
             match duration {

--- a/iml-gui/crate/src/components/sfa_overview/enclosures/ss9012.rs
+++ b/iml-gui/crate/src/components/sfa_overview/enclosures/ss9012.rs
@@ -57,43 +57,38 @@ pub(crate) fn view<T>(x: &Model) -> Node<T> {
                 sfa_item(x.psu4.as_deref(), span!["PSU4"]).merge_attrs(class![C.w_20]),
             ],
             div![
-                class![
-                    C.bg_gray_300,
-                    C.col_span_6,
-                    C.grid_flow_col,
-                    C.grid,
-                    C.h_12,
-                    C.p_1
-                ],
+                class![C.bg_gray_300, C.col_span_6, C.grid_flow_col, C.grid, C.h_12, C.p_1],
                 div![
                     class![C.border_2, C.border_gray_200],
-                    div![class![
-                        C.bg_gray_300,
-                        C.border_4,
-                        C.border_gray_400,
-                        C.flex_col,
-                        C.flex,
-                        C.h_full,
-                        C.items_center,
-                        C.justify_center,
-                        C.rounded_md,
-                    ],
+                    div![
+                        class![
+                            C.bg_gray_300,
+                            C.border_4,
+                            C.border_gray_400,
+                            C.flex_col,
+                            C.flex,
+                            C.h_full,
+                            C.items_center,
+                            C.justify_center,
+                            C.rounded_md,
+                        ],
                         "ESM A"
                     ]
                 ],
                 div![
                     class![C.border_2, C.border_gray_200],
-                    div![class![
-                        C.bg_gray_300,
-                        C.border_4,
-                        C.border_gray_400,
-                        C.flex_col,
-                        C.flex,
-                        C.h_full,
-                        C.items_center,
-                        C.justify_center,
-                        C.rounded_md,
-                    ],
+                    div![
+                        class![
+                            C.bg_gray_300,
+                            C.border_4,
+                            C.border_gray_400,
+                            C.flex_col,
+                            C.flex,
+                            C.h_full,
+                            C.items_center,
+                            C.justify_center,
+                            C.rounded_md,
+                        ],
                         "ESM B"
                     ]
                 ],

--- a/iml-gui/crate/src/components/sfa_overview/mod.rs
+++ b/iml-gui/crate/src/components/sfa_overview/mod.rs
@@ -32,7 +32,7 @@ impl ToHealthState for Option<&SfaPowerSupply> {
     fn to_health_state_reason(&self) -> Cow<'_, str> {
         self.as_ref()
             .map(|x| Cow::Borrowed(x.health_state_reason.as_str()))
-            .map(|x| if x.is_empty() { Cow::Borrowed("No Issues") } else { x })
+            .map(|x| if x.is_empty() { Cow::Borrowed("Healthy") } else { x })
             .unwrap_or_else(|| Cow::Borrowed("Status Unknown"))
     }
 }
@@ -57,7 +57,7 @@ impl ToHealthState for Option<&SfaController> {
                 sfa_status_text(&x.child_health_state)
             ))
         } else if x.health_state_reason.is_empty() {
-            Cow::Borrowed("No Issues")
+            Cow::Borrowed("Healthy")
         } else {
             Cow::Borrowed(&x.health_state_reason)
         }
@@ -77,7 +77,7 @@ impl ToHealthState for &SfaEnclosure {
                 sfa_status_text(&self.child_health_state)
             ))
         } else if self.health_state_reason.is_empty() {
-            Cow::Borrowed("No Issues")
+            Cow::Borrowed("Healthy")
         } else {
             Cow::Borrowed(&self.health_state_reason)
         }
@@ -96,8 +96,10 @@ impl ToHealthState for &SfaStorageSystem {
                 "A {} issue has been detected with at least one element within the subsystem.",
                 sfa_status_text(&self.child_health_state)
             ))
+        } else if self.health_state_reason.is_empty() {
+            Cow::Borrowed("Healthy")
         } else {
-            Cow::Borrowed(self.health_state_reason.as_str())
+            Cow::Borrowed(&self.health_state_reason)
         }
     }
 }


### PR DESCRIPTION
When an SFA component is healthy have the tooltip say Healthy instead of
No Issues.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1961)
<!-- Reviewable:end -->
