### PR TITLE
Fix branch of _test_yum_rpm_sanity that returns a tuple of bool

### DIFF
--- a/chroma_core/models/host_jobs/test_host_contact.py
+++ b/chroma_core/models/host_jobs/test_host_contact.py
@@ -208,7 +208,7 @@ exit(missing_electric_fence)"
                 job_log.error("Failed configuration check on '%s': Unable to access any yum mirrors" % address)
         except AgentException:
             job_log.exception("Exception thrown while trying to invoke agent on '%s':" % address)
-            return False, False
+            return False
 
         return can_update
 


### PR DESCRIPTION
There is a branch of _test_yum_rpm_sanity that returns a tuple of bool.

This causes issues in the CLI, which is expecting a single boolean.

Normalize the return to always return a single boolean.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/1995)
<!-- Reviewable:end -->
