### PR TITLE
Remove ObjectCache from ClientMount

### DIFF
--- a/chroma_core/lib/cache.py
+++ b/chroma_core/lib/cache.py
@@ -139,18 +139,6 @@ class ObjectCache(object):
         cls.instance = None
 
     @classmethod
-    def host_client_mounts(cls, host_id):
-        from chroma_core.models.client_mount import LustreClientMount
-
-        return cls.get(LustreClientMount, lambda hcm: hcm.host_id == host_id)
-
-    @classmethod
-    def filesystem_client_mounts(cls, fs_name):
-        from chroma_core.models.client_mount import LustreClientMount
-
-        return cls.get(LustreClientMount, lambda lcm: lcm.filesystem == fs_name)
-
-    @classmethod
     def client_mount_copytools(cls, cm_id):
         from chroma_core.models.client_mount import LustreClientMount
         from chroma_core.models.copytool import Copytool


### PR DESCRIPTION
The `LustreClientMount` uses `ObjectCache` for many of it's lookups.

However, we do not update this `ObjectCache` when we discover changes to client mounts.

It is easier to remove this indirection and just ask the DB directly.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2133)
<!-- Reviewable:end -->
