### PR TITLE
Update rabbit healthcheck

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,8 +15,6 @@ build: clean
 	COMPOSE_DOCKER_CLI_BUILD=1 docker-compose build
 
 save: build
-	COMPOSE_DOCKER_CLI_BUILD=1 docker-compose pull postgres rabbit update-handler
+	COMPOSE_DOCKER_CLI_BUILD=1 docker-compose pull postgres update-handler
 	docker save -o iml-images.tar $(COMPOSE_IMAGES)
 	gzip -9 < iml-images.tar > iml-images.tgz
-
-

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,7 +64,10 @@ services:
     ports:
       - 3000:3000
   rabbit:
-    image: "rabbitmq:3.6-management-alpine"
+    image: "imlteam/rabbitmq:6.2.0-dev"
+    build:
+      context: ../
+      dockerfile: ./docker/rabbitmq.dockerfile
     hostname: "rabbit"
     deploy:
       <<: *default-deploy
@@ -76,11 +79,15 @@ services:
       - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit heartbeat 0
       - RABBITMQ_ERLANG_COOKIE='lustre-secret'
     healthcheck:
-      test: ["CMD-SHELL", "rabbitmqctl status"]
+      test:
+        [
+          "CMD-SHELL",
+          "curl --fail http://chroma:chroma123@rabbit:15672/api/aliveness-test/chromavhost/",
+        ]
       timeout: 5s
-      interval: 5s
+      interval: 30s
       retries: 5
-      start_period: 10s
+      start_period: 30s
   nginx:
     image: "imlteam/manager-nginx:6.2.0-dev"
     build:

--- a/docker/rabbitmq.dockerfile
+++ b/docker/rabbitmq.dockerfile
@@ -1,0 +1,3 @@
+FROM rabbitmq:3.6-management-alpine
+USER root
+RUN apk add curl


### PR DESCRIPTION
Instead of spawning a new erlang process once per 5s we can use curl to
check the rabbitmq api.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1990)
<!-- Reviewable:end -->
