### PR TITLE
tests: Mount filesystem(s) during detect_fs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,7 @@ dependencies = [
  "iml-wire-types",
  "insta",
  "petgraph",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",

--- a/iml-system-docker-tests/src/lib.rs
+++ b/iml-system-docker-tests/src/lib.rs
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use iml_cmd::{CheckedCommandExt, CmdError};
+use iml_cmd::CheckedCommandExt;
 use iml_system_test_utils::*;
 use tracing::Level;
 use tracing_subscriber::fmt::Subscriber;
 
-pub async fn run_fs_test(config: Config) -> Result<Config, CmdError> {
+pub async fn run_fs_test(config: Config) -> Result<Config, TestError> {
     Subscriber::builder().with_max_level(Level::DEBUG).init();
 
     let snapshot_map = snapshots::get_snapshots().await?;

--- a/iml-system-docker-tests/tests/ldiskfs_test.rs
+++ b/iml-system-docker-tests/tests/ldiskfs_test.rs
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use iml_cmd::CmdError;
 use iml_system_docker_tests::run_fs_test;
 use iml_system_test_utils::*;
 
 #[tokio::test]
-async fn test_docker_ldiskfs_setup() -> Result<(), CmdError> {
+async fn test_docker_ldiskfs_setup() -> Result<(), TestError> {
     let config: Config = Config::default();
     let config: Config = Config {
         profile_map: vec![("base_monitored".into(), config.storage_servers())],

--- a/iml-system-docker-tests/tests/stratagem_test.rs
+++ b/iml-system-docker-tests/tests/stratagem_test.rs
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use iml_cmd::CmdError;
 use iml_system_docker_tests::run_fs_test;
 use iml_system_test_utils::*;
 
 #[tokio::test]
-async fn test_docker_stratagem_setup() -> Result<(), CmdError> {
+async fn test_docker_stratagem_setup() -> Result<(), TestError> {
     let config: Config = Config::default();
     let config: Config = Config {
         profile_map: vec![

--- a/iml-system-docker-tests/tests/zfs_test.rs
+++ b/iml-system-docker-tests/tests/zfs_test.rs
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use iml_cmd::CmdError;
 use iml_system_docker_tests::run_fs_test;
 use iml_system_test_utils::*;
 
 #[tokio::test]
-async fn test_docker_zfs_setup() -> Result<(), CmdError> {
+async fn test_docker_zfs_setup() -> Result<(), TestError> {
     let config: Config = Config::default();
     let config: Config = Config {
         profile_map: vec![("base_monitored".into(), config.storage_servers())],

--- a/iml-system-rpm-tests/src/lib.rs
+++ b/iml-system-rpm-tests/src/lib.rs
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use iml_cmd::{CheckedCommandExt, CmdError};
+use iml_cmd::CheckedCommandExt;
 use iml_system_test_utils::*;
 use tracing::Level;
 use tracing_subscriber::fmt::Subscriber;
 
-pub async fn run_fs_test(config: Config) -> Result<Config, CmdError> {
+pub async fn run_fs_test(config: Config) -> Result<Config, TestError> {
     Subscriber::builder().with_max_level(Level::DEBUG).init();
 
     let snapshot_map = snapshots::get_snapshots().await?;

--- a/iml-system-rpm-tests/tests/ldiskfs_test.rs
+++ b/iml-system-rpm-tests/tests/ldiskfs_test.rs
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use iml_cmd::CmdError;
 use iml_system_rpm_tests::run_fs_test;
 use iml_system_test_utils::*;
 
 #[tokio::test]
-async fn test_ldiskfs_setup() -> Result<(), CmdError> {
+async fn test_ldiskfs_setup() -> Result<(), TestError> {
     let config: Config = Config::default();
 
     let config = Config {

--- a/iml-system-rpm-tests/tests/stratagem_test.rs
+++ b/iml-system-rpm-tests/tests/stratagem_test.rs
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use iml_cmd::CmdError;
 use iml_system_rpm_tests::run_fs_test;
 use iml_system_test_utils::*;
 
 #[tokio::test]
-async fn test_stratagem_setup() -> Result<(), CmdError> {
+async fn test_stratagem_setup() -> Result<(), TestError> {
     let config = Config::default();
     let config: Config = Config {
         profile_map: vec![

--- a/iml-system-rpm-tests/tests/zfs_test.rs
+++ b/iml-system-rpm-tests/tests/zfs_test.rs
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use iml_cmd::CmdError;
 use iml_system_rpm_tests::run_fs_test;
 use iml_system_test_utils::*;
 
 #[tokio::test]
-async fn test_zfs_setup() -> Result<(), CmdError> {
+async fn test_zfs_setup() -> Result<(), TestError> {
     let config = Config::default();
     let config: Config = Config {
         profile_map: vec![("base_monitored".into(), config.storage_servers())],

--- a/iml-system-test-utils/Cargo.toml
+++ b/iml-system-test-utils/Cargo.toml
@@ -12,6 +12,7 @@ iml-fs = { version = "0.3", path = "../iml-fs" }
 iml-systemd = { version = "0.3", path = "../iml-systemd" }
 iml-wire-types = { version = "0.3", path = "../iml-wire-types" }
 petgraph = "0.5"
+serde_json = "1"
 thiserror = "1.0"
 tokio = {version="0.2", features=["process", "macros", "fs"]}
 tracing = "0.1"

--- a/iml-system-test-utils/src/lib.rs
+++ b/iml-system-test-utils/src/lib.rs
@@ -629,7 +629,7 @@ pub async fn create_fs(config: Config) -> Result<Config, TestError> {
 
 async fn mount_fs(config: &Config) -> Result<usize, TestError> {
     let (count, provisioner) = match config.fs_type {
-        FsType::LDISKFS => (2, "mount-lustre-fs,mount-lustre-fs2"),
+        FsType::LDISKFS => (2, "mount-ldiskfs-fs,mount-ldiskfs-fs2"),
         FsType::ZFS => (1, "mount-zfs-fs"),
     };
 

--- a/iml-system-test-utils/src/snapshots.rs
+++ b/iml-system-test-utils/src/snapshots.rs
@@ -1,6 +1,5 @@
 use crate::*;
 use futures::{Future, FutureExt};
-use iml_cmd::CmdError;
 use petgraph::{
     graph::{DiGraph, EdgeIndex, NodeIndex},
     prelude::*,
@@ -11,7 +10,7 @@ use std::{cmp::Ordering, collections::HashMap, fmt, pin::Pin, process::Output, s
 
 type SnapshotMap = HashMap<String, Vec<SnapshotName>>;
 
-type BoxedFuture = Pin<Box<dyn Future<Output = Result<Config, CmdError>> + Send>>;
+type BoxedFuture = Pin<Box<dyn Future<Output = Result<Config, TestError>> + Send>>;
 type TransitionFn = Box<dyn Fn(Config) -> BoxedFuture + Send + Sync>;
 
 #[derive(PartialEq, Eq, Debug)]
@@ -175,7 +174,7 @@ pub fn get_snapshot_name_for_state(config: &Config, state: TestState) -> snapsho
 
 fn mk_transition<Fut>(f: fn(Config) -> Fut) -> TransitionFn
 where
-    Fut: Future<Output = Result<Config, CmdError>> + Send + 'static,
+    Fut: Future<Output = Result<Config, TestError>> + Send + 'static,
 {
     Box::new(move |config| Box::pin(f(config).boxed()))
 }
@@ -469,7 +468,7 @@ pub fn get_active_test_path(
     }
 }
 
-pub async fn fetch_snapshot_list() -> Result<std::process::Output, CmdError> {
+pub async fn fetch_snapshot_list() -> Result<std::process::Output, TestError> {
     let mut cmd = vagrant::vagrant().await?;
 
     let x = cmd.arg("snapshot").arg("list").output().await?;
@@ -524,7 +523,7 @@ pub fn parse_snapshots(snapshots: Output) -> SnapshotMap {
     snapshot_map
 }
 
-pub async fn get_snapshots() -> Result<SnapshotMap, CmdError> {
+pub async fn get_snapshots() -> Result<SnapshotMap, TestError> {
     let snapshot_data = fetch_snapshot_list().await?;
     Ok(parse_snapshots(snapshot_data))
 }

--- a/iml-system-test-utils/src/snapshots.rs
+++ b/iml-system-test-utils/src/snapshots.rs
@@ -338,7 +338,7 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
         ldiskfs_created,
         filesystem_detected,
         Transition {
-            path: SnapshotPath::All,
+            path: SnapshotPath::Ldiskfs,
             transition: mk_transition(detect_fs),
         },
     );
@@ -347,7 +347,7 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
         zfs_created,
         filesystem_detected,
         Transition {
-            path: SnapshotPath::All,
+            path: SnapshotPath::ZFS,
             transition: mk_transition(detect_fs),
         },
     );
@@ -356,7 +356,7 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
         stratagem_created,
         filesystem_detected,
         Transition {
-            path: SnapshotPath::All,
+            path: SnapshotPath::Stratagem,
             transition: mk_transition(detect_fs),
         },
     );

--- a/iml-system-test-utils/src/snapshots.rs
+++ b/iml-system-test-utils/src/snapshots.rs
@@ -347,7 +347,7 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
         zfs_created,
         filesystem_detected,
         Transition {
-            path: SnapshotPath::ZFS,
+            path: SnapshotPath::Zfs,
             transition: mk_transition(detect_fs),
         },
     );

--- a/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_ldiskfs_test_path_from_graph.snap
+++ b/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_ldiskfs_test_path_from_graph.snap
@@ -7,7 +7,5 @@ edge: LdiskfsOrZfs has nodes (Snapshot { name: Bare, available: false }, Snapsho
 edge: LdiskfsOrZfs has nodes (Snapshot { name: ImlConfigured, available: false }, Snapshot { name: ServersDeployed, available: false })
 edge: Ldiskfs has nodes (Snapshot { name: ServersDeployed, available: false }, Snapshot { name: LdiskfsInstalled, available: false })
 edge: Ldiskfs has nodes (Snapshot { name: LdiskfsInstalled, available: false }, Snapshot { name: LdiskfsCreated, available: false })
-edge: All has nodes (Snapshot { name: LdiskfsCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
-edge: All has nodes (Snapshot { name: ZfsCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
-edge: All has nodes (Snapshot { name: StratagemCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
+edge: Ldiskfs has nodes (Snapshot { name: LdiskfsCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
 

--- a/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_stratagem_test_path_from_graph.snap
+++ b/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_stratagem_test_path_from_graph.snap
@@ -4,10 +4,8 @@ expression: "print_edges(&graph, &edges)"
 ---
 edge: All has nodes (Snapshot { name: Init, available: true }, Snapshot { name: Bare, available: false })
 edge: Stratagem has nodes (Snapshot { name: Bare, available: false }, Snapshot { name: ImlStratagemConfigured, available: false })
-edge: All has nodes (Snapshot { name: LdiskfsCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
-edge: All has nodes (Snapshot { name: ZfsCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
 edge: Stratagem has nodes (Snapshot { name: ImlStratagemConfigured, available: false }, Snapshot { name: StratagemServersDeployed, available: false })
 edge: Stratagem has nodes (Snapshot { name: StratagemServersDeployed, available: false }, Snapshot { name: StratagemInstalled, available: false })
 edge: Stratagem has nodes (Snapshot { name: StratagemInstalled, available: false }, Snapshot { name: StratagemCreated, available: false })
-edge: All has nodes (Snapshot { name: StratagemCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
+edge: Stratagem has nodes (Snapshot { name: StratagemCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
 

--- a/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_zfs_test_path_from_graph.snap
+++ b/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_zfs_test_path_from_graph.snap
@@ -6,8 +6,6 @@ edge: All has nodes (Snapshot { name: Init, available: true }, Snapshot { name: 
 edge: LdiskfsOrZfs has nodes (Snapshot { name: Bare, available: false }, Snapshot { name: ImlConfigured, available: false })
 edge: LdiskfsOrZfs has nodes (Snapshot { name: ImlConfigured, available: false }, Snapshot { name: ServersDeployed, available: false })
 edge: Zfs has nodes (Snapshot { name: ServersDeployed, available: false }, Snapshot { name: ZfsInstalled, available: false })
-edge: All has nodes (Snapshot { name: LdiskfsCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
 edge: Zfs has nodes (Snapshot { name: ZfsInstalled, available: false }, Snapshot { name: ZfsCreated, available: false })
-edge: All has nodes (Snapshot { name: ZfsCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
-edge: All has nodes (Snapshot { name: StratagemCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
+edge: Zfs has nodes (Snapshot { name: ZfsCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
 

--- a/iml-system-test-utils/src/ssh.rs
+++ b/iml-system-test-utils/src/ssh.rs
@@ -268,6 +268,17 @@ pub async fn detect_fs(host: &str) -> Result<(), CmdError> {
         .await
 }
 
+pub async fn list_fs_json(host: &str) -> Result<Vec<serde_json::Value>, CmdError> {
+    ssh_exec_cmd(host, "iml filesystem list -p json")
+        .await?
+        .checked_output()
+        .await
+        .map(|o| {
+            let v: Vec<serde_json::Value> = serde_json::from_slice(&o.stdout).unwrap();
+            v
+        })
+}
+
 pub async fn systemd_status(host: &str, service_name: &str) -> Result<Command, CmdError> {
     let cmd = ssh_exec_cmd(host, format!("systemctl status {}", service_name).as_str()).await?;
 

--- a/iml-system-test-utils/src/ssh.rs
+++ b/iml-system-test-utils/src/ssh.rs
@@ -269,7 +269,7 @@ pub async fn detect_fs(host: &str) -> Result<(), CmdError> {
 }
 
 pub async fn list_fs_json(host: &str) -> Result<Vec<serde_json::Value>, CmdError> {
-    ssh_exec_cmd(host, "iml filesystem list -p json")
+    ssh_exec_cmd(host, "iml filesystem list --display json")
         .await?
         .checked_output()
         .await

--- a/iml-system-test-utils/src/ssh.rs
+++ b/iml-system-test-utils/src/ssh.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2020 DDN. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
-use crate::Config;
-use futures::future::try_join_all;
-use iml_cmd::{CheckedChildExt, CheckedCommandExt, CmdError};
+use crate::{Config, TestError};
+use futures::future::{try_join_all, TryFutureExt};
+use iml_cmd::{CheckedChildExt, CheckedCommandExt};
 use std::{
     process::{Output, Stdio},
     str,
@@ -11,7 +11,7 @@ use std::{
 };
 use tokio::{fs::canonicalize, io::AsyncWriteExt, process::Command};
 
-pub async fn scp(from: String, to: String) -> Result<(), CmdError> {
+pub async fn scp(from: String, to: String) -> Result<(), TestError> {
     tracing::debug!("transferring file from {} to {}", from, to);
 
     let path = canonicalize("../vagrant/").await?;
@@ -37,7 +37,7 @@ pub async fn scp_down_parallel(
     servers: &[&str],
     remote_path: &str,
     to: &str,
-) -> Result<(), CmdError> {
+) -> Result<(), TestError> {
     let remote_calls = servers.iter().map(|host| {
         let from = format!("{}:{}", host, remote_path);
         scp(from, to.to_string())
@@ -52,7 +52,7 @@ pub async fn scp_up_parallel(
     servers: &[&str],
     from: &str,
     to_remote: &str,
-) -> Result<(), CmdError> {
+) -> Result<(), TestError> {
     let remote_calls = servers.iter().map(|host| {
         let to = format!("{}:{}", host, to_remote);
         scp(from.into(), to)
@@ -63,7 +63,7 @@ pub async fn scp_up_parallel(
     Ok(())
 }
 
-pub async fn ssh_exec_cmd<'a, 'b>(host: &'a str, cmd: &'b str) -> Result<Command, CmdError> {
+pub async fn ssh_exec_cmd<'a, 'b>(host: &'a str, cmd: &'b str) -> Result<Command, TestError> {
     tracing::debug!("Running command {} on {}", cmd, host);
     let path = canonicalize("../vagrant/").await?;
 
@@ -82,7 +82,7 @@ pub async fn ssh_exec_cmd<'a, 'b>(host: &'a str, cmd: &'b str) -> Result<Command
     Ok(x)
 }
 
-pub async fn ssh_exec<'a, 'b>(host: &'a str, cmd: &'b str) -> Result<(&'a str, Output), CmdError> {
+pub async fn ssh_exec<'a, 'b>(host: &'a str, cmd: &'b str) -> Result<(&'a str, Output), TestError> {
     let mut cmd = ssh_exec_cmd(host, cmd).await?;
 
     let out = cmd.checked_output().await?;
@@ -93,7 +93,7 @@ pub async fn ssh_exec<'a, 'b>(host: &'a str, cmd: &'b str) -> Result<(&'a str, O
 async fn ssh_exec_parallel<'a, 'b>(
     servers: &[&'a str],
     cmd: &'b str,
-) -> Result<Vec<(&'a str, Output)>, CmdError> {
+) -> Result<Vec<(&'a str, Output)>, TestError> {
     let remote_calls = servers.iter().map(|host| ssh_exec(host, cmd));
 
     let output = try_join_all(remote_calls).await?;
@@ -113,7 +113,7 @@ pub async fn ssh_script<'a, 'b>(
     host: &'a str,
     script: &'b str,
     args: &[&'b str],
-) -> Result<(&'a str, Output), CmdError> {
+) -> Result<(&'a str, Output), TestError> {
     let path = canonicalize("../vagrant/").await?;
 
     let mut script_path = path.clone();
@@ -150,7 +150,7 @@ async fn ssh_script_parallel<'a, 'b>(
     servers: &'b [&'a str],
     script: &'b str,
     args: &[&'b str],
-) -> Result<Vec<(&'a str, Output)>, CmdError> {
+) -> Result<Vec<(&'a str, Output)>, TestError> {
     let remote_calls = servers.iter().map(|host| ssh_script(host, script, args));
 
     let output = try_join_all(remote_calls).await?;
@@ -168,7 +168,7 @@ async fn ssh_script_parallel<'a, 'b>(
 
 pub async fn install_ldiskfs_no_iml<'a, 'b>(
     config: &Config,
-) -> Result<Vec<(&'a str, Output)>, CmdError> {
+) -> Result<Vec<(&'a str, Output)>, TestError> {
     ssh_script_parallel(
         &config.storage_server_ips(),
         "scripts/install_ldiskfs_no_iml.sh",
@@ -179,7 +179,7 @@ pub async fn install_ldiskfs_no_iml<'a, 'b>(
 
 pub async fn install_zfs_no_iml<'a, 'b>(
     config: &Config,
-) -> Result<Vec<(&'a str, Output)>, CmdError> {
+) -> Result<Vec<(&'a str, Output)>, TestError> {
     ssh_script_parallel(
         &config.storage_server_ips(),
         "scripts/install_zfs_no_iml.sh",
@@ -188,44 +188,44 @@ pub async fn install_zfs_no_iml<'a, 'b>(
     .await
 }
 
-pub async fn yum_update<'a, 'b>(hosts: &'b [&'a str]) -> Result<Vec<(&'a str, Output)>, CmdError> {
+pub async fn yum_update<'a, 'b>(hosts: &'b [&'a str]) -> Result<Vec<(&'a str, Output)>, TestError> {
     ssh_exec_parallel(hosts, "yum clean metadata; yum update -y").await
 }
 
 pub async fn configure_ntp_for_host_only_if<'a, 'b>(
     hosts: &'b [&'a str],
-) -> Result<Vec<(&'a str, Output)>, CmdError> {
+) -> Result<Vec<(&'a str, Output)>, TestError> {
     ssh_script_parallel(hosts, "scripts/configure_ntp.sh", &["10.73.10.1"]).await
 }
 
 pub async fn configure_ntp_for_adm<'a, 'b>(
     hosts: &'b [&'a str],
-) -> Result<Vec<(&'a str, Output)>, CmdError> {
+) -> Result<Vec<(&'a str, Output)>, TestError> {
     ssh_script_parallel(hosts, "scripts/configure_ntp.sh", &["adm.local"]).await
 }
 
 pub async fn wait_for_ntp_for_host_only_if<'a, 'b>(
     hosts: &'b [&'a str],
-) -> Result<Vec<(&'a str, Output)>, CmdError> {
+) -> Result<Vec<(&'a str, Output)>, TestError> {
     ssh_script_parallel(hosts, "scripts/wait_for_ntp.sh", &["10.73.10.1"]).await
 }
 
 pub async fn wait_for_ntp_for_adm<'a, 'b>(
     hosts: &'b [&'a str],
-) -> Result<Vec<(&'a str, Output)>, CmdError> {
+) -> Result<Vec<(&'a str, Output)>, TestError> {
     ssh_script_parallel(hosts, "scripts/wait_for_ntp.sh", &["adm.local"]).await
 }
 
 pub async fn enable_debug_on_hosts<'a, 'b>(
     hosts: &'b [&'a str],
-) -> Result<Vec<(&'a str, Output)>, CmdError> {
+) -> Result<Vec<(&'a str, Output)>, TestError> {
     ssh_script_parallel(hosts, "scripts/enable_debug.sh", &[]).await
 }
 
 pub async fn create_iml_diagnostics<'a, 'b>(
     hosts: Vec<&'a str>,
     prefix: &'a str,
-) -> Result<(), CmdError> {
+) -> Result<(), TestError> {
     let path_buf = canonicalize("../vagrant/").await?;
     let path = path_buf.as_path().to_str().expect("Couldn't get path.");
 
@@ -258,20 +258,23 @@ pub async fn create_iml_diagnostics<'a, 'b>(
         .arg("-R")
         .arg(report_dir)
         .checked_status()
+        .err_into()
         .await
 }
 
-pub async fn detect_fs(host: &str) -> Result<(), CmdError> {
+pub async fn detect_fs(host: &str) -> Result<(), TestError> {
     ssh_exec_cmd(host, "iml filesystem detect")
         .await?
         .checked_status()
+        .err_into()
         .await
 }
 
-pub async fn list_fs_json(host: &str) -> Result<Vec<serde_json::Value>, CmdError> {
+pub async fn list_fs_json(host: &str) -> Result<Vec<serde_json::Value>, TestError> {
     ssh_exec_cmd(host, "iml filesystem list --display json")
         .await?
         .checked_output()
+        .err_into()
         .await
         .map(|o| {
             let v: Vec<serde_json::Value> = serde_json::from_slice(&o.stdout).unwrap();
@@ -279,13 +282,13 @@ pub async fn list_fs_json(host: &str) -> Result<Vec<serde_json::Value>, CmdError
         })
 }
 
-pub async fn systemd_status(host: &str, service_name: &str) -> Result<Command, CmdError> {
+pub async fn systemd_status(host: &str, service_name: &str) -> Result<Command, TestError> {
     let cmd = ssh_exec_cmd(host, format!("systemctl status {}", service_name).as_str()).await?;
 
     Ok(cmd)
 }
 
-pub async fn add_servers(host: &str, profile: &str, hosts: Vec<String>) -> Result<(), CmdError> {
+pub async fn add_servers(host: &str, profile: &str, hosts: Vec<String>) -> Result<(), TestError> {
     ssh_exec_cmd(
         host,
         &format!("iml server add {} -p {}", hosts.join(","), profile),

--- a/iml-system-test-utils/src/vagrant.rs
+++ b/iml-system-test-utils/src/vagrant.rs
@@ -3,11 +3,11 @@
 // license that can be found in the LICENSE file.
 
 use crate::*;
-use iml_cmd::CmdError;
+use futures::future::TryFutureExt;
 use std::str;
 use tokio::{fs::canonicalize, process::Command};
 
-pub async fn vagrant() -> Result<Command, CmdError> {
+pub async fn vagrant() -> Result<Command, TestError> {
     let mut x = Command::new("vagrant");
 
     let path = canonicalize("../vagrant/").await?;
@@ -17,7 +17,7 @@ pub async fn vagrant() -> Result<Command, CmdError> {
     Ok(x)
 }
 
-pub async fn up<'a>() -> Result<Command, CmdError> {
+pub async fn up<'a>() -> Result<Command, TestError> {
     let mut x = vagrant().await?;
 
     x.arg("up");
@@ -25,7 +25,7 @@ pub async fn up<'a>() -> Result<Command, CmdError> {
     Ok(x)
 }
 
-pub async fn destroy<'a>(config: &Config) -> Result<(), CmdError> {
+pub async fn destroy<'a>(config: &Config) -> Result<(), TestError> {
     let nodes = config.destroy_list();
 
     for node in &nodes {
@@ -45,28 +45,28 @@ pub async fn destroy<'a>(config: &Config) -> Result<(), CmdError> {
     Ok(())
 }
 
-pub async fn halt() -> Result<Command, CmdError> {
+pub async fn halt() -> Result<Command, TestError> {
     let mut x = vagrant().await?;
     x.arg("halt");
 
     Ok(x)
 }
 
-pub async fn suspend() -> Result<Command, CmdError> {
+pub async fn suspend() -> Result<Command, TestError> {
     let mut x = vagrant().await?;
     x.arg("suspend");
 
     Ok(x)
 }
 
-pub async fn reload() -> Result<Command, CmdError> {
+pub async fn reload() -> Result<Command, TestError> {
     let mut x = vagrant().await?;
     x.arg("reload");
 
     Ok(x)
 }
 
-async fn snapshot() -> Result<Command, CmdError> {
+async fn snapshot() -> Result<Command, TestError> {
     let mut x = vagrant().await?;
 
     x.arg("snapshot");
@@ -74,7 +74,7 @@ async fn snapshot() -> Result<Command, CmdError> {
     Ok(x)
 }
 
-pub async fn snapshot_save(host: &str, name: &str) -> Result<Command, CmdError> {
+pub async fn snapshot_save(host: &str, name: &str) -> Result<Command, TestError> {
     let mut x = snapshot().await?;
 
     x.arg("save").arg("-f").arg(host).arg(name);
@@ -82,7 +82,7 @@ pub async fn snapshot_save(host: &str, name: &str) -> Result<Command, CmdError> 
     Ok(x)
 }
 
-pub async fn snapshot_restore(host: &str, name: &str) -> Result<Command, CmdError> {
+pub async fn snapshot_restore(host: &str, name: &str) -> Result<Command, TestError> {
     let mut x = snapshot().await?;
 
     x.arg("restore").arg(host).arg(name);
@@ -90,7 +90,7 @@ pub async fn snapshot_restore(host: &str, name: &str) -> Result<Command, CmdErro
     Ok(x)
 }
 
-pub async fn snapshot_delete(host: &str, name: &str) -> Result<Command, CmdError> {
+pub async fn snapshot_delete(host: &str, name: &str) -> Result<Command, TestError> {
     let mut x = snapshot().await?;
 
     x.arg("delete").arg("-f").arg(host).arg(name);
@@ -98,7 +98,7 @@ pub async fn snapshot_delete(host: &str, name: &str) -> Result<Command, CmdError
     Ok(x)
 }
 
-pub async fn provision(name: &str) -> Result<Command, CmdError> {
+pub async fn provision(name: &str) -> Result<Command, TestError> {
     let mut x = vagrant().await?;
 
     x.arg("provision").arg("--provision-with").arg(name);
@@ -106,7 +106,7 @@ pub async fn provision(name: &str) -> Result<Command, CmdError> {
     Ok(x)
 }
 
-pub async fn provision_node(node: &str, name: &str) -> Result<Command, CmdError> {
+pub async fn provision_node(node: &str, name: &str) -> Result<Command, TestError> {
     let mut x = vagrant().await?;
 
     x.arg("provision")
@@ -117,8 +117,8 @@ pub async fn provision_node(node: &str, name: &str) -> Result<Command, CmdError>
     Ok(x)
 }
 
-pub async fn rsync(host: &str) -> Result<(), CmdError> {
+pub async fn rsync(host: &str) -> Result<(), TestError> {
     let mut x = vagrant().await?;
 
-    x.arg("rsync").arg(host).checked_status().await
+    x.arg("rsync").arg(host).checked_status().err_into().await
 }

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -97,7 +97,7 @@ From here you can decide what type of setup to run.
 - Monitored ZFS:
 
   ```sh
-  vagrant provision --provision-with=install-zfs-no-iml,configure-lustre-network,create-pools,zfs-params,create-zfs-fs
+  vagrant provision --provision-with=install-zfs-no-iml,configure-lustre-network,create-pools,zfs-params,create-zfs-fs,mount-zfs-fs
   ```
 
 - Managed Mode:

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -334,13 +334,13 @@ Vagrant.configure('2') do |config|
                          inline: <<-SHELL
                            mkfs.lustre --servicenode 10.73.20.11@tcp:10.73.20.12@tcp --mgs --backfstype=zfs mgt/mgt
                            mkfs.lustre --reformat --failover 10.73.20.12@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=0 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp mdt0/mdt0
-                           mkdir -p /lustre/zfsmo/{mgs,mdt0}
                          SHELL
 
         mds.vm.provision 'mount-zfs-fs',
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
+                           mkdir -p /lustre/zfsmo/{mgs,mdt0}
                            mount -t lustre mgt/mgt /lustre/zfsmo/mgs
                            mount -t lustre mdt0/mdt0 /lustre/zfsmo/mdt0
                          SHELL
@@ -357,8 +357,7 @@ Vagrant.configure('2') do |config|
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
-                           mkdir -p /mnt/mgs
-                           mkdir -p /mnt/mdt0
+                           mkdir -p /mnt/{mgs,mdt0}
                            mount -t lustre /dev/mapper/mpatha /mnt/mgs
                            mount -t lustre /dev/mapper/mpathb /mnt/mdt0
                          SHELL
@@ -410,13 +409,13 @@ Vagrant.configure('2') do |config|
                          run: 'never',
                          inline: <<-SHELL
                            mkfs.lustre --failover 10.73.20.11@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=1 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp mdt1/mdt1
-                           mkdir -p /lustre/zfsmo/mdt1
                          SHELL
 
         mds.vm.provision 'mount-zfs-fs',
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
+                           mkdir -p /lustre/zfsmo/mdt1
                            mount -t lustre mdt1/mdt1 /lustre/zfsmo/mdt1
                          SHELL
 
@@ -602,13 +601,13 @@ Vagrant.configure('2') do |config|
                               mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=7 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost7/ost7
                               mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=8 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost8/ost8
                               mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=9 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost9/ost9
-                              mkdir -p /lustre/zfsmo/ost{0..9}
                          SHELL
 
          oss.vm.provision 'mount-zfs-fs',
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
+                              mkdir -p /lustre/zfsmo/ost{0..9}
                               mount -t lustre ost0/ost0 /lustre/zfsmo/ost0
                               mount -t lustre ost1/ost1 /lustre/zfsmo/ost1
                               mount -t lustre ost2/ost2 /lustre/zfsmo/ost2
@@ -621,7 +620,7 @@ Vagrant.configure('2') do |config|
                               mount -t lustre ost9/ost9 /lustre/zfsmo/ost9
                          SHELL
 
-       oss.vm.provision 'create-ldiskfs-fs',
+        oss.vm.provision 'create-ldiskfs-fs',
                          type: 'shell',
                          run: 'never',
                          path: 'scripts/create_ldiskfs_fs_osts.sh',
@@ -734,13 +733,13 @@ Vagrant.configure('2') do |config|
                               mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=17 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost17/ost17
                               mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=18 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost18/ost18
                               mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=19 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost19/ost19
-                              mkdir -p /lustre/zfsmo/ost{10..19}
                          SHELL
 
         oss.vm.provision 'mount-zfs-fs',
                          type: 'shell',
                          run: 'never',
                          inline: <<-SHELL
+                              mkdir -p /lustre/zfsmo/ost{10..19}
                               mount -t lustre ost10/ost10 /lustre/zfsmo/ost10
                               mount -t lustre ost11/ost11 /lustre/zfsmo/ost11
                               mount -t lustre ost12/ost12 /lustre/zfsmo/ost12

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -333,11 +333,15 @@ Vagrant.configure('2') do |config|
                          run: 'never',
                          inline: <<-SHELL
                            mkfs.lustre --servicenode 10.73.20.11@tcp:10.73.20.12@tcp --mgs --backfstype=zfs mgt/mgt
-                           mkdir -p /lustre/zfsmo/mgs
-                           mount -t lustre mgt/mgt /lustre/zfsmo/mgs
-
                            mkfs.lustre --reformat --failover 10.73.20.12@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=0 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp mdt0/mdt0
-                           mkdir -p /lustre/zfsmo/mdt0
+                           mkdir -p /lustre/zfsmo/{mgs,mdt0}
+                         SHELL
+
+        mds.vm.provision 'mount-zfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
+                           mount -t lustre mgt/mgt /lustre/zfsmo/mgs
                            mount -t lustre mdt0/mdt0 /lustre/zfsmo/mdt0
                          SHELL
 
@@ -407,6 +411,12 @@ Vagrant.configure('2') do |config|
                          inline: <<-SHELL
                            mkfs.lustre --failover 10.73.20.11@tcp --mdt --backfstype=zfs --fsname=zfsmo --index=1 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp mdt1/mdt1
                            mkdir -p /lustre/zfsmo/mdt1
+                         SHELL
+
+        mds.vm.provision 'mount-zfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
                            mount -t lustre mdt1/mdt1 /lustre/zfsmo/mdt1
                          SHELL
 
@@ -593,6 +603,12 @@ Vagrant.configure('2') do |config|
                               mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=8 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost8/ost8
                               mkfs.lustre --failover 10.73.20.22@tcp --ost --backfstype=zfs --fsname=zfsmo --index=9 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost9/ost9
                               mkdir -p /lustre/zfsmo/ost{0..9}
+                         SHELL
+
+         oss.vm.provision 'mount-zfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
                               mount -t lustre ost0/ost0 /lustre/zfsmo/ost0
                               mount -t lustre ost1/ost1 /lustre/zfsmo/ost1
                               mount -t lustre ost2/ost2 /lustre/zfsmo/ost2
@@ -605,7 +621,7 @@ Vagrant.configure('2') do |config|
                               mount -t lustre ost9/ost9 /lustre/zfsmo/ost9
                          SHELL
 
-        oss.vm.provision 'create-ldiskfs-fs',
+       oss.vm.provision 'create-ldiskfs-fs',
                          type: 'shell',
                          run: 'never',
                          path: 'scripts/create_ldiskfs_fs_osts.sh',
@@ -719,6 +735,12 @@ Vagrant.configure('2') do |config|
                               mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=18 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost18/ost18
                               mkfs.lustre --failover 10.73.20.21@tcp --ost --backfstype=zfs --fsname=zfsmo --index=19 --mgsnode=10.73.20.11@tcp:10.73.20.12@tcp ost19/ost19
                               mkdir -p /lustre/zfsmo/ost{10..19}
+                         SHELL
+
+        oss.vm.provision 'mount-zfs-fs',
+                         type: 'shell',
+                         run: 'never',
+                         inline: <<-SHELL
                               mount -t lustre ost10/ost10 /lustre/zfsmo/ost10
                               mount -t lustre ost11/ost11 /lustre/zfsmo/ost11
                               mount -t lustre ost12/ost12 /lustre/zfsmo/ost12


### PR DESCRIPTION
vagrant: Split mount from create for zfs backed fs
test: Check that the correct number of filesystems
were detected in detect_fs()

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2102)
<!-- Reviewable:end -->
