### PR TITLE
Add the configure_ntp provisioner to client nodes

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -793,6 +793,10 @@ Vagrant.configure('2') do |config|
 
       configure_lustre_network c
 
+      configure_ntp c
+
+      configure_ntp_docker c
+
       c.vm.provision 'install-iml-local',
             type: 'shell',
             run: 'never',


### PR DESCRIPTION
Monitored clients should have ntp configured. It's useful to have this
provisioner on the client nodes.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1977)
<!-- Reviewable:end -->
