### PR TITLE
Improve and unify server operations in CLI

### DIFF
--- a/iml-system-test-utils/src/vagrant.rs
+++ b/iml-system-test-utils/src/vagrant.rs
@@ -381,7 +381,7 @@ pub async fn setup_deploy_servers(
 
         run_vm_command(
             config.manager,
-            &format!("iml server add -h {} -p {}", hosts.join(","), profile),
+            &format!("iml server add -p {} {}", profile, hosts.join(",")),
         )
         .await?
         .checked_status()

--- a/vagrant/scripts/deploy_hosts.sh
+++ b/vagrant/scripts/deploy_hosts.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-iml server add --hosts mds[1,2].local,oss[1,2].local --profile $1
+iml server add --profile $1 mds[1,2].local oss[1,2].local


### PR DESCRIPTION
This affects commands:

  1. iml server add
  2. iml server remove
  3. iml server force-remove

All of them now use multiple (one and more) hostlist expressions,
for example:

    iml server remove mds[1,2].local c1.local
    iml server add -p stratagem_client c1.local

Signed-off-by: Igor Pashev <pashev.igor@gmail.com>

Closes #2033.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2040)
<!-- Reviewable:end -->
