### PR TITLE
Use a single lustre install step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,18 @@ local:
 check:
 	black --check ./
 	cargo fmt --all -- --check
-	PQ_LIB_DIR=/usr/pgsql-9.6/lib cargo check
+	PQ_LIB_DIR=/usr/pgsql-9.6/lib cargo check --locked --all-targets
 	PQ_LIB_DIR=/usr/pgsql-9.6/lib cargo clippy -- -W warnings
+	cargo check --locked --manifest-path iml-system-rpm-tests/Cargo.toml --tests
+	cargo clippy --manifest-path iml-system-rpm-tests/Cargo.toml --tests -- -W warnings
+	cargo check --locked --manifest-path iml-system-docker-tests/Cargo.toml --tests
+	cargo clippy --manifest-path iml-system-docker-tests/Cargo.toml --tests -- -W warnings
 
 fmt:
 	black ./
 	cargo fmt --all
+	cargo fmt --all --manifest-path iml-system-rpm-tests/Cargo.toml
+	cargo fmt --all --manifest-path iml-system-docker-tests/Cargo.toml
 
 iml-gui-rpm:
 	$(MAKE) -f .copr/Makefile iml-gui-srpm outdir=.

--- a/iml-system-docker-tests/Cargo.lock
+++ b/iml-system-docker-tests/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,18 +70,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
-dependencies = [
- "loom",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cfg-if"
@@ -89,10 +86,12 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -213,19 +212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,10 +223,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "im"
-version = "14.3.0"
+name = "hashbrown"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696059c87b83c5a258817ecd67c3af915e3ed141891fc35a1e79908801cf0ce7"
+checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "im"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
 dependencies = [
  "bitmaps",
  "rand_core",
@@ -315,6 +319,7 @@ dependencies = [
  "iml-systemd",
  "iml-wire-types",
  "petgraph",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
@@ -337,6 +342,7 @@ dependencies = [
 name = "iml-wire-types"
 version = "0.3.0"
 dependencies = [
+ "chrono",
  "im",
  "iml-api-utils",
  "iml-orm",
@@ -347,11 +353,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
+checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
 dependencies = [
  "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -379,6 +386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
+name = "js-sys"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,28 +412,17 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.72"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
+checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
 ]
 
 [[package]]
@@ -530,6 +535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,18 +562,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
+checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
+checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -585,9 +600,9 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro-nested"
@@ -597,9 +612,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
 ]
@@ -665,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
@@ -707,40 +722,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -764,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
@@ -805,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "sized-chunks"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59044ea371ad781ff976f7b06480b9f0180e834eda94114f2afb4afc12b7718"
+checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
 dependencies = [
  "bitmaps",
  "typenum",
@@ -839,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -903,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
+checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
  "bytes",
  "futures-core",
@@ -916,6 +901,7 @@ dependencies = [
  "mio",
  "mio-named-pipes",
  "mio-uds",
+ "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -950,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
+checksum = "dbdf4ccd1652592b01286a5dbe1e2a77d78afaa34beadd9872a5f7396f92aaa9"
 dependencies = [
  "cfg-if",
  "tracing-attributes",
@@ -1002,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72c8cf3ec4ed69fef614d011a5ae4274537a8a8c59133558029bd731eb71659"
+checksum = "e4f5dd7095c2481b7b3cbed71c8de53085fb3542bc3c2b4c73cba43e8f11c7ba"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -1043,6 +1029,60 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 
 [[package]]
 name = "winapi"

--- a/iml-system-rpm-tests/Cargo.lock
+++ b/iml-system-rpm-tests/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,10 +95,12 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -237,10 +245,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "im"
-version = "14.3.0"
+name = "hermit-abi"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696059c87b83c5a258817ecd67c3af915e3ed141891fc35a1e79908801cf0ce7"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "im"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
 dependencies = [
  "bitmaps",
  "rand_core",
@@ -313,6 +330,7 @@ dependencies = [
  "iml-systemd",
  "iml-wire-types",
  "petgraph",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
@@ -335,6 +353,7 @@ dependencies = [
 name = "iml-wire-types"
 version = "0.3.0"
 dependencies = [
+ "chrono",
  "im",
  "iml-api-utils",
  "iml-orm",
@@ -375,6 +394,15 @@ name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+
+[[package]]
+name = "js-sys"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -525,6 +553,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -803,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "sized-chunks"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59044ea371ad781ff976f7b06480b9f0180e834eda94114f2afb4afc12b7718"
+checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
 dependencies = [
  "bitmaps",
  "typenum",
@@ -914,6 +952,7 @@ dependencies = [
  "mio",
  "mio-named-pipes",
  "mio-uds",
+ "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -1041,6 +1080,60 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 
 [[package]]
 name = "winapi"

--- a/iml-system-test-utils/README.md
+++ b/iml-system-test-utils/README.md
@@ -1,4 +1,4 @@
-## Integration Testing Overview
+# Integration Testing Overview
 
 The system level tests are broken up into two types:
 
@@ -73,7 +73,6 @@ The edges of the graph hold the functionality to transition from one state to an
 
 A unit test is provided in *snapshots.rs* that will generate *dot* output of the graph. This dot output can then be piped into graphviz where an image of the graph will be generated. Use the following command to run the test and get the dot output:
 
-```bash
+```sh
 cargo test test_generate_graph_dot_file -- --nocapture
 ```
-

--- a/iml-system-test-utils/src/snapshots.rs
+++ b/iml-system-test-utils/src/snapshots.rs
@@ -6,7 +6,7 @@ use petgraph::{
     visit::EdgeFiltered,
     Direction,
 };
-use std::{cmp::Ordering, collections::HashMap, fmt, pin::Pin, process::Output, str};
+use std::{collections::HashMap, fmt, pin::Pin, process::Output, str};
 
 type SnapshotMap = HashMap<String, Vec<SnapshotName>>;
 
@@ -48,17 +48,16 @@ impl<'a> fmt::Debug for Transition {
     }
 }
 
-#[derive(Eq, PartialEq, PartialOrd, Debug)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Copy, Clone)]
+#[repr(usize)]
 pub enum SnapshotName {
     Init,
     Bare,
+    LustreRpmsInstalled,
     ImlConfigured,
     ImlStratagemConfigured,
     ServersDeployed,
     StratagemServersDeployed,
-    LdiskfsInstalled,
-    ZfsInstalled,
-    StratagemInstalled,
     LdiskfsCreated,
     ZfsCreated,
     StratagemCreated,
@@ -67,46 +66,16 @@ pub enum SnapshotName {
     StratagemDetected,
 }
 
-impl SnapshotName {
-    pub fn ordinal(&self) -> usize {
-        match &*self {
-            Self::Init => 0,
-            Self::Bare => 1,
-            Self::ImlConfigured => 2,
-            Self::ImlStratagemConfigured => 3,
-            Self::ServersDeployed => 4,
-            Self::StratagemServersDeployed => 5,
-            Self::LdiskfsInstalled => 6,
-            Self::ZfsInstalled => 7,
-            Self::StratagemInstalled => 8,
-            Self::LdiskfsCreated => 9,
-            Self::ZfsCreated => 10,
-            Self::StratagemCreated => 11,
-            Self::LdiskfsDetected => 12,
-            Self::ZfsDetected => 13,
-            Self::StratagemDetected => 14,
-        }
-    }
-}
-
-impl Ord for SnapshotName {
-    fn cmp(&self, other: &SnapshotName) -> Ordering {
-        self.ordinal().cmp(&other.ordinal())
-    }
-}
-
 impl From<&String> for SnapshotName {
     fn from(s: &String) -> Self {
         match s.to_lowercase().as_str() {
             "init" => Self::Init,
             "bare" => Self::Bare,
+            "lustre-rpms-installed" => Self::LustreRpmsInstalled,
             "iml-configured" => Self::ImlConfigured,
             "iml-stratagem-configured" => Self::ImlStratagemConfigured,
             "servers-deployed" => Self::ServersDeployed,
             "stratagem-servers-deployed" => Self::StratagemServersDeployed,
-            "ldiskfs-installed" => Self::LdiskfsInstalled,
-            "zfs-installed" => Self::ZfsInstalled,
-            "stratagem-installed" => Self::StratagemInstalled,
             "ldiskfs-created" => Self::LdiskfsCreated,
             "zfs-created" => Self::ZfsCreated,
             "stratagem-created" => Self::StratagemCreated,
@@ -123,13 +92,11 @@ impl fmt::Display for SnapshotName {
         match self {
             Self::Init => write!(f, "init"),
             Self::Bare => write!(f, "bare"),
+            Self::LustreRpmsInstalled => write!(f, "lustre-rpms-installed"),
             Self::ImlConfigured => write!(f, "iml-configured"),
             Self::ImlStratagemConfigured => write!(f, "iml-stratagem-configured"),
             Self::ServersDeployed => write!(f, "servers-deployed"),
             Self::StratagemServersDeployed => write!(f, "stratagem-servers-deployed"),
-            Self::LdiskfsInstalled => write!(f, "ldiskfs-installed"),
-            Self::ZfsInstalled => write!(f, "zfs-installed"),
-            Self::StratagemInstalled => write!(f, "stratagem-installed"),
             Self::LdiskfsCreated => write!(f, "ldiskfs-created"),
             Self::ZfsCreated => write!(f, "zfs-created"),
             Self::StratagemCreated => write!(f, "stratagem-created"),
@@ -143,6 +110,7 @@ impl fmt::Display for SnapshotName {
 pub fn get_snapshot_name_for_state(config: &Config, state: TestState) -> snapshots::SnapshotName {
     match state {
         TestState::Bare => SnapshotName::Bare,
+        TestState::LustreRpmsInstalled => SnapshotName::LustreRpmsInstalled,
         TestState::Configured => {
             if config.use_stratagem {
                 SnapshotName::ImlStratagemConfigured
@@ -155,16 +123,6 @@ pub fn get_snapshot_name_for_state(config: &Config, state: TestState) -> snapsho
                 SnapshotName::StratagemServersDeployed
             } else {
                 SnapshotName::ServersDeployed
-            }
-        }
-        TestState::FsInstalled => {
-            if config.use_stratagem {
-                SnapshotName::StratagemInstalled
-            } else {
-                match config.fs_type {
-                    FsType::LDISKFS => SnapshotName::LdiskfsInstalled,
-                    FsType::ZFS => SnapshotName::ZfsInstalled,
-                }
             }
         }
         TestState::FsCreated => {
@@ -198,6 +156,10 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
         name: SnapshotName::Bare,
         available: snapshots.contains(&SnapshotName::Bare),
     });
+    let lustre_rpms_installed = graph.add_node(Snapshot {
+        name: SnapshotName::LustreRpmsInstalled,
+        available: snapshots.contains(&SnapshotName::LustreRpmsInstalled),
+    });
     let iml_configured = graph.add_node(Snapshot {
         name: SnapshotName::ImlConfigured,
         available: snapshots.contains(&SnapshotName::ImlConfigured),
@@ -213,18 +175,6 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
     let stratagem_servers_deployed = graph.add_node(Snapshot {
         name: SnapshotName::StratagemServersDeployed,
         available: snapshots.contains(&SnapshotName::StratagemServersDeployed),
-    });
-    let ldiskfs_installed = graph.add_node(Snapshot {
-        name: SnapshotName::LdiskfsInstalled,
-        available: snapshots.contains(&SnapshotName::LdiskfsInstalled),
-    });
-    let zfs_installed = graph.add_node(Snapshot {
-        name: SnapshotName::ZfsInstalled,
-        available: snapshots.contains(&SnapshotName::ZfsInstalled),
-    });
-    let stratagem_installed = graph.add_node(Snapshot {
-        name: SnapshotName::StratagemInstalled,
-        available: snapshots.contains(&SnapshotName::StratagemInstalled),
     });
     let ldiskfs_created = graph.add_node(Snapshot {
         name: SnapshotName::LdiskfsCreated,
@@ -262,6 +212,15 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
 
     graph.add_edge(
         bare,
+        lustre_rpms_installed,
+        Transition {
+            path: SnapshotPath::All,
+            transition: mk_transition(install_fs),
+        },
+    );
+
+    graph.add_edge(
+        lustre_rpms_installed,
         iml_configured,
         Transition {
             path: SnapshotPath::LdiskfsOrZfs,
@@ -270,7 +229,7 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
     );
 
     graph.add_edge(
-        bare,
+        lustre_rpms_installed,
         iml_stratagem_configured,
         Transition {
             path: SnapshotPath::Stratagem,
@@ -298,33 +257,6 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
 
     graph.add_edge(
         servers_deployed,
-        ldiskfs_installed,
-        Transition {
-            path: SnapshotPath::Ldiskfs,
-            transition: mk_transition(install_fs),
-        },
-    );
-
-    graph.add_edge(
-        servers_deployed,
-        zfs_installed,
-        Transition {
-            path: SnapshotPath::Zfs,
-            transition: mk_transition(install_fs),
-        },
-    );
-
-    graph.add_edge(
-        stratagem_servers_deployed,
-        stratagem_installed,
-        Transition {
-            path: SnapshotPath::Stratagem,
-            transition: mk_transition(install_fs),
-        },
-    );
-
-    graph.add_edge(
-        ldiskfs_installed,
         ldiskfs_created,
         Transition {
             path: SnapshotPath::Ldiskfs,
@@ -333,7 +265,7 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
     );
 
     graph.add_edge(
-        zfs_installed,
+        servers_deployed,
         zfs_created,
         Transition {
             path: SnapshotPath::Zfs,
@@ -342,7 +274,7 @@ pub fn create_graph(snapshots: &[SnapshotName]) -> DiGraph<Snapshot, Transition>
     );
 
     graph.add_edge(
-        stratagem_installed,
+        stratagem_servers_deployed,
         stratagem_created,
         Transition {
             path: SnapshotPath::Stratagem,
@@ -558,35 +490,29 @@ mod tests {
             stderr: vec![],
             stdout: r#"==> iscsi: 
 bare
+lustre-rpms-installed
 servers-deployed
 iml-configured
 stratagem-created
 iml-stratagem-configured
-ldiskfs-installed
-stratagem-installed
 ldiskfs-created
 stratagem-servers-deployed
-zfs-installed
 zfs-created
 ==> adm: VM not created. Moving on...
 ==> mds1: 
 bare
+lustre-rpms-installed
 zfs-created
-stratagem-installed
 stratagem-created
-ldiskfs-installed
 stratagem-servers-deployed
-zfs-installed
 servers-deployed
 ldiskfs-created
 iml-stratagem-configured
 iml-configured
 ==> mds2: 
 stratagem-created
-ldiskfs-installed
-zfs-installed
 ldiskfs-created
-stratagem-installed
+lustre-rpms-installed
 stratagem-servers-deployed
 iml-stratagem-configured
 bare
@@ -595,27 +521,23 @@ iml-configured
 servers-deployed
 ==> oss1: 
 bare
+lustre-rpms-installed
 stratagem-created
 iml-stratagem-configured
-zfs-installed
 ldiskfs-created
 servers-deployed
-ldiskfs-installed
 iml-configured
 zfs-created
-stratagem-installed
 stratagem-servers-deployed
 ==> oss2: 
 iml-configured
 bare
+lustre-rpms-installed
 ldiskfs-created
 stratagem-servers-deployed
-zfs-installed
 stratagem-created
-ldiskfs-installed
 zfs-created
 servers-deployed
-stratagem-installed
 iml-stratagem-configured
 ==> c2: VM not created. Moving on...
 ==> c3: VM not created. Moving on...
@@ -648,13 +570,11 @@ iml-stratagem-configured
     fn get_full_graph() -> DiGraph<Snapshot, Transition> {
         create_graph(&vec![
             SnapshotName::Bare,
+            SnapshotName::LustreRpmsInstalled,
             SnapshotName::ImlConfigured,
             SnapshotName::ImlStratagemConfigured,
             SnapshotName::ServersDeployed,
             SnapshotName::StratagemServersDeployed,
-            SnapshotName::LdiskfsInstalled,
-            SnapshotName::ZfsInstalled,
-            SnapshotName::StratagemInstalled,
             SnapshotName::LdiskfsCreated,
             SnapshotName::ZfsCreated,
             SnapshotName::StratagemCreated,
@@ -671,13 +591,11 @@ iml-stratagem-configured
                     "iscsi".into(),
                     vec![
                         SnapshotName::Bare,
+                        SnapshotName::LustreRpmsInstalled,
                         SnapshotName::ImlConfigured,
                         SnapshotName::ImlStratagemConfigured,
                         SnapshotName::ServersDeployed,
                         SnapshotName::StratagemServersDeployed,
-                        SnapshotName::LdiskfsInstalled,
-                        SnapshotName::ZfsInstalled,
-                        SnapshotName::StratagemInstalled,
                         SnapshotName::LdiskfsCreated,
                         SnapshotName::ZfsCreated,
                         SnapshotName::StratagemCreated,
@@ -687,13 +605,11 @@ iml-stratagem-configured
                     "mds1".into(),
                     vec![
                         SnapshotName::Bare,
+                        SnapshotName::LustreRpmsInstalled,
                         SnapshotName::ImlConfigured,
                         SnapshotName::ImlStratagemConfigured,
                         SnapshotName::ServersDeployed,
                         SnapshotName::StratagemServersDeployed,
-                        SnapshotName::LdiskfsInstalled,
-                        SnapshotName::ZfsInstalled,
-                        SnapshotName::StratagemInstalled,
                         SnapshotName::LdiskfsCreated,
                         SnapshotName::ZfsCreated,
                         SnapshotName::StratagemCreated,
@@ -703,13 +619,11 @@ iml-stratagem-configured
                     "mds2".into(),
                     vec![
                         SnapshotName::Bare,
+                        SnapshotName::LustreRpmsInstalled,
                         SnapshotName::ImlConfigured,
                         SnapshotName::ImlStratagemConfigured,
                         SnapshotName::ServersDeployed,
                         SnapshotName::StratagemServersDeployed,
-                        SnapshotName::LdiskfsInstalled,
-                        SnapshotName::ZfsInstalled,
-                        SnapshotName::StratagemInstalled,
                         SnapshotName::LdiskfsCreated,
                         SnapshotName::ZfsCreated,
                         SnapshotName::StratagemCreated,
@@ -719,13 +633,11 @@ iml-stratagem-configured
                     "oss1".into(),
                     vec![
                         SnapshotName::Bare,
+                        SnapshotName::LustreRpmsInstalled,
                         SnapshotName::ImlConfigured,
                         SnapshotName::ImlStratagemConfigured,
                         SnapshotName::ServersDeployed,
                         SnapshotName::StratagemServersDeployed,
-                        SnapshotName::LdiskfsInstalled,
-                        SnapshotName::ZfsInstalled,
-                        SnapshotName::StratagemInstalled,
                         SnapshotName::LdiskfsCreated,
                         SnapshotName::ZfsCreated,
                         SnapshotName::StratagemCreated,
@@ -735,13 +647,11 @@ iml-stratagem-configured
                     "oss2".into(),
                     vec![
                         SnapshotName::Bare,
+                        SnapshotName::LustreRpmsInstalled,
                         SnapshotName::ImlConfigured,
                         SnapshotName::ImlStratagemConfigured,
                         SnapshotName::ServersDeployed,
                         SnapshotName::StratagemServersDeployed,
-                        SnapshotName::LdiskfsInstalled,
-                        SnapshotName::ZfsInstalled,
-                        SnapshotName::StratagemInstalled,
                         SnapshotName::LdiskfsCreated,
                         SnapshotName::ZfsCreated,
                         SnapshotName::StratagemCreated,
@@ -767,9 +677,9 @@ iml-stratagem-configured
             vec![
                 &SnapshotName::Init,
                 &SnapshotName::Bare,
+                &SnapshotName::LustreRpmsInstalled,
                 &SnapshotName::ImlConfigured,
                 &SnapshotName::ServersDeployed,
-                &SnapshotName::LdiskfsInstalled,
                 &SnapshotName::LdiskfsCreated,
             ],
             snapshots
@@ -789,9 +699,9 @@ iml-stratagem-configured
             vec![
                 &SnapshotName::Init,
                 &SnapshotName::Bare,
+                &SnapshotName::LustreRpmsInstalled,
                 &SnapshotName::ImlConfigured,
                 &SnapshotName::ServersDeployed,
-                &SnapshotName::ZfsInstalled,
                 &SnapshotName::ZfsCreated,
             ],
             snapshots
@@ -811,9 +721,9 @@ iml-stratagem-configured
             vec![
                 &SnapshotName::Init,
                 &SnapshotName::Bare,
+                &SnapshotName::LustreRpmsInstalled,
                 &SnapshotName::ImlStratagemConfigured,
                 &SnapshotName::StratagemServersDeployed,
-                &SnapshotName::StratagemInstalled,
                 &SnapshotName::StratagemCreated,
             ],
             snapshots

--- a/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_ldiskfs_test_path_from_graph.snap
+++ b/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_ldiskfs_test_path_from_graph.snap
@@ -3,9 +3,9 @@ source: iml-system-test-utils/src/snapshots.rs
 expression: "print_edges(&graph, &edges)"
 ---
 edge: All has nodes (Snapshot { name: Init, available: true }, Snapshot { name: Bare, available: false })
-edge: LdiskfsOrZfs has nodes (Snapshot { name: Bare, available: false }, Snapshot { name: ImlConfigured, available: false })
+edge: All has nodes (Snapshot { name: Bare, available: false }, Snapshot { name: LustreRpmsInstalled, available: false })
+edge: LdiskfsOrZfs has nodes (Snapshot { name: LustreRpmsInstalled, available: false }, Snapshot { name: ImlConfigured, available: false })
 edge: LdiskfsOrZfs has nodes (Snapshot { name: ImlConfigured, available: false }, Snapshot { name: ServersDeployed, available: false })
-edge: Ldiskfs has nodes (Snapshot { name: ServersDeployed, available: false }, Snapshot { name: LdiskfsInstalled, available: false })
-edge: Ldiskfs has nodes (Snapshot { name: LdiskfsInstalled, available: false }, Snapshot { name: LdiskfsCreated, available: false })
+edge: Ldiskfs has nodes (Snapshot { name: ServersDeployed, available: false }, Snapshot { name: LdiskfsCreated, available: false })
 edge: Ldiskfs has nodes (Snapshot { name: LdiskfsCreated, available: false }, Snapshot { name: LdiskfsDetected, available: false })
 

--- a/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_stratagem_test_path_from_graph.snap
+++ b/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_stratagem_test_path_from_graph.snap
@@ -3,9 +3,9 @@ source: iml-system-test-utils/src/snapshots.rs
 expression: "print_edges(&graph, &edges)"
 ---
 edge: All has nodes (Snapshot { name: Init, available: true }, Snapshot { name: Bare, available: false })
-edge: Stratagem has nodes (Snapshot { name: Bare, available: false }, Snapshot { name: ImlStratagemConfigured, available: false })
+edge: All has nodes (Snapshot { name: Bare, available: false }, Snapshot { name: LustreRpmsInstalled, available: false })
+edge: Stratagem has nodes (Snapshot { name: LustreRpmsInstalled, available: false }, Snapshot { name: ImlStratagemConfigured, available: false })
 edge: Stratagem has nodes (Snapshot { name: ImlStratagemConfigured, available: false }, Snapshot { name: StratagemServersDeployed, available: false })
-edge: Stratagem has nodes (Snapshot { name: StratagemServersDeployed, available: false }, Snapshot { name: StratagemInstalled, available: false })
-edge: Stratagem has nodes (Snapshot { name: StratagemInstalled, available: false }, Snapshot { name: StratagemCreated, available: false })
+edge: Stratagem has nodes (Snapshot { name: StratagemServersDeployed, available: false }, Snapshot { name: StratagemCreated, available: false })
 edge: Stratagem has nodes (Snapshot { name: StratagemCreated, available: false }, Snapshot { name: StratagemDetected, available: false })
 

--- a/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_zfs_test_path_from_graph.snap
+++ b/iml-system-test-utils/src/snapshots/iml_system_test_utils__snapshots__tests__get_zfs_test_path_from_graph.snap
@@ -3,9 +3,9 @@ source: iml-system-test-utils/src/snapshots.rs
 expression: "print_edges(&graph, &edges)"
 ---
 edge: All has nodes (Snapshot { name: Init, available: true }, Snapshot { name: Bare, available: false })
-edge: LdiskfsOrZfs has nodes (Snapshot { name: Bare, available: false }, Snapshot { name: ImlConfigured, available: false })
+edge: All has nodes (Snapshot { name: Bare, available: false }, Snapshot { name: LustreRpmsInstalled, available: false })
+edge: LdiskfsOrZfs has nodes (Snapshot { name: LustreRpmsInstalled, available: false }, Snapshot { name: ImlConfigured, available: false })
 edge: LdiskfsOrZfs has nodes (Snapshot { name: ImlConfigured, available: false }, Snapshot { name: ServersDeployed, available: false })
-edge: Zfs has nodes (Snapshot { name: ServersDeployed, available: false }, Snapshot { name: ZfsInstalled, available: false })
-edge: Zfs has nodes (Snapshot { name: ZfsInstalled, available: false }, Snapshot { name: ZfsCreated, available: false })
+edge: Zfs has nodes (Snapshot { name: ServersDeployed, available: false }, Snapshot { name: ZfsCreated, available: false })
 edge: Zfs has nodes (Snapshot { name: ZfsCreated, available: false }, Snapshot { name: ZfsDetected, available: false })
 

--- a/iml-system-test-utils/src/ssh.rs
+++ b/iml-system-test-utils/src/ssh.rs
@@ -166,9 +166,16 @@ async fn ssh_script_parallel<'a, 'b>(
     Ok(output)
 }
 
-pub async fn install_ldiskfs_no_iml<'a, 'b>(
-    config: &Config,
-) -> Result<Vec<(&'a str, Output)>, TestError> {
+pub async fn install_ldiskfs_zfs_no_iml(config: &Config) -> Result<Vec<(&str, Output)>, TestError> {
+    ssh_script_parallel(
+        &config.storage_server_ips(),
+        "scripts/install_ldiskfs_zfs_no_iml.sh",
+        &[config.lustre_version()],
+    )
+    .await
+}
+
+pub async fn install_ldiskfs_no_iml(config: &Config) -> Result<Vec<(&str, Output)>, TestError> {
     ssh_script_parallel(
         &config.storage_server_ips(),
         "scripts/install_ldiskfs_no_iml.sh",
@@ -177,9 +184,7 @@ pub async fn install_ldiskfs_no_iml<'a, 'b>(
     .await
 }
 
-pub async fn install_zfs_no_iml<'a, 'b>(
-    config: &Config,
-) -> Result<Vec<(&'a str, Output)>, TestError> {
+pub async fn install_zfs_no_iml(config: &Config) -> Result<Vec<(&str, Output)>, TestError> {
     ssh_script_parallel(
         &config.storage_server_ips(),
         "scripts/install_zfs_no_iml.sh",

--- a/vagrant/scripts/install_ldiskfs_zfs_no_iml.sh
+++ b/vagrant/scripts/install_ldiskfs_zfs_no_iml.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+LUSTRE=$1
+
+yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-$LUSTRE/el7/patchless-ldiskfs-server/
+yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
+yum-config-manager --add-repo=http://download.zfsonlinux.org/epel/7.6/kmod/x86_64/
+yum install -y --nogpgcheck lustre zfs kmod-lustre-osd-ldiskfs kmod-lustre-osd-zfs
+systemctl enable --now zfs-zed


### PR DESCRIPTION
We should be able to do a single lustre install step for each monitored
test variant.

This should shave a bunch of time off test runs, as lustre will be
installed via snapshot for all branches.

Fixes #2119.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2124)
<!-- Reviewable:end -->
