### PR TITLE
Ensure empty snapshots do not produce parse error

### DIFF
--- a/iml-agent/src/action_plugins/lustre/snapshot.rs
+++ b/iml-agent/src/action_plugins/lustre/snapshot.rs
@@ -17,7 +17,8 @@ pub async fn list(l: List) -> Result<Vec<Snapshot>, ImlAgentError> {
     if l.detail {
         args.push("--detail");
     }
-    let stdout = lctl(args).await?.trim();
+    let stdout = lctl(args).await?;
+    let stdout = stdout.trim();
 
     if stdout.is_empty() {
         Ok(vec![])

--- a/iml-agent/src/action_plugins/lustre/snapshot.rs
+++ b/iml-agent/src/action_plugins/lustre/snapshot.rs
@@ -17,8 +17,13 @@ pub async fn list(l: List) -> Result<Vec<Snapshot>, ImlAgentError> {
     if l.detail {
         args.push("--detail");
     }
-    let stdout = lctl(args).await?;
-    parse_snapshot_list(&stdout).map_err(ImlAgentError::CombineEasyError)
+    let stdout = lctl(args).await?.trim();
+
+    if stdout.is_empty() {
+        Ok(vec![])
+    } else {
+        parse_snapshot_list(&stdout).map_err(ImlAgentError::CombineEasyError)
+    }
 }
 
 fn parse_snapshot_list(input: &str) -> Result<Vec<Snapshot>, easy::Errors<char, String, usize>> {


### PR DESCRIPTION
If `snapshot_list` is called when there are no snapshots, no output is
produced.

If this is fed into `parse_snapshot_list` it will produce an error like:

```
Parse error at 0
Unexpected `end of input`
Expected `:` or `whitespaces`
```

The easiest way to head this off is to make sure the input is non-empty
and return an empty `Vec` if it is.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2170)
<!-- Reviewable:end -->
