### PR TITLE
Fixup controller monitoring

### DIFF
--- a/iml-orm/src/sfa/controller.rs
+++ b/iml-orm/src/sfa/controller.rs
@@ -73,6 +73,7 @@ impl SfaController {
                 sc::enclosure_index.eq(excluded(sc::enclosure_index)),
                 sc::health_state.eq(excluded(sc::health_state)),
                 sc::health_state_reason.eq(excluded(sc::health_state_reason)),
+                sc::child_health_state.eq(excluded(sc::child_health_state)),
             ))
     }
     fn batch_delete_filter<'a>(xs: Vec<&'a Self>) -> ByRecords<'a> {


### PR DESCRIPTION
Controllers need to be wrapped in a retry_future.

In addition, we need to update child health state when it changes.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1974)
<!-- Reviewable:end -->
