### PR TITLE
Add wait-for-settings check

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "manager-config:/var/lib/chroma"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail influxdb:8086/ping?wait_for_leader=10s"]
-      interval: 5s
+      interval: 30s
       timeout: 15s
       retries: 5
       start_period: 60s

--- a/docker/influxdb.dockerfile
+++ b/docker/influxdb.dockerfile
@@ -1,9 +1,9 @@
-FROM influxdb:1.7.6-alpine
+FROM influxdb:1.8.0-alpine
 USER root
 RUN apk add curl
 
 COPY docker/influxdb/setup-influxdb.sh /docker-entrypoint-initdb.d/
-COPY docker/wait-for-dependencies.sh /usr/bin/
+COPY docker/wait-for-settings.sh /usr/bin/
 
-ENTRYPOINT ["wait-for-dependencies.sh"]
+ENTRYPOINT ["wait-for-settings.sh"]
 CMD ["/entrypoint.sh", "influxd"]

--- a/docker/wait-for-settings.sh
+++ b/docker/wait-for-settings.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+until [ -f /var/lib/chroma/iml-settings.conf ]; do
+  echo "Waiting for settings."
+  sleep 1
+done
+
+TMP=$PROXY_HOST
+
+set -a
+source /var/lib/chroma/iml-settings.conf
+set +a
+
+
+if [[ ! -z "$TMP" ]]; then
+  export PROXY_HOST=$TMP
+fi
+
+echo "Starting service."
+exec $@


### PR DESCRIPTION
There are containers that do not depend on rabbitmq being available.

For these cases, we can use a wait-for-settings.sh that only waits for
shared settings to be available.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1987)
<!-- Reviewable:end -->
