### PR TITLE
Make docker image tarball a required file

### DIFF
--- a/iml-docker.service
+++ b/iml-docker.service
@@ -10,7 +10,7 @@ StandardError=journal
 StandardOutput=journal
 EnvironmentFile=-/etc/iml-docker/setup/config
 WorkingDirectory=/etc/iml-docker
-ExecStartPre=-/usr/bin/docker load -i /var/tmp/iml-images.tgz
+ExecStartPre=-/usr/bin/docker load -i /var/lib/iml-images.tgz
 ExecStart=/usr/bin/docker stack deploy -c docker-compose.yml -c docker-compose.overrides.yml iml --resolve-image=never
 ExecStart=/bin/bash -c 'until /usr/bin/iml server list > /dev/null 2>&1; do sleep 1; done'
 ExecStop=/usr/bin/docker stack rm iml

--- a/iml-docker.spec
+++ b/iml-docker.spec
@@ -37,8 +37,8 @@ mv iml-docker.service %{buildroot}%{_unitdir}
 
 %files
 %{_sysconfdir}/iml-docker
-%attr(750, root, root) %{_sharedstatedir}/iml-images.tgz
-%attr(754, root, root) %{_bindir}/iml
+%attr(0640, root, root) %{_sharedstatedir}/iml-images.tgz
+%attr(0755, root, root) %{_bindir}/iml
 %attr(754, root, root) %{_bindir}/update-embedded
 %attr(0644, root, root) %{_unitdir}/iml-docker.service
 

--- a/iml-docker.spec
+++ b/iml-docker.spec
@@ -25,11 +25,11 @@ Requires: sed
 %install
 rm -rf %{buildroot}
 mkdir -p %{buildroot}%{_sysconfdir}/iml-docker/setup/branding
-mkdir -p %{buildroot}%{_tmppath}
+mkdir -p %{buildroot}%{_sharedstatedir}
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_unitdir}
 cp docker-compose.yml %{buildroot}%{_sysconfdir}/iml-docker
-mv iml-images.tgz %{buildroot}%{_tmppath}
+mv iml-images.tgz %{buildroot}%{_sharedstatedir}
 mv iml-cli-proxy.sh %{buildroot}%{_bindir}/iml
 mv update-embedded.sh %{buildroot}%{_bindir}/update-embedded
 mv iml-docker.service %{buildroot}%{_unitdir}
@@ -37,10 +37,10 @@ mv iml-docker.service %{buildroot}%{_unitdir}
 
 %files
 %{_sysconfdir}/iml-docker
-%attr(750, root, root) %config(missingok) %{_tmppath}/iml-images.tgz
+%attr(750, root, root) %{_sharedstatedir}/iml-images.tgz
 %attr(754, root, root) %{_bindir}/iml
 %attr(754, root, root) %{_bindir}/update-embedded
-%attr(0644,root,root) %{_unitdir}/iml-docker.service
+%attr(0644, root, root) %{_unitdir}/iml-docker.service
 
 
 %post


### PR DESCRIPTION
`iml-images.tgz` currently lives under /var/tmp
and is marked as ok if it's missing.

This can cause an issue if the tarball is removed, as `iml-docker` will
not be able to load the images and startup.

Move the tarball to `/var/lib`, and make it non-optional.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2103)
<!-- Reviewable:end -->
