### PR TITLE
Add ops to ResourceAgentType

### DIFF
--- a/iml-agent/src/action_plugins/high_availability/mod.rs
+++ b/iml-agent/src/action_plugins/high_availability/mod.rs
@@ -47,7 +47,7 @@ fn create(elem: &Element) -> ResourceAgentInfo {
                             nv.get_attr("name").unwrap_or_default(),
                             (
                                 nv.get_attr("interval").map(str::to_string),
-                                nv.get_attr("timeout").map(str::to_string)
+                                nv.get_attr("timeout").map(str::to_string),
                             ),
                         )
                     })
@@ -260,7 +260,11 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect(),
-            ops: PacemakerOperations::new(Some("300s".to_string()), Some("20s".to_string()), Some("300s".to_string())),
+            ops: PacemakerOperations::new(
+                Some("300s".to_string()),
+                Some("20s".to_string()),
+                Some("300s".to_string()),
+            ),
         };
 
         assert_eq!(process_resource(testxml).unwrap(), r1);
@@ -282,7 +286,11 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect(),
-            ops: PacemakerOperations::new(Some("450".to_string()), Some("30".to_string()), Some("300".to_string())),
+            ops: PacemakerOperations::new(
+                Some("450".to_string()),
+                Some("30".to_string()),
+                Some("300".to_string()),
+            ),
         };
 
         assert_eq!(process_resource(testxml).unwrap(), r1);

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -1544,19 +1544,19 @@ pub enum PacemakerScore {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PacemakerOperations {
-    // Seconds to wait for Resource to start
-    pub start: Option<u32>,
-    // Seconds of monitor interval
-    pub monitor: Option<u32>,
-    // Seconds to wait for Resource to stop
-    pub stop: Option<u32>,
+    // Time to wait for Resource to start
+    pub start: Option<String>,
+    // Time of monitor interval
+    pub monitor: Option<String>,
+    // Time to wait for Resource to stop
+    pub stop: Option<String>,
 }
 
 impl PacemakerOperations {
     pub fn new<'a>(
-        start: impl Into<Option<u32>>,
-        monitor: impl Into<Option<u32>>,
-        stop: impl Into<Option<u32>>,
+        start: impl Into<Option<String>>,
+        monitor: impl Into<Option<String>>,
+        stop: impl Into<Option<String>>,
     ) -> Self {
         Self {
             start: start.into(),

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -1553,7 +1553,7 @@ pub struct PacemakerOperations {
 }
 
 impl PacemakerOperations {
-    pub fn new<'a>(
+    pub fn new(
         start: impl Into<Option<String>>,
         monitor: impl Into<Option<String>>,
         stop: impl Into<Option<String>>,

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -1523,6 +1523,71 @@ pub struct ResourceAgentInfo {
     pub agent: ResourceAgentType,
     pub id: String,
     pub args: HashMap<String, String>,
+    pub ops: PacemakerOperations,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum OrderingKind {
+    Mandatory,
+    Optional,
+    Serialize,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PacemakerScore {
+    Infinity,
+    Value(i32),
+    NegInfinity,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PacemakerOperations {
+    // Seconds to wait for Resource to start
+    pub start: Option<u32>,
+    // Seconds of monitor interval
+    pub monitor: Option<u32>,
+    // Seconds to wait for Resource to stop
+    pub stop: Option<u32>,
+}
+
+impl PacemakerOperations {
+    pub fn new<'a>(
+        start: impl Into<Option<u32>>,
+        monitor: impl Into<Option<u32>>,
+        stop: impl Into<Option<u32>>,
+    ) -> Self {
+        Self {
+            start: start.into(),
+            monitor: monitor.into(),
+            stop: stop.into(),
+        }
+    }
+}
+
+/// Information about pacemaker resource agents
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ResourceConstraint {
+    Ordering {
+        id: String,
+        first: String,
+        then: String,
+        kind: Option<OrderingKind>,
+    },
+    Location {
+        id: String,
+        rsc: String,
+        node: String,
+        score: PacemakerScore,
+    },
+    Colocation {
+        id: String,
+        rsc: String,
+        with_rsc: String,
+        score: PacemakerScore,
+    },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
Also add wire-types for resource constraints.

Related #1464

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2166)
<!-- Reviewable:end -->
