### PR TITLE
Agent to teardown sessions on signals

### DIFF
--- a/iml-agent/src/main.rs
+++ b/iml-agent/src/main.rs
@@ -3,13 +3,17 @@
 // license that can be found in the LICENSE file.
 
 use env::{MANAGER_URL, PEM};
-use futures::{FutureExt, TryFutureExt};
+use futures::{
+    future::{select, AbortHandle, Abortable},
+    FutureExt, TryFutureExt,
+};
 use iml_agent::{
     agent_error::Result,
     daemon_plugins, env,
     http_comms::{agent_client::AgentClient, crypto_client, session},
     poller, reader,
 };
+use tokio::signal::unix::{signal, SignalKind};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -31,15 +35,30 @@ async fn main() -> Result<()> {
     let registry_keys: Vec<iml_wire_types::PluginName> = registry.keys().cloned().collect();
     let sessions = session::Sessions::new(&registry_keys);
 
-    tokio::spawn(
+    let (reader, reader_reg) = AbortHandle::new_pair();
+    tokio::spawn(Abortable::new(
         reader::create_reader(sessions.clone(), agent_client.clone(), registry)
             .map_err(|e| {
                 tracing::error!("{}", e);
             })
             .map(drop),
-    );
+        reader_reg,
+    ));
 
-    poller::create_poller(agent_client, sessions).await;
+    let (poller, poller_reg) = AbortHandle::new_pair();
+    tokio::spawn(Abortable::new(
+        poller::create_poller(agent_client, sessions.clone()),
+        poller_reg,
+    ));
+
+    let mut sigterm = signal(SignalKind::terminate()).expect("Could not listen to SIGTERM");
+    let mut sigint = signal(SignalKind::interrupt()).expect("Could not listen to SIGINT");
+    select(sigterm.recv().boxed(), sigint.recv().boxed()).await;
+
+    tracing::info!("Terminating on signal...");
+    poller.abort();
+    reader.abort();
+    sessions.terminate_all_sessions().await?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes #1476.

```
jul 15 15:24:10 c1.local iml-agent-daemon[663]: Jul 15 15:24:10.810 DEBUG iml_agent::http_comms::crypto_client: resp headers: {"server": "nginx/1.16.1", "date": "Wed, 15 Jul 2020 15:24:10 GMT", "content-length": "0", "connection": "keep-alive"}
jul 15 15:24:13 c1.local systemd[1]: Stopping Rust IML Agent Daemon...
jul 15 15:24:13 c1.local iml-agent-daemon[663]: Jul 15 15:24:13.191  INFO iml_agent_daemon: Terminating...
jul 15 15:24:13 c1.local iml-agent-daemon[663]: Jul 15 15:24:13.191  INFO iml_agent::http_comms::session: Terminating all sessions
jul 15 15:24:13 c1.local iml-agent-daemon[663]: Jul 15 15:24:13.191  INFO iml_agent::http_comms::session: Terminating session PluginName("stats")/Id("40cf2205-aaee-44ef-9601-f6a38b306851")
jul 15 15:24:13 c1.local iml-agent-daemon[663]: Jul 15 15:24:13.192  INFO iml_agent::http_comms::session: Terminating session PluginName("ntp")/Id("928ba107-9443-4df2-9e86-da141bd958f2")
jul 15 15:24:13 c1.local iml-agent-daemon[663]: Jul 15 15:24:13.192  INFO iml_agent::http_comms::session: Terminating session PluginName("postoffice")/Id("8162b9b7-3fda-47a2-bc55-9fa3b12c860b")
jul 15 15:24:13 c1.local iml-agent-daemon[663]: Jul 15 15:24:13.192 DEBUG iml_agent::daemon_plugins::postoffice: Ending Inotify Listen for /etc/iml/postman.conf
jul 15 15:24:13 c1.local iml-agent-daemon[663]: Jul 15 15:24:13.192  INFO iml_agent::http_comms::session: Terminating session PluginName("device")/Id("13a704ce-f772-4caa-9233-649f27a1c85a")
jul 15 15:24:13 c1.local iml-agent-daemon[663]: Jul 15 15:24:13.193  INFO iml_agent::http_comms::session: Terminating session PluginName("ostpool")/Id("370515a3-0986-4b04-8b2a-db1dda484d3e")
jul 15 15:24:13 c1.local iml-agent-daemon[663]: Jul 15 15:24:13.193  INFO iml_agent::http_comms::session: Terminating session PluginName("action_runner")/Id("d64d353c-30ed-45c3-bb4e-a7163d580783")
jul 15 15:24:13 c1.local systemd[1]: Stopped Rust IML Agent Daemon.
jul 15 15:24:13 c1.local systemd[1]: Started Rust IML Agent Daemon.
jul 15 15:24:13 c1.local iml-agent-daemon[1828]: Jul 15 15:24:13.280  INFO iml_agent_daemon: Starting Rust agent_daemon
jul 15 15:24:13 c1.local iml-agent-daemon[1828]: unable to write 'random state'
jul 15 15:24:13 c1.local iml-agent-daemon[1828]: Jul 15 15:24:13.312  INFO iml_agent::daemon_plugins::daemon_plugin: Loaded the following DaemonPlugins:
```


Signed-off-by: Igor Pashev <pashev.igor@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2077)
<!-- Reviewable:end -->
