### PR TITLE
Update retry_future to take ownership of policy

### DIFF
--- a/iml-manager-client/src/lib.rs
+++ b/iml-manager-client/src/lib.rs
@@ -150,7 +150,7 @@ pub async fn get_influx<T: DeserializeOwned + Debug>(
     Ok(json)
 }
 
-fn create_policy<E: Debug>() -> impl RetryPolicy<E> + Send {
+fn create_policy<E: Debug>() -> impl RetryPolicy<E> {
     |k: u32, e| match k {
         0 => RetryAction::RetryNow,
         k if k < 3 => RetryAction::WaitFor(Duration::from_secs((2 * k) as u64)),
@@ -168,13 +168,13 @@ pub async fn get_retry<T: DeserializeOwned + Debug>(
 ) -> Result<T, ImlManagerClientError> {
     let client2 = client.clone();
 
-    let mut policy = create_policy();
+    let policy = create_policy();
 
     let query = &query;
 
     retry_future(
         move |_| get(client2.clone(), path.to_string(), query),
-        &mut policy,
+        policy,
     )
     .await
 }

--- a/iml-request-retry/Cargo.toml
+++ b/iml-request-retry/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-tokio = "0.2"
+tokio = { version = "0.2", features = ["macros"] }
 rand = "0.7"
 tracing = "0.1"
 

--- a/iml-request-retry/examples/demo-server-client.rs
+++ b/iml-request-retry/examples/demo-server-client.rs
@@ -54,13 +54,13 @@ async fn server(addr: &SocketAddr) {
 }
 
 async fn retry_client_obj(addr: &SocketAddr, client_id: u32) -> Result<String, reqwest::Error> {
-    let mut policy_1 = |k: u32, e| match k {
+    let policy_1 = |k: u32, e| match k {
         0 => RetryAction::RetryNow,
         k if k < 3 => RetryAction::WaitFor(Duration::from_secs((2 * k) as u64)),
         _ => RetryAction::ReturnError(e),
     };
 
-    retry_future(|_| http_call(addr, client_id), &mut policy_1).await
+    retry_future(|_| http_call(addr, client_id), policy_1).await
 }
 
 async fn retry_client_fun(addr: &SocketAddr, client_id: u32) -> Result<String, reqwest::Error> {

--- a/iml-request-retry/src/lib.rs
+++ b/iml-request-retry/src/lib.rs
@@ -62,14 +62,7 @@ where
     }
 }
 
-/// *NOTE*: the constraint `(dyn RetryPolicy<E> + Send)` (not just `dyn RetryPolicy<E>`) is needed,
-/// otherwise we might have e.g. error
-/// [E0277]: `dyn iml_request_retry::RetryPolicy<reqwest::error::Error>` cannot be sent between threads safely
-/// on the caller side. See `examples/demo-server-client.rs`.
-pub async fn retry_future<T, E, F, FF>(
-    factory: FF,
-    policy: &mut (dyn RetryPolicy<E> + Send),
-) -> Result<T, E>
+pub async fn retry_future<T, E, F, FF>(factory: FF, mut policy: impl RetryPolicy<E>) -> Result<T, E>
 where
     E: Debug,
     F: Future<Output = Result<T, E>>,

--- a/iml-sfa/src/main.rs
+++ b/iml-sfa/src/main.rs
@@ -34,10 +34,7 @@ enum ImlSfaError {
     ImlOrm(#[from] iml_orm::ImlOrmError),
 }
 
-fn retry_fn<F, T, E>(
-    endpoints: &Vec<Url>,
-    f: impl Fn(u32) -> F,
-) -> impl Future<Output = Result<T, E>>
+fn retry_fn<F, T, E>(endpoints: &[Url], f: impl Fn(u32) -> F) -> impl Future<Output = Result<T, E>>
 where
     F: Future<Output = Result<T, E>>,
     E: Debug,

--- a/iml-sfa/src/main.rs
+++ b/iml-sfa/src/main.rs
@@ -14,7 +14,7 @@ use iml_orm::{
     AsyncRunQueryDslPostgres, Changeable, DbPool, Executable, GetChanges as _, Identifiable,
     Upserts,
 };
-use iml_request_retry::{retry_future, RetryAction, RetryPolicy};
+use iml_request_retry::{retry_future, RetryAction};
 use iml_tracing::tracing;
 use std::{convert::TryInto as _, fmt::Debug, time::Duration};
 use thiserror::Error;
@@ -34,14 +34,25 @@ enum ImlSfaError {
     ImlOrm(#[from] iml_orm::ImlOrmError),
 }
 
-fn create_retry_endpoint_policy<E: Debug>(len: u32) -> impl RetryPolicy<E> + Send {
-    move |k: u32, e| {
+fn retry_fn<F, T, E>(
+    endpoints: &Vec<Url>,
+    f: impl Fn(u32) -> F,
+) -> impl Future<Output = Result<T, E>>
+where
+    F: Future<Output = Result<T, E>>,
+    E: Debug,
+{
+    let len = (endpoints.len() - 1) as u32;
+
+    let policy = move |k: u32, e| {
         if k < len {
             RetryAction::RetryNow
         } else {
             RetryAction::ReturnError(e)
         }
-    }
+    };
+
+    retry_future(f, policy)
 }
 
 #[tokio::main]
@@ -86,44 +97,34 @@ async fn main() -> Result<(), ImlSfaError> {
     loop {
         interval.tick().await;
 
-        let mut fut1_policy = create_retry_endpoint_policy((endpoints[0].len() - 1) as u32);
-        let fut1 = retry_future(
-            |c| client.fetch_sfa_enclosures(endpoints[0][c as usize].clone()),
-            &mut fut1_policy,
-        );
+        let endpoints = &endpoints[0];
 
-        let mut fut2_policy = create_retry_endpoint_policy((endpoints[0].len() - 1) as u32);
-        let fut2 = retry_future(
-            |c| client.fetch_sfa_storage_system(endpoints[0][c as usize].clone()),
-            &mut fut2_policy,
-        );
+        let fut1 = retry_fn(endpoints, |c| {
+            client.fetch_sfa_enclosures(endpoints[c as usize].clone())
+        });
 
-        let mut fut3_policy = create_retry_endpoint_policy((endpoints[0].len() - 1) as u32);
-        let fut3 = retry_future(
-            |c| client.fetch_sfa_disk_drives(endpoints[0][c as usize].clone()),
-            &mut fut3_policy,
-        );
+        let fut2 = retry_fn(endpoints, |c| {
+            client.fetch_sfa_storage_system(endpoints[c as usize].clone())
+        });
 
-        let mut fut4_policy = create_retry_endpoint_policy((endpoints[0].len() - 1) as u32);
-        let fut4 = retry_future(
-            |c| client.fetch_sfa_jobs(endpoints[0][c as usize].clone()),
-            &mut fut4_policy,
-        );
+        let fut3 = retry_fn(endpoints, |c| {
+            client.fetch_sfa_disk_drives(endpoints[c as usize].clone())
+        });
 
-        let mut fut5_policy = create_retry_endpoint_policy((endpoints[0].len() - 1) as u32);
-        let fut5 = retry_future(
-            |c| client.fetch_sfa_power_supply(endpoints[0][c as usize].clone()),
-            &mut fut5_policy,
-        );
+        let fut4 = retry_fn(endpoints, |c| {
+            client.fetch_sfa_jobs(endpoints[c as usize].clone())
+        });
+
+        let fut5 = retry_fn(endpoints, |c| {
+            client.fetch_sfa_power_supply(endpoints[c as usize].clone())
+        });
 
         let (new_enclosures, x, new_drives, new_jobs, new_power_supplies) =
             future::try_join5(fut1, fut2, fut3, fut4, fut5).await?;
 
-        let mut policy = create_retry_endpoint_policy((endpoints[0].len() - 1) as u32);
-        let new_controllers = retry_future(
-            |c| client.fetch_sfa_controllers(endpoints[0][c as usize].clone()),
-            &mut policy,
-        )
+        let new_controllers = retry_fn(endpoints, |c| {
+            client.fetch_sfa_controllers(endpoints[c as usize].clone())
+        })
         .await?;
 
         tracing::trace!("SfaStorageSystem {:?}", x);


### PR DESCRIPTION
By updating retry_future to take ownership of it's policy,
we can allow for policies to be created within fns.

In addition, we can drop the `Send` bound.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2029)
<!-- Reviewable:end -->
