### PR TITLE
Handle sessions in one place

### DIFF
--- a/iml-gui/crate/src/components/tree.rs
+++ b/iml-gui/crate/src/components/tree.rs
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 use crate::{
-    components::{attrs, alert_indicator, font_awesome, paging, Placement, tooltip},
+    components::{alert_indicator, attrs, font_awesome, paging, tooltip, Placement},
     generated::css_classes::C,
     route::RouteId,
     GMsg, Route,

--- a/iml-gui/crate/src/page/partial/footer.rs
+++ b/iml-gui/crate/src/page/partial/footer.rs
@@ -24,20 +24,17 @@ pub fn view(conf: &Conf) -> impl View<Msg> {
         }
     };
 
-    let footer_text =  match conf.branding {
+    let footer_text = match conf.branding {
         Branding::Whamcloud => div![
             footer_string,
             year.to_string(),
             " DDN. All rights reserved.".to_string(),
         ],
-        _ => div![footer_string]
+        _ => div![footer_string],
     };
 
     footer![
         class![C.h_5, C.flex, C.justify_center],
-        div![
-            class![C.px_5, C.text_sm, C.items_center,],
-            footer_text
-        ]
+        div![class![C.px_5, C.text_sm, C.items_center,], footer_text]
     ]
 }

--- a/iml-gui/crate/src/page/partial/header.rs
+++ b/iml-gui/crate/src/page/partial/header.rs
@@ -245,7 +245,7 @@ fn nav(model: &Model) -> Node<Msg> {
                     C.lg__h_16,
                 ],
                 main_menu_items(model),
-                auth_view(&model.auth, model.logging_out),
+                auth_view(&model.auth),
             ]
         } else {
             empty![]
@@ -255,13 +255,11 @@ fn nav(model: &Model) -> Node<Msg> {
 
 /// Show the logged in user if available.
 /// Also show the Login / Logout link
-pub fn auth_view(auth: &auth::Model, logging_out: bool) -> Node<Msg> {
+pub fn auth_view(auth: &auth::Model) -> Node<Msg> {
     let x = match auth.get_session() {
         Some(session) => session,
         None => return empty![],
     };
-
-    let disabled = attrs! { At::Disabled => logging_out.as_at_value() };
 
     let cls = class![
         C.block,
@@ -283,14 +281,14 @@ pub fn auth_view(auth: &auth::Model, logging_out: bool) -> Node<Msg> {
         C.text_gray_300
     ];
 
-    let mut auth_link = a![&cls, &disabled, if !x.has_user() { "Login" } else { "Logout" }];
+    let mut auth_link = a![&cls, if !x.has_user() { "Login" } else { "Logout" }];
 
     let auth_link = if !x.has_user() {
         auth_link.merge_attrs(attrs! {
             At::Href => Route::Login.to_href(),
         })
     } else {
-        auth_link.add_listener(simple_ev(Ev::Click, Msg::Logout));
+        auth_link.add_listener(simple_ev(Ev::Click, Msg::Auth(Box::new(auth::Msg::Logout))));
 
         auth_link
     };
@@ -301,7 +299,6 @@ pub fn auth_view(auth: &auth::Model, logging_out: bool) -> Node<Msg> {
             Some(user) => {
                 a![
                     &cls,
-                    &disabled,
                     attrs! {
                         At::Href => Route::User(user.id.into()).to_href()
                     },


### PR DESCRIPTION
This includes logging in and logging out.

`logged_out` is removed because "disabled" is not working with `a` anyway.
Can be added to the auth::Model if needed.

Closes  #2030, #1805,  #1737, #1735 (supersedes https://github.com/whamcloud/integrated-manager-for-lustre/pull/1755).

![sessions](https://user-images.githubusercontent.com/131844/86124522-934b2100-badb-11ea-8f9f-a3429c53d1c9.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2026)
<!-- Reviewable:end -->
