### PR TITLE
Split FilesystemDetect state into 3

### DIFF
--- a/iml-system-test-utils/src/snapshots.rs
+++ b/iml-system-test-utils/src/snapshots.rs
@@ -62,7 +62,9 @@ pub enum SnapshotName {
     LdiskfsCreated,
     ZfsCreated,
     StratagemCreated,
-    FilesystemDetected,
+    LdiskfsDetected,
+    ZfsDetected,
+    StratagemDetected,
 }
 
 impl SnapshotName {
@@ -80,7 +82,9 @@ impl SnapshotName {
             Self::LdiskfsCreated => 9,
             Self::ZfsCreated => 10,
             Self::StratagemCreated => 11,
-            Self::FilesystemDetected => 12,
+            Self::LdiskfsDetected => 12,
+            Self::ZfsDetected => 13,
+            Self::StratagemDetected => 14,
         }
     }
 }
@@ -106,7 +110,9 @@ impl From<&String> for SnapshotName {
             "ldiskfs-created" => Self::LdiskfsCreated,
             "zfs-created" => Self::ZfsCreated,
             "stratagem-created" => Self::StratagemCreated,
-            "filesystem-detected" => Self::FilesystemDetected,
+            "ldiskfs-detected" => Self::LdiskfsDetected,
+            "zfs-detected" => Self::ZfsDetected,
+            "stratagem-detected" => Self::StratagemDetected,
             _ => Self::Bare,
         }
     }
@@ -127,7 +133,9 @@ impl fmt::Display for SnapshotName {
             Self::LdiskfsCreated => write!(f, "ldiskfs-created"),
             Self::ZfsCreated => write!(f, "zfs-created"),
             Self::StratagemCreated => write!(f, "stratagem-created"),
-            Self::FilesystemDetected => write!(f, "filesystem-detected"),
+            Self::LdiskfsDetected => write!(f, "ldiskfs-detected"),
+            Self::ZfsDetected => write!(f, "zfs-detected"),
+            Self::StratagemDetected => write!(f, "stratagem-detected"),
         }
     }
 }
@@ -230,9 +238,17 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
         name: SnapshotName::StratagemCreated,
         available: snapshots.contains(&SnapshotName::StratagemCreated),
     });
-    let filesystem_detected = graph.add_node(Snapshot {
-        name: SnapshotName::FilesystemDetected,
-        available: snapshots.contains(&SnapshotName::FilesystemDetected),
+    let ldiskfs_detected = graph.add_node(Snapshot {
+        name: SnapshotName::LdiskfsDetected,
+        available: snapshots.contains(&SnapshotName::LdiskfsDetected),
+    });
+    let zfs_detected = graph.add_node(Snapshot {
+        name: SnapshotName::ZfsDetected,
+        available: snapshots.contains(&SnapshotName::ZfsDetected),
+    });
+    let stratagem_detected = graph.add_node(Snapshot {
+        name: SnapshotName::StratagemDetected,
+        available: snapshots.contains(&SnapshotName::StratagemDetected),
     });
 
     graph.add_edge(
@@ -336,7 +352,7 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
 
     graph.add_edge(
         ldiskfs_created,
-        filesystem_detected,
+        ldiskfs_detected,
         Transition {
             path: SnapshotPath::Ldiskfs,
             transition: mk_transition(detect_fs),
@@ -345,7 +361,7 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
 
     graph.add_edge(
         zfs_created,
-        filesystem_detected,
+        zfs_detected,
         Transition {
             path: SnapshotPath::Zfs,
             transition: mk_transition(detect_fs),
@@ -354,7 +370,7 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
 
     graph.add_edge(
         stratagem_created,
-        filesystem_detected,
+        stratagem_detected,
         Transition {
             path: SnapshotPath::Stratagem,
             transition: mk_transition(detect_fs),

--- a/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_ldiskfs_test_path_from_graph.snap
+++ b/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_ldiskfs_test_path_from_graph.snap
@@ -7,5 +7,5 @@ edge: LdiskfsOrZfs has nodes (Snapshot { name: Bare, available: false }, Snapsho
 edge: LdiskfsOrZfs has nodes (Snapshot { name: ImlConfigured, available: false }, Snapshot { name: ServersDeployed, available: false })
 edge: Ldiskfs has nodes (Snapshot { name: ServersDeployed, available: false }, Snapshot { name: LdiskfsInstalled, available: false })
 edge: Ldiskfs has nodes (Snapshot { name: LdiskfsInstalled, available: false }, Snapshot { name: LdiskfsCreated, available: false })
-edge: Ldiskfs has nodes (Snapshot { name: LdiskfsCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
+edge: Ldiskfs has nodes (Snapshot { name: LdiskfsCreated, available: false }, Snapshot { name: LdiskfsDetected, available: false })
 

--- a/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_stratagem_test_path_from_graph.snap
+++ b/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_stratagem_test_path_from_graph.snap
@@ -7,5 +7,5 @@ edge: Stratagem has nodes (Snapshot { name: Bare, available: false }, Snapshot {
 edge: Stratagem has nodes (Snapshot { name: ImlStratagemConfigured, available: false }, Snapshot { name: StratagemServersDeployed, available: false })
 edge: Stratagem has nodes (Snapshot { name: StratagemServersDeployed, available: false }, Snapshot { name: StratagemInstalled, available: false })
 edge: Stratagem has nodes (Snapshot { name: StratagemInstalled, available: false }, Snapshot { name: StratagemCreated, available: false })
-edge: Stratagem has nodes (Snapshot { name: StratagemCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
+edge: Stratagem has nodes (Snapshot { name: StratagemCreated, available: false }, Snapshot { name: StratagemDetected, available: false })
 

--- a/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_zfs_test_path_from_graph.snap
+++ b/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_zfs_test_path_from_graph.snap
@@ -7,5 +7,5 @@ edge: LdiskfsOrZfs has nodes (Snapshot { name: Bare, available: false }, Snapsho
 edge: LdiskfsOrZfs has nodes (Snapshot { name: ImlConfigured, available: false }, Snapshot { name: ServersDeployed, available: false })
 edge: Zfs has nodes (Snapshot { name: ServersDeployed, available: false }, Snapshot { name: ZfsInstalled, available: false })
 edge: Zfs has nodes (Snapshot { name: ZfsInstalled, available: false }, Snapshot { name: ZfsCreated, available: false })
-edge: Zfs has nodes (Snapshot { name: ZfsCreated, available: false }, Snapshot { name: FilesystemDetected, available: false })
+edge: Zfs has nodes (Snapshot { name: ZfsCreated, available: false }, Snapshot { name: ZfsDetected, available: false })
 


### PR DESCRIPTION
Split FilesystemDetect state as shown:

![graph](https://user-images.githubusercontent.com/2285913/88955978-af70e800-d26a-11ea-8810-d91be4e388c3.png)

Needed for Issue #1832 

Fixes #2117

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2118)
<!-- Reviewable:end -->
