### PR TITLE
Allow for empty EnumerateInstances

### DIFF
--- a/wbem-client/fixtures/empty.xml
+++ b/wbem-client/fixtures/empty.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<CIM CIMVERSION="2.0" DTDVERSION="2.0">
+    <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+        <SIMPLERSP>
+            <IMETHODRESPONSE NAME="EnumerateInstances">
+                <IRETURNVALUE>
+                </IRETURNVALUE>
+            </IMETHODRESPONSE>
+        </SIMPLERSP>
+    </MESSAGE>
+</CIM>

--- a/wbem-client/src/cim_xml.rs
+++ b/wbem-client/src/cim_xml.rs
@@ -284,7 +284,7 @@ pub mod resp {
     pub struct Instance {
         #[serde(rename = "CLASSNAME")]
         pub class_name: String,
-        #[serde(rename = "$value")]
+        #[serde(rename = "$value", default)]
         pub properties: Vec<Property>,
     }
 
@@ -312,7 +312,7 @@ pub mod resp {
 
     #[derive(Debug, serde::Deserialize, PartialEq)]
     pub struct IReturnValueNamedInstance {
-        #[serde(rename = "VALUE.NAMEDINSTANCE")]
+        #[serde(rename = "VALUE.NAMEDINSTANCE", default)]
         pub named_instance: Vec<NamedInstance>,
     }
 
@@ -378,6 +378,16 @@ pub mod resp {
             let xml = include_bytes!("../fixtures/instance.xml");
 
             let r: Cim<IReturnValueInstance> =
+                quick_xml::de::from_str(std::str::from_utf8(xml).unwrap()).unwrap();
+
+            insta::assert_debug_snapshot!(r);
+        }
+
+        #[test]
+        fn test_empty() {
+            let xml = include_bytes!("../fixtures/empty.xml");
+
+            let r: Cim<IReturnValueNamedInstance> =
                 quick_xml::de::from_str(std::str::from_utf8(xml).unwrap()).unwrap();
 
             insta::assert_debug_snapshot!(r);

--- a/wbem-client/src/snapshots/wbem_client__cim_xml__resp__tests__empty.snap
+++ b/wbem-client/src/snapshots/wbem_client__cim_xml__resp__tests__empty.snap
@@ -1,0 +1,15 @@
+---
+source: wbem-client/src/cim_xml.rs
+expression: r
+---
+Cim {
+    message: Message {
+        simplersp: SimpleRsp {
+            imethodresponse: IMethodResponse {
+                i_return_value: IReturnValueNamedInstance {
+                    named_instance: [],
+                },
+            },
+        },
+    },
+}


### PR DESCRIPTION
`EnumerateInstances` may return an empty `IRETURNVALUE`. This is a valid
scenario and we should default to an empty `Vec` in this case.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1980)
<!-- Reviewable:end -->
