### PR TITLE
Move ActionType to iml_wire_types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,6 @@ name = "iml-action-client"
 version = "0.1.0"
 dependencies = [
  "futures",
- "iml-action-runner",
  "iml-manager-env",
  "iml-wire-types",
  "reqwest",

--- a/iml-action-client/Cargo.toml
+++ b/iml-action-client/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-iml-action-runner = { path = "../iml-services/iml-action-runner", version = "0.3" }
 iml-manager-env = { path = "../iml-manager-env", version = "0.3" }
 iml-wire-types = { path = "../iml-wire-types", version = "0.3" }
 reqwest = { version = "0.10", default-features = false, features = ["rustls-tls", "json", "stream"] }

--- a/iml-action-client/src/lib.rs
+++ b/iml-action-client/src/lib.rs
@@ -7,9 +7,8 @@ use futures::{
     future::{self, Either},
     Future, FutureExt, TryFutureExt,
 };
-use iml_action_runner::ActionType;
 use iml_manager_env::get_action_runner_connect;
-use iml_wire_types::{Action, ActionId, ActionName, Fqdn};
+use iml_wire_types::{Action, ActionType, ActionId, ActionName, Fqdn};
 use thiserror::Error;
 use uuid::Uuid;
 

--- a/iml-action-client/src/lib.rs
+++ b/iml-action-client/src/lib.rs
@@ -8,7 +8,7 @@ use futures::{
     Future, FutureExt, TryFutureExt,
 };
 use iml_manager_env::get_action_runner_connect;
-use iml_wire_types::{Action, ActionType, ActionId, ActionName, Fqdn};
+use iml_wire_types::{Action, ActionId, ActionName, ActionType, Fqdn};
 use thiserror::Error;
 use uuid::Uuid;
 

--- a/iml-services/iml-action-runner/src/lib.rs
+++ b/iml-services/iml-action-runner/src/lib.rs
@@ -9,21 +9,9 @@ pub mod receiver;
 pub mod sender;
 
 use futures::{channel::oneshot, lock::Mutex};
-use iml_wire_types::{Action, Fqdn, Id};
+use iml_wire_types::{Fqdn, Id};
 use std::{collections::HashMap, sync::Arc};
 
 pub type Shared<T> = Arc<Mutex<T>>;
 pub type Sessions = HashMap<Fqdn, Id>;
 pub type Sender = oneshot::Sender<Result<serde_json::Value, String>>;
-
-/// Actions can be run either locally or remotely.
-/// Besides the node these are run on, the interface should
-/// be the same.
-///
-/// This should probably be collapsed into a single struct over an enum at some point.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum ActionType {
-    Remote((Fqdn, Action)),
-    Local(Action),
-}

--- a/iml-services/iml-action-runner/src/sender.rs
+++ b/iml-services/iml-action-runner/src/sender.rs
@@ -9,11 +9,11 @@ use crate::{
     },
     error::ActionRunnerError,
     local_actions::{handle_local_action, SharedLocalActionsInFlight},
-    ActionType, Sessions, Shared,
+    Sessions, Shared,
 };
 use futures::{channel::oneshot, TryFutureExt};
 use iml_rabbit::{send_message, Channel, Connection};
-use iml_wire_types::{Action, ActionId, Id, ManagerMessage};
+use iml_wire_types::{Action, ActionId, ActionType, Id, ManagerMessage};
 use std::{sync::Arc, time::Duration};
 use warp::{self, Filter};
 

--- a/iml-services/iml-action-runner/tests/action_runner_tests.rs
+++ b/iml-services/iml-action-runner/tests/action_runner_tests.rs
@@ -8,11 +8,11 @@ use iml_action_runner::{
     error::ActionRunnerError,
     local_actions::SharedLocalActionsInFlight,
     sender::sender,
-    ActionType, Sessions, Shared,
+    Sessions, Shared,
 };
 use iml_agent_comms::messaging::consume_agent_tx_queue;
 use iml_rabbit::ConnectionProperties;
-use iml_wire_types::{Action, ActionId, ActionName, Fqdn, Id};
+use iml_wire_types::{Action, ActionId, ActionName, ActionType, Fqdn, Id};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time::delay_for;

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -232,6 +232,18 @@ impl TryFrom<Action> for serde_json::Value {
     }
 }
 
+/// Actions can be run either locally or remotely.
+/// Besides the node these are run on, the interface should
+/// be the same.
+///
+/// This should probably be collapsed into a single struct over an enum at some point.
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ActionType {
+    Remote((Fqdn, Action)),
+    Local(Action),
+}
+
 /// The result of running the action on an agent.
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct ActionResult {


### PR DESCRIPTION

This allows to break cyclic dependency of iml-action-runner and
iml-action-client which occurs when iml-action-runner wants to call
iml-action-client::invoke_rust_agent.

Signed-off-by: Michael Pankov <work@michaelpankov.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2128)
<!-- Reviewable:end -->
