### PR TITLE
Add ManagedFilesystem.get_server_groups()

### DIFF
--- a/chroma_core/models/filesystem.py
+++ b/chroma_core/models/filesystem.py
@@ -109,6 +109,20 @@ class ManagedFilesystem(StatefulObject):
         # (http://stackoverflow.com/questions/4764110/django-template-cant-loop-defaultdict)
         return dict(servers)
 
+    def get_server_groups(self):
+        """Return: Array(Array(ManagedHost)) """
+        targets = self.get_targets()
+
+        groups = {}
+
+        for t in targets:
+            hosts = [x.host for x in t.managedtargetmount_set.all()]
+            name = ",".join(sorted([x.fqdn for x in hosts]))
+            if name not in groups:
+                groups[name] = hosts
+        
+        return groups.values()
+
     def get_pools(self):
         return OstPool.objects.filter(filesystem=self)
 


### PR DESCRIPTION
Assemble a list of server groups in roughly O(get_servers())

Fixes #2139

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2160)
<!-- Reviewable:end -->
