### PR TITLE
Tests: Add clients to ldiskfs zfs profile list

### DIFF
--- a/iml-system-docker-tests/tests/ldiskfs_test.rs
+++ b/iml-system-docker-tests/tests/ldiskfs_test.rs
@@ -9,7 +9,7 @@ use iml_system_test_utils::*;
 async fn test_docker_ldiskfs_setup() -> Result<(), TestError> {
     let config: Config = Config::default();
     let config: Config = Config {
-        profile_map: vec![("base_monitored".into(), config.storage_servers())],
+        profile_map: vec![("base_monitored".into(), config.storage_servers()), ("base_client".into(), config.client_servers())],
         test_type: TestType::Docker,
         ntp_server: NtpServer::HostOnly,
         ..config

--- a/iml-system-docker-tests/tests/zfs_test.rs
+++ b/iml-system-docker-tests/tests/zfs_test.rs
@@ -9,7 +9,7 @@ use iml_system_test_utils::*;
 async fn test_docker_zfs_setup() -> Result<(), TestError> {
     let config: Config = Config::default();
     let config: Config = Config {
-        profile_map: vec![("base_monitored".into(), config.storage_servers())],
+        profile_map: vec![("base_monitored".into(), config.storage_servers()), ("base_client".into(), config.client_servers())],
         test_type: TestType::Docker,
         ntp_server: NtpServer::HostOnly,
         fs_type: FsType::ZFS,

--- a/iml-system-rpm-tests/tests/ldiskfs_test.rs
+++ b/iml-system-rpm-tests/tests/ldiskfs_test.rs
@@ -10,7 +10,7 @@ async fn test_ldiskfs_setup() -> Result<(), TestError> {
     let config: Config = Config::default();
 
     let config = Config {
-        profile_map: vec![("base_monitored".into(), config.storage_servers())],
+        profile_map: vec![("base_monitored".into(), config.storage_servers()), ("base_client".into(), config.client_servers())],
         ..config
     };
 

--- a/iml-system-rpm-tests/tests/zfs_test.rs
+++ b/iml-system-rpm-tests/tests/zfs_test.rs
@@ -9,7 +9,7 @@ use iml_system_test_utils::*;
 async fn test_zfs_setup() -> Result<(), TestError> {
     let config = Config::default();
     let config: Config = Config {
-        profile_map: vec![("base_monitored".into(), config.storage_servers())],
+        profile_map: vec![("base_monitored".into(), config.storage_servers()), ("base_client".into(), config.client_servers())],
         fs_type: FsType::ZFS,
         ..config
     };

--- a/iml-system-test-utils/src/lib.rs
+++ b/iml-system-test-utils/src/lib.rs
@@ -688,31 +688,32 @@ pub async fn detect_fs(config: Config) -> Result<Config, TestError> {
     }
 }
 
-async fn configure_extra_profile(vagrant_path: &PathBuf) -> Result<Vec<PathBuf>, TestError> {
+// Returns list of server profile file names
+async fn configure_extra_profile(vagrant_path: &PathBuf) -> Result<Vec<String>, TestError> {
     let mut rc = vec![];
     // Register Stratagem Server Profile
     let mut profile_path = vagrant_path.clone();
     profile_path.push("stratagem-server.profile");
+    rc.push("stratagem-server.profile".into());
 
     let mut file = File::create(&profile_path).await?;
     file.write_all(STRATAGEM_SERVER_PROFILE.as_bytes()).await?;
-    rc.push(profile_path);
 
     // Register Stratagem Client Profile
     let mut profile_path = vagrant_path.clone();
     profile_path.push("stratagem-client.profile");
+    rc.push("stratagem-client.profile".into());
 
     let mut file = File::create(&profile_path).await?;
     file.write_all(STRATAGEM_CLIENT_PROFILE.as_bytes()).await?;
-    rc.push(profile_path);
 
     // Register Base Client Profile
     let mut profile_path = vagrant_path.clone();
     profile_path.push("base-client.profile");
+    rc.push("base-client.profile".into());
 
     let mut file = File::create(&profile_path).await?;
     file.write_all(BASE_CLIENT_PROFILE.as_bytes()).await?;
-    rc.push(profile_path);
 
     Ok(rc)
 }
@@ -734,7 +735,7 @@ pub async fn configure_rpm_setup(config: &Config) -> Result<(), TestError> {
          && sudo systemctl restart iml-manager.target",
         path_list
             .into_iter()
-            .map(|p| format!(" && sudo chroma-config profile register {}", p.display()))
+            .map(|p| format!(" && sudo chroma-config profile register /vagrant/{}", p))
             .collect::<Vec<String>>()
             .concat()
     );
@@ -765,7 +766,7 @@ pub async fn configure_docker_setup(config: &Config) -> Result<(), TestError> {
         "sudo mkdir -p /etc/iml-docker/setup && sudo cp /vagrant/config /etc/iml-docker/setup/ {}",
         path_list
             .into_iter()
-            .map(|p| format!(" && sudo cp {} /etc/iml-docker/setup/", p.display()))
+            .map(|p| format!(" && sudo cp /vagrant/{} /etc/iml-docker/setup/", p))
             .collect::<Vec<String>>()
             .concat()
     );

--- a/iml-system-test-utils/src/lib.rs
+++ b/iml-system-test-utils/src/lib.rs
@@ -690,7 +690,7 @@ pub async fn detect_fs(config: Config) -> Result<Config, TestError> {
 
 async fn configure_extra_profile(vagrant_path: &PathBuf) -> Result<Vec<PathBuf>, TestError> {
     let mut rc = vec![];
-    // Register Stratage Server Profile
+    // Register Stratagem Server Profile
     let mut profile_path = vagrant_path.clone();
     profile_path.push("stratagem-server.profile");
 

--- a/iml-system-test-utils/src/lib.rs
+++ b/iml-system-test-utils/src/lib.rs
@@ -7,7 +7,7 @@ use futures::future::try_join_all;
 use iml_cmd::CheckedCommandExt;
 use iml_wire_types::Branding;
 use ssh::create_iml_diagnostics;
-use std::{collections::HashMap, env, str, time::Duration};
+use std::{collections::HashMap, env, path::PathBuf, str, time::Duration};
 use tokio::{
     fs::{canonicalize, File},
     io::AsyncWriteExt,
@@ -90,6 +90,28 @@ pub const STRATAGEM_CLIENT_PROFILE: &str = r#"{
     "corosync2": false,
     "pacemaker": false,
     "ui_description": "A client that can receive stratagem data",
+    "packages": [
+      "python2-iml-agent-management",
+      "lustre-client"
+    ],
+    "repolist": [
+      "base",
+      "lustre-client"
+    ]
+  }
+  "#;
+
+pub const BASE_CLIENT_PROFILE: &str = r#"{
+    "ui_name": "Client Node",
+    "managed": false,
+    "worker": false,
+    "name": "base_client",
+    "initial_state": "monitored",
+    "ntp": false,
+    "corosync": false,
+    "corosync2": false,
+    "pacemaker": false,
+    "ui_description": "A Lustre client",
     "packages": [
       "python2-iml-agent-management",
       "lustre-client"
@@ -666,6 +688,35 @@ pub async fn detect_fs(config: Config) -> Result<Config, TestError> {
     }
 }
 
+async fn configure_extra_profile(vagrant_path: &PathBuf) -> Result<Vec<PathBuf>, TestError> {
+    let mut rc = vec![];
+    // Register Stratage Server Profile
+    let mut profile_path = vagrant_path.clone();
+    profile_path.push("stratagem-server.profile");
+
+    let mut file = File::create(&profile_path).await?;
+    file.write_all(STRATAGEM_SERVER_PROFILE.as_bytes()).await?;
+    rc.push(profile_path);
+
+    // Register Stratagem Client Profile
+    let mut profile_path = vagrant_path.clone();
+    profile_path.push("stratagem-client.profile");
+
+    let mut file = File::create(&profile_path).await?;
+    file.write_all(STRATAGEM_CLIENT_PROFILE.as_bytes()).await?;
+    rc.push(profile_path);
+
+    // Register Base Client Profile
+    let mut profile_path = vagrant_path.clone();
+    profile_path.push("base-client.profile");
+
+    let mut file = File::create(&profile_path).await?;
+    file.write_all(BASE_CLIENT_PROFILE.as_bytes()).await?;
+    rc.push(profile_path);
+
+    Ok(rc)
+}
+
 pub async fn configure_rpm_setup(config: &Config) -> Result<(), TestError> {
     let config_content: String = config.get_setup_config();
 
@@ -676,29 +727,17 @@ pub async fn configure_rpm_setup(config: &Config) -> Result<(), TestError> {
     let mut file = File::create(config_path).await?;
     file.write_all(config_content.as_bytes()).await?;
 
-    let mut vm_cmd: String =
-        "mkdir -p /var/lib/chroma && sudo cp /vagrant/overrides.conf /var/lib/chroma".into();
-    if config.use_stratagem {
-        let mut server_profile_path = vagrant_path.clone();
-        server_profile_path.push("stratagem-server.profile");
+    let path_list = configure_extra_profile(&vagrant_path).await?;
 
-        let mut file = File::create(server_profile_path).await?;
-        file.write_all(STRATAGEM_SERVER_PROFILE.as_bytes()).await?;
-
-        let mut client_profile_path = vagrant_path.clone();
-        client_profile_path.push("stratagem-client.profile");
-
-        let mut file = File::create(client_profile_path).await?;
-        file.write_all(STRATAGEM_CLIENT_PROFILE.as_bytes()).await?;
-
-        vm_cmd = format!(
-            "{}{}",
-            vm_cmd,
-            "&& sudo chroma-config profile register /vagrant/stratagem-server.profile \
-        && sudo chroma-config profile register /vagrant/stratagem-client.profile \
-        && sudo systemctl restart iml-manager.target"
-        );
-    }
+    let vm_cmd = format!(
+        "mkdir -p /var/lib/chroma && sudo cp /vagrant/overrides.conf /var/lib/chroma {} \
+         && sudo systemctl restart iml-manager.target",
+        path_list
+            .into_iter()
+            .map(|p| format!(" && sudo chroma-config profile register {}", p.display()))
+            .collect::<Vec<String>>()
+            .concat()
+    );
 
     vagrant::rsync(config.manager).await?;
 
@@ -720,29 +759,16 @@ pub async fn configure_docker_setup(config: &Config) -> Result<(), TestError> {
     let mut file = File::create(config_path).await?;
     file.write_all(config_content.as_bytes()).await?;
 
-    let mut vm_cmd: String =
-        "sudo mkdir -p /etc/iml-docker/setup && sudo cp /vagrant/config /etc/iml-docker/setup/"
-            .into();
-    if config.use_stratagem {
-        let mut server_profile_path = vagrant_path.clone();
-        server_profile_path.push("stratagem-server.profile");
+    let path_list = configure_extra_profile(&vagrant_path).await?;
 
-        let mut file = File::create(server_profile_path).await?;
-        file.write_all(STRATAGEM_SERVER_PROFILE.as_bytes()).await?;
-
-        let mut client_profile_path = vagrant_path.clone();
-        client_profile_path.push("stratagem-client.profile");
-
-        let mut file = File::create(client_profile_path).await?;
-        file.write_all(STRATAGEM_CLIENT_PROFILE.as_bytes()).await?;
-
-        vm_cmd = format!(
-            "{}{}",
-            vm_cmd,
-            "&& sudo cp /vagrant/stratagem-server.profile /etc/iml-docker/setup/ \
-             && sudo cp /vagrant/stratagem-client.profile /etc/iml-docker/setup/"
-        );
-    }
+    let vm_cmd = format!(
+        "sudo mkdir -p /etc/iml-docker/setup && sudo cp /vagrant/config /etc/iml-docker/setup/ {}",
+        path_list
+            .into_iter()
+            .map(|p| format!(" && sudo cp {} /etc/iml-docker/setup/", p.display()))
+            .collect::<Vec<String>>()
+            .concat()
+    );
 
     vagrant::rsync(config.manager).await?;
 


### PR DESCRIPTION
Without profiles for clients, they nothing is installed, and no
Bare snapshot is taken of them.  Any subsequent test that requires
a Bare snapshot will be without clients.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2111)
<!-- Reviewable:end -->
