### PR TITLE
Allow local actions to make db calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,9 +1348,11 @@ dependencies = [
 name = "iml-action-runner"
 version = "0.3.0"
 dependencies = [
+ "dotenv",
  "futures",
  "iml-agent-comms",
  "iml-manager-env",
+ "iml-postgres",
  "iml-rabbit",
  "iml-service-queue",
  "iml-tracing",
@@ -1359,6 +1361,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-runtime-shutdown",
  "tokio-test",

--- a/iml-orm/README.md
+++ b/iml-orm/README.md
@@ -1,5 +1,7 @@
 # IML ORM
 
+## Note: This crate is deprecated; use `iml_postgres` with `sqlx` instead
+
 An orm using [diesel](http://diesel.rs/).
 
 This crate makes use of a few different feature flags for portability:

--- a/iml-services/iml-action-runner/Cargo.toml
+++ b/iml-services/iml-action-runner/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.3.0"
 [dependencies]
 futures = "0.3"
 iml-manager-env = {path = "../../iml-manager-env", version = "0.3"}
+iml-postgres = {path = "../../iml-postgres", version = "0.3"}
 iml-rabbit = {path = "../../iml-rabbit", version = "0.3", features = ["warp-filters"]}
 iml-service-queue = {path = "../iml-service-queue", version = "0.3"}
 iml-tracing = {version = "0.2", path = "../../iml-tracing"}
@@ -14,12 +15,14 @@ iml-util = {path = "../../iml-util", version = "0.3"}
 iml-wire-types = {path = "../../iml-wire-types", version = "0.3"}
 serde = {version = "1", features = ["derive"]}
 serde_json = "1.0"
+thiserror = "1.0"
 tokio = {version = "0.2", features = ["rt-threaded"]}
 tokio-runtime-shutdown = {path = "../../tokio-runtime-shutdown", version = "0.3"}
 tracing = "0.1"
 warp = "0.2"
 
 [dev-dependencies]
+dotenv = "0.15"
 iml-agent-comms = {path = "../../iml-agent-comms", version = "0.3"}
 rand = "0.7"
 tokio-test = "0.2"

--- a/iml-services/iml-action-runner/src/db.rs
+++ b/iml-services/iml-action-runner/src/db.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::error::ActionRunnerError;
+use iml_postgres::sqlx;
+
+pub(crate) async fn get_host_fqdn_by_id(
+    id: i32,
+    pool: sqlx::PgPool,
+) -> Result<Option<String>, ActionRunnerError> {
+    let fqdn = sqlx::query!(
+        "select fqdn from chroma_core_managedhost where id = $1 and not_deleted = 't'",
+        id
+    )
+    .fetch_optional(&pool)
+    .await?
+    .map(|x| x.fqdn);
+
+    Ok(fqdn)
+}

--- a/iml-services/iml-action-runner/src/lib.rs
+++ b/iml-services/iml-action-runner/src/lib.rs
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 pub mod data;
+pub mod db;
 pub mod error;
 pub mod local_actions;
 pub mod receiver;

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -179,6 +179,14 @@ impl From<&str> for ActionName {
     }
 }
 
+impl Deref for ActionName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_str()
+    }
+}
+
 impl From<String> for ActionName {
     fn from(name: String) -> Self {
         Self(name)

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -36,6 +36,26 @@
       ]
     }
   },
+  "131959cfcc0275c8797cb5aa12f0ad15dd6baa2f75c716815607a039defac3a6": {
+    "query": "select fqdn from chroma_core_managedhost where id = $1 and not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "fqdn",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "1bcbed2e431ad27c5f4969dab2089990e14611629b0760f4a7a499f0126347be": {
     "query": "\n             INSERT INTO chroma_core_logmessage\n             (datetime, fqdn, severity, facility, tag, message, message_class)\n             SELECT datetime, $2, severity, facility, source, message, message_class\n             FROM UNNEST($1::timestamptz[], $3::smallint[], $4::smallint[], $5::text[], $6::text[], $7::smallint[])\n             AS t(datetime, severity, facility, source, message, message_class)\n         ",
     "describe": {


### PR DESCRIPTION
Update local actions to pass in a `PgPool`. This will allow db calls to
be made and can be used in place of the Django ORM.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2141)
<!-- Reviewable:end -->
