### PR TITLE
Remove blocking debug in postoffice

### DIFF
--- a/iml-agent/src/daemon_plugins/postoffice.rs
+++ b/iml-agent/src/daemon_plugins/postoffice.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::{
-    executor::block_on,
     stream::{StreamExt as _, TryStreamExt},
     Future, FutureExt,
 };
@@ -45,11 +44,7 @@ pub fn socket_name(mailbox: &str) -> String {
 
 impl std::fmt::Debug for PostOffice {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "PostOffice {{ {:?} }}",
-            block_on(self.routes.lock()).keys()
-        )
+        write!(f, "PostOffice {{ {:?} }}", self.routes)
     }
 }
 


### PR DESCRIPTION
When someone tries to print the postoffice daemon plugin
it will take an internal lock and block the current thread.

This is at the very least suprising and should be removed.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2002)
<!-- Reviewable:end -->
