### PR TITLE
Do not set environment variables in tests

### DIFF
--- a/iml-agent/src/action_plugins/lamigo.rs
+++ b/iml-agent/src/action_plugins/lamigo.rs
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::{agent_error::ImlAgentError, daemon_plugins::postoffice, env};
+use crate::{agent_error::ImlAgentError, env};
 use futures::future::TryFutureExt;
-use std::{collections::HashMap, fmt, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf};
 use tokio::fs;
 
 #[derive(serde::Deserialize, structopt::StructOpt, Clone, Debug)]

--- a/iml-agent/src/action_plugins/lpurge.rs
+++ b/iml-agent/src/action_plugins/lpurge.rs
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::{agent_error::ImlAgentError, daemon_plugins::postoffice, env};
+use crate::{agent_error::ImlAgentError, env};
 use futures::future::TryFutureExt;
-use std::{collections::HashMap, fmt, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf};
 use tokio::fs;
 
 #[derive(serde::Deserialize, structopt::StructOpt, Debug)]

--- a/iml-agent/src/action_plugins/snapshots/iml_agent__action_plugins__lpurge__lpurge_conf_tests__works.snap
+++ b/iml-agent/src/action_plugins/snapshots/iml_agent__action_plugins__lpurge__lpurge_conf_tests__works.snap
@@ -6,7 +6,7 @@ device=lima-OST0010
 dryrun=true
 freehi=123
 freelo=60
-listen_socket=/run/iml/postman-foobar.sock
+listen_socket=foobar
 max_jobs=0
 pool=lima.santiago
 

--- a/iml-agent/src/daemon_plugins/postoffice.rs
+++ b/iml-agent/src/daemon_plugins/postoffice.rs
@@ -36,12 +36,6 @@ pub fn create() -> impl DaemonPlugin {
     }
 }
 
-/// Return socket address for a given mailbox
-pub fn socket_name(mailbox: &str) -> String {
-    let sock_dir = env::get_var("SOCK_DIR");
-    format!("{}/postman-{}.sock", sock_dir, mailbox)
-}
-
 impl std::fmt::Debug for PostOffice {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "PostOffice {{ {:?} }}", self.routes)
@@ -51,7 +45,7 @@ impl std::fmt::Debug for PostOffice {
 // Returned trigger should be dropped to cause route to stop
 fn start_route(mailbox: String) -> Trigger {
     let (trigger, tripwire) = Tripwire::new();
-    let addr = socket_name(&mailbox);
+    let addr = env::mailbox_sock(&mailbox);
 
     let rc = async move {
         // remove old unix socket

--- a/iml-agent/src/env.rs
+++ b/iml-agent/src/env.rs
@@ -49,6 +49,15 @@ fn get_authority_cert_path() -> String {
     get_var("AUTHORITY_CRT_PATH")
 }
 
+pub fn sock_dir() -> String {
+    get_var("SOCK_DIR")
+}
+
+/// Return socket address for a given mailbox
+pub fn mailbox_sock(mailbox: &str) -> String {
+    format!("{}/postman-{}.sock", sock_dir(), mailbox)
+}
+
 lazy_static! {
     // Gets the pfx file.
     // If pfx is not found it will be created.


### PR DESCRIPTION
We have a number of intermittently failing tests that are due to setting environment variables within the tests.

Rust tests run in parallel and the environment is basically a singleton. Therefore, these tests leak state with each other and are non-deterministic.

In addition, we are pulling items between action plugins, where we could factor it out into the env instead.

Fixes #1826.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2008)
<!-- Reviewable:end -->
