### PR TITLE
Fix OST pool grow

### DIFF
--- a/chroma_core/services/job_scheduler/job_scheduler.py
+++ b/chroma_core/services/job_scheduler/job_scheduler.py
@@ -1165,7 +1165,7 @@ class JobScheduler(object):
         with self._lock:
             ostpool = OstPool.objects.get(pk=ostpool_data["id"])
 
-            current = set(ostpool.osts.all())
+            current = set(ostpool.osts.values_list("name", flat=True).all())
             to_add = newlist - current
             to_remove = current - newlist
 


### PR DESCRIPTION
Different types of sets were compared to each other:
objects and strings:

    current set([<ManagedOst: fs-OST0000>]),
    new set([u'fs-OST0000', u'fs-OST0001']),
    add set([u'fs-OST0000', u'fs-OST0001']),
    remove set([<ManagedOst: fs-OST0000>]).

Make sure to compare strings only.

There is a minor and likely unrelated issue when growing with the same OST: an empty job list results in an error:
```
[root@adm ~]# vim /var/log/chroma/job_scheduler.log
[root@adm ~]# iml filesystem pool grow fs fast fs-OST0002
Growing ost pool...
[1/1]   ✔ Updating OST Pool successful
[root@adm ~]# iml filesystem pool grow fs fast fs-OST0001
Growing ost pool...
✗ HTTP status client error (404 Not Found) for url (https://adm.local/api/ostpool/4/)
[root@adm ~]# iml filesystem pool show fs fast
+------------+------------+
| Filesystem | fs         |
+------------+------------+
| Name       | fast       |
+------------+------------+
| OSTs       | fs-OST0000 |
|            | fs-OST0001 |
|            | fs-OST0002 |
+------------+------------+
[root@adm ~]# 
```

Closes #1852 and probably #1853:
```
chroma=> select * from chroma_core_ostpool;
 id | name | not_deleted | content_type_id | filesystem_id 
----+------+-------------+-----------------+---------------
  1 | fast |             |              44 |             1
  2 | fast |             |              44 |             1
  3 | fast |             |              44 |             1
  4 | fast | t           |              44 |             1
(4 filas)

chroma=> select * from chroma_core_ostpool_osts;
 id | ostpool_id | managedost_id 
----+------------+---------------
 17 |          4 |            10
 18 |          4 |            12
 19 |          4 |            13
```

Signed-off-by: Igor Pashev <pashev.igor@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2064)
<!-- Reviewable:end -->
