### PR TITLE
Rename client nodes to non hexadecimal characters

### DIFF
--- a/iml-system-test-utils/src/lib.rs
+++ b/iml-system-test-utils/src/lib.rs
@@ -194,7 +194,7 @@ impl Default for Config {
             mds_ips: vec!["10.73.10.11", "10.73.10.12"],
             oss: vec!["oss1", "oss2"],
             oss_ips: vec!["10.73.10.21", "10.73.10.22"],
-            client: vec!["c1"],
+            client: vec!["client1"],
             client_ips: vec!["10.73.10.31"],
             iscsi: "iscsi",
             lustre_version: "2.12.4",
@@ -204,7 +204,7 @@ impl Default for Config {
                 ("mds2", "10.73.10.12"),
                 ("oss1", "10.73.10.21"),
                 ("oss2", "10.73.10.22"),
-                ("c1", "10.73.10.31"),
+                ("client1", "10.73.10.31"),
             ]
             .into_iter()
             .collect::<HashMap<&'static str, &'static str>>(),
@@ -775,6 +775,6 @@ mod tests {
 
         let servers = xs.to_server_list();
 
-        assert_eq!(servers, vec!["mds1", "mds2", "oss1", "oss2", "c1"]);
+        assert_eq!(servers, vec!["mds1", "mds2", "oss1", "oss2", "client1"]);
     }
 }

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -65,7 +65,7 @@ Vagrant.configure('2') do |config|
 #{MGMT_NET_PFX}.22 oss2.local oss2
     __EOF
     (1..8).each do |cidx|
-      f.puts "#{MGMT_NET_PFX}.3#{cidx} c#{cidx}.local c#{cidx}\n"
+      f.puts "#{MGMT_NET_PFX}.3#{cidx} client#{cidx}.local client#{cidx}\n"
     end
   end
 
@@ -829,9 +829,9 @@ Vagrant.configure('2') do |config|
   # By default, only 2 compute nodes are created.
   # The configuration supports a maximum of 8 compute nodes.
   (1..8).each do |i|
-    config.vm.define "c#{i}",
+    config.vm.define "client#{i}",
                      autostart: i <= 2 do |c|
-      c.vm.hostname = "c#{i}.local"
+      c.vm.hostname = "client#{i}.local"
 
       # Admin / management network
       provision_mgmt_net c, "3#{i}"

--- a/vagrant/scripts/install_iml_docker_local.sh
+++ b/vagrant/scripts/install_iml_docker_local.sh
@@ -29,7 +29,7 @@ services:
       - "mds2.local:10.73.10.12"
       - "oss1.local:10.73.10.21"
       - "oss2.local:10.73.10.22"
-      - "c1.local:10.73.10.31"
+      - "client1.local:10.73.10.31"
     environment:
       - "NTP_SERVER_HOSTNAME=10.73.10.1"
   iml-warp-drive:

--- a/vagrant/scripts/install_iml_docker_repouri.sh
+++ b/vagrant/scripts/install_iml_docker_repouri.sh
@@ -43,7 +43,7 @@ services:
       - "mds2.local:10.73.10.12"
       - "oss1.local:10.73.10.21"
       - "oss2.local:10.73.10.22"
-      - "c1.local:10.73.10.31"
+      - "client1.local:10.73.10.31"
     environment:
       - "NTP_SERVER_HOSTNAME=10.73.10.1"
   iml-warp-drive:


### PR DESCRIPTION
Due to an interesting bug in Vagrant, nodes that have a hexadecimal only
name have the chance to collide with an existing vm index name.

When this occurs, Vagrant confuses VMs with each other.

Rename `c[1-8]` nodes to `client[1-8]` to avoid this bug.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2113)
<!-- Reviewable:end -->
