### PR TITLE
Fix Journal cursor deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,9 +141,9 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -338,11 +347,11 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cargo_metadata"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8de60b887edf6d74370fc8eb177040da4847d971d6234c7b13a6da324ef0caf"
+checksum = "052dbdd9db69a339d5fa9ac87bfe2e1319f709119f0345988a597af82bb1011c"
 dependencies = [
- "semver",
+ "semver 0.10.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -523,9 +532,9 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cpuid-bool"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6763c20301ab0dc67051d1b6f4cc9132ad9e6eddcb1f10c6c53ea6d6ae2183"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crossbeam-channel"
@@ -658,9 +667,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -803,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b480f641ccf0faf324e20c1d3e53d81b7484c698b42ea677f6907ae4db195371"
+checksum = "6eab5ee3df98a279d9b316b1af6ac95422127b1290317e6d18c1743c99418b01"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -835,9 +844,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -965,9 +974,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -1083,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9b7860757ce258c89fd48d28b68c41713e597a7b09e793f6c6a6e2ea37c827"
+checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
 dependencies = [
  "ahash",
  "autocfg 1.0.0",
@@ -1839,11 +1848,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
+checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
 dependencies = [
  "autocfg 1.0.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2023,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
+checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
 
 [[package]]
 name = "libloading"
@@ -2568,9 +2578,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -2653,9 +2663,9 @@ dependencies = [
  "phf_generator 0.8.0",
  "phf_shared 0.8.0",
  "proc-macro-hack",
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -2692,9 +2702,9 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -2797,9 +2807,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
  "version_check 0.9.2",
 ]
 
@@ -2809,9 +2819,9 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
  "syn-mid",
  "version_check 0.9.2",
 ]
@@ -2839,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2883,7 +2893,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
 ]
 
 [[package]]
@@ -3226,7 +3236,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -3325,6 +3335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+dependencies = [
+ "semver-parser",
  "serde",
 ]
 
@@ -3349,9 +3368,9 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -3372,9 +3391,9 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -3567,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "sqlx"
 version = "0.4.0-pre"
-source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#2551a320a2d0d3ee181ab271ab83d92b3e855b78"
+source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#7ed185a88981f1f7a6144f9c91e81e9eca46d317"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -3576,7 +3595,7 @@ dependencies = [
 [[package]]
 name = "sqlx-core"
 version = "0.4.0-pre"
-source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#2551a320a2d0d3ee181ab271ab83d92b3e855b78"
+source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#7ed185a88981f1f7a6144f9c91e81e9eca46d317"
 dependencies = [
  "atoi",
  "base64 0.12.3",
@@ -3622,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "sqlx-macros"
 version = "0.4.0-pre"
-source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#2551a320a2d0d3ee181ab271ab83d92b3e855b78"
+source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#7ed185a88981f1f7a6144f9c91e81e9eca46d317"
 dependencies = [
  "cargo_metadata",
  "dotenv",
@@ -3631,21 +3650,21 @@ dependencies = [
  "heck",
  "hex",
  "lazy_static",
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "serde",
  "serde_json",
  "sha2",
  "sqlx-core",
  "sqlx-rt",
- "syn 1.0.34",
+ "syn 1.0.35",
  "url",
 ]
 
 [[package]]
 name = "sqlx-rt"
 version = "0.1.0-pre"
-source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#2551a320a2d0d3ee181ab271ab83d92b3e855b78"
+source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#7ed185a88981f1f7a6144f9c91e81e9eca46d317"
 dependencies = [
  "native-tls",
  "once_cell",
@@ -3688,11 +3707,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -3702,13 +3721,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -3795,9 +3814,9 @@ checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -3835,11 +3854,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
+checksum = "fb7f4c519df8c117855e19dd8cc851e89eb746fe7a73f0157e0d95fdec5369b0"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
 ]
@@ -3850,9 +3869,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -3973,9 +3992,9 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -4030,10 +4049,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
  "standback",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -4094,9 +4113,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -4225,9 +4244,9 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
 ]
 
 [[package]]
@@ -4237,6 +4256,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -4262,11 +4291,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72c8cf3ec4ed69fef614d011a5ae4274537a8a8c59133558029bd731eb71659"
+checksum = "cafe899b943f5433c6cab468d75a17ea92948fe9fe60b00f41e13d5e0d4fd054"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term 0.12.1",
  "chrono",
  "lazy_static",
  "matchers",
@@ -4480,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e95175b7a927258ecbb816bdada3cc469cb68593e7940b96a60f4af366a9970"
+checksum = "df341dee97c9ae29dfa5e0b0fbbbf620e0d6a36686389bedf83b3daeb8b0d0ac"
 dependencies = [
  "bytes",
  "futures",
@@ -4501,6 +4530,8 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower-service",
+ "tracing",
+ "tracing-futures",
  "urlencoding",
 ]
 
@@ -4531,9 +4562,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.11",
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
  "wasm-bindgen-shared",
 ]
 
@@ -4565,9 +4596,9 @@ version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf592c807080719d1ff2f245a687cbadb3ed28b2077ed7084b47aba8b691f2c6"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.34",
+ "syn 1.0.35",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/iml-agent/src/daemon_plugins/journal.rs
+++ b/iml-agent/src/daemon_plugins/journal.rs
@@ -7,12 +7,10 @@ use crate::{
     daemon_plugins::{DaemonPlugin, Output},
     env::get_journal_port,
 };
-use futures::{lock::Mutex, Future, FutureExt, Stream, TryStreamExt};
+use futures::{lock::Mutex, Future, FutureExt};
 use iml_wire_types::{JournalMessage, JournalPriority};
 use lazy_static::lazy_static;
-use std::{io, pin::Pin, str, sync::Arc};
-use tokio::io::stream_reader;
-use tokio_util::codec::{FramedRead, LinesCodec};
+use std::{convert::TryFrom, pin::Pin, str, sync::Arc};
 
 #[derive(Debug, PartialEq, serde::Deserialize)]
 #[serde(untagged)]
@@ -28,7 +26,7 @@ struct IncomingMessage {
     #[serde(rename = "__REALTIME_TIMESTAMP")]
     pub realtime_timestamp: String,
     #[serde(rename = "PRIORITY")]
-    pub priority: Option<JournalPriority>,
+    pub priority: Option<String>,
     #[serde(rename = "SYSLOG_FACILITY")]
     pub syslog_facility: Option<String>,
     #[serde(rename = "SYSLOG_IDENTIFIER")]
@@ -53,58 +51,59 @@ lazy_static! {
 }
 
 async fn read_entries(
-    cursor: &Option<String>,
-) -> Result<impl Stream<Item = Result<(String, JournalMessage), ImlAgentError>>, ImlAgentError> {
+    cursor: Option<String>,
+) -> Result<Vec<(String, JournalMessage)>, ImlAgentError> {
     let client = reqwest::Client::new();
 
     let range = if let Some(x) = cursor {
         format!("entries={}:1:1000", x)
     } else {
-        "entries=:-1000:".into()
+        "entries=:-999:".into()
     };
 
-    let s = client
+    tracing::debug!("Journal Range header: {}", range);
+
+    let xs = client
         .get(URL.as_str())
         .header(reqwest::header::RANGE, range)
         .header(reqwest::header::ACCEPT, "application/json")
         .send()
         .await?
-        .bytes_stream()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
+        .text()
+        .await?
+        .lines()
+        .map(|x| serde_json::from_str(&x))
+        .collect::<Result<Vec<IncomingMessage>, _>>()?;
 
-    let s = stream_reader(s);
-
-    let s = FramedRead::new(s, LinesCodec::new())
-        .map_err(ImlAgentError::from)
-        .and_then(|x| async move {
-            let x: IncomingMessage = serde_json::from_str(&x)?;
-
-            Ok(x)
-        })
-        .and_then(|x| async move {
+    let xs = xs
+        .into_iter()
+        .map(|x| {
             let message = match x.message {
                 Msg::String(x) => x,
                 Msg::Bytes(x) => std::str::from_utf8(&x)?.to_string(),
             };
 
-            Ok((
-                x.cursor,
-                JournalMessage {
-                    datetime: std::time::Duration::from_micros(
-                        x.realtime_timestamp.parse::<u64>()?,
-                    ),
-                    severity: x.priority.unwrap_or(JournalPriority::Info),
-                    facility: x
-                        .syslog_facility
-                        .unwrap_or_else(|| "3".to_string())
-                        .parse::<i16>()?,
-                    source: x.syslog_identifier.unwrap_or_else(|| "unknown".to_string()),
-                    message,
-                },
-            ))
-        });
+            let priority = match x.priority {
+                Some(x) => JournalPriority::try_from(x)?,
+                None => JournalPriority::Info,
+            };
 
-    Ok(s)
+            let journal_message = JournalMessage {
+                datetime: std::time::Duration::from_micros(x.realtime_timestamp.parse::<u64>()?),
+                severity: priority,
+                facility: x
+                    .syslog_facility
+                    .unwrap_or_else(|| "3".to_string())
+                    .parse::<i16>()?,
+                source: x.syslog_identifier.unwrap_or_else(|| "unknown".to_string()),
+                message,
+            };
+
+            Ok((x.cursor, journal_message))
+        })
+        .collect::<Result<Vec<_>, ImlAgentError>>()?;
+
+    Ok(xs)
 }
 
 impl DaemonPlugin for Journal {
@@ -119,17 +118,21 @@ impl DaemonPlugin for Journal {
         let cursor_lock = Arc::clone(&self.cursor);
 
         async move {
-            let cursor = cursor_lock.lock().await;
+            let cursor = { cursor_lock.lock().await.as_ref().cloned() };
 
-            let xs: Vec<_> = read_entries(&cursor).await?.try_collect().await?;
+            let xs = read_entries(cursor).await?;
             let (cursors, messages): (Vec<String>, Vec<JournalMessage>) = xs.into_iter().unzip();
 
             if messages.is_empty() {
+                tracing::debug!("No new journal messages since last tick");
+
                 return Ok(None);
             }
 
             if let Some(new_cursor) = cursors.last() {
                 let mut cursor = cursor_lock.lock().await;
+
+                tracing::debug!("Replacing cursor with {}", new_cursor);
 
                 cursor.replace(new_cursor.clone());
             }

--- a/iml-services/iml-journal/src/main.rs
+++ b/iml-services/iml-journal/src/main.rs
@@ -74,8 +74,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("count returned None");
 
     while let Some((host, xs)) = s.try_next().await? {
-        tracing::info!("{:?}", xs);
-
         num_rows = purge_excess(&pool, num_rows).await?;
 
         struct Row {
@@ -95,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             None => {
                 tracing::warn!("Host '{}' is unknown", host);
 
-                return Ok(());
+                continue;
             }
         };
 

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -1602,7 +1602,6 @@ pub struct JournalMessage {
 }
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(try_from = "String")]
 #[repr(i16)]
 pub enum JournalPriority {
     Emerg,


### PR DESCRIPTION
The Journal daemon plugin keeps a Mutex around the cursor of where it last read
from the journal.

However, when updating the session we attempt to take a lock on the
cursor before the first one has been dropped.

Wrap the acquistion of the cursor and clone the contents, so it's
expclitly dropped.

In addition, read all the journal response into text and then convert to
messages instead of streaming, as this is what we end up doing anyway.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2092)
<!-- Reviewable:end -->
