### PR TITLE
Fixup client mounts

### DIFF
--- a/chroma_api/stratagem.py
+++ b/chroma_api/stratagem.py
@@ -154,14 +154,6 @@ def validate_mdt_profile(bundle):
         }
 
 
-def validate_client_profile(bundle):
-    if not ManagedHost.objects.filter(server_profile_id__in=["stratagem_client", "stratagem_existing_client"]).exists():
-        return {
-            "code": "stratagem_client_profile_not_installed",
-            "message": "A client must be added with the 'Stratagem Client' profile to run this command.",
-        }
-
-
 class RunStratagemValidation(Validation):
     def is_valid(self, bundle, request=None):
         return (
@@ -169,7 +161,6 @@ class RunStratagemValidation(Validation):
             or validate_filesystem(bundle)
             or validate_target_mount(bundle)
             or validate_mdt_profile(bundle)
-            or validate_client_profile(bundle)
             or {}
         )
 

--- a/chroma_core/models/client_mount.py
+++ b/chroma_core/models/client_mount.py
@@ -308,7 +308,7 @@ class MountLustreFilesystemsJob(AdvertisedJob):
         unmounted = LustreClientMount.objects.filter(state="unmounted", host=self.host)
 
         args = {
-            "host": self.host,
+            "host": self.host.fqdn,
             "filesystems": [
                 {
                     "mountspec": ManagedFilesystem.objects.get(name=m.filesystem).mount_path(),
@@ -386,7 +386,7 @@ class UnmountLustreFilesystemsJob(AdvertisedJob):
             filesystems.extend([{"mountspec": mount_path, "mountpoint": x} for x in m.mountpoints])
 
         args = {
-            "host": self.host,
+            "host": self.host.fqdn,
             "filesystems": filesystems,
         }
 


### PR DESCRIPTION
Fixup the client mount action so it correctly
determines if a client is currently mounted.

In addition, remove the requirement for the stratagem client,
it will not be needed with the task queue.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2148)
<!-- Reviewable:end -->
