### PR TITLE
Update docker online-help version from 5.1 to 6.1

### DIFF
--- a/docker/nginx.dockerfile
+++ b/docker/nginx.dockerfile
@@ -15,7 +15,7 @@ RUN apk update && apk upgrade && \
   && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && apk del gettext
 COPY --from=rust-iml-gui /usr/share/iml-manager/rust-iml-gui /usr/share/iml-manager/rust-iml-gui
-COPY --from=imlteam/online-help:5.1 /root /usr/lib/iml-manager/iml-online-help
+COPY --from=imlteam/online-help:6.1 /root /usr/lib/iml-manager/iml-online-help
 COPY --from=builder /build/iml.template /etc/nginx/conf.d/iml.template
 COPY --from=builder /build/iml-timer.conf /etc/nginx/conf.d/iml-timer.extras
 CMD dockerize -template /etc/nginx/conf.d/iml.template:/etc/nginx/conf.d/default.conf -stdout /var/log/nginx/access.log -stderr /var/log/nginx/error.log -wait file:///var/lib/chroma/iml-settings.conf -timeout 10m nginx


### PR DESCRIPTION
Update docker online-help version from 5.1 to 6.1

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1965)
<!-- Reviewable:end -->
