### PR TITLE
Introduce iml-change crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "iml-change"
+version = "0.1.0"
+
+[[package]]
 name = "iml-cmd"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   'iml-agent',
   'iml-api-utils',
   'iml-api',
+  'iml-change',
   'iml-cmd',
   'iml-fs',
   'iml-influx',

--- a/iml-change/Cargo.toml
+++ b/iml-change/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+name = "iml-change"
+version = "0.1.0"

--- a/iml-change/README.md
+++ b/iml-change/README.md
@@ -1,0 +1,5 @@
+# iml-change
+
+This crate provides a way to sort collections of items into buckets that can be upserted or deleted.
+Users should implement the `Identifiable` trait and the `Changeable` trait for their items.
+Once these are implemented, `get_changes` can be used to sort into `Upsertable` and `Deletable` collections.

--- a/iml-change/src/lib.rs
+++ b/iml-change/src/lib.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use std::{
+    cmp::{Eq, Ord},
+    collections::BTreeSet,
+    fmt::Debug,
+    iter::FromIterator,
+};
+
+pub trait Identifiable {
+    type Id: Eq + Ord;
+
+    fn id(&self) -> Self::Id;
+}
+
+pub trait Changeable: Eq + Ord + Debug {}
+
+impl<T> Changeable for T where T: Eq + Ord + Debug {}
+
+#[derive(Debug)]
+pub struct Upserts<T: Changeable>(pub Vec<T>);
+
+#[derive(Debug)]
+pub struct Deletions<T: Changeable>(pub Vec<T>);
+
+type Changes<'a, T> = (Option<Upserts<&'a T>>, Option<Deletions<&'a T>>);
+
+pub trait GetChanges<T: Changeable + Identifiable> {
+    /// Given new and old items, this method compares them and
+    /// returns a tuple of `Upserts` and `Deletions`.
+    fn get_changes<'a>(&'a self, old: &'a Self) -> Changes<'a, T>;
+}
+
+impl<T: Changeable + Identifiable> GetChanges<T> for Vec<T> {
+    fn get_changes<'a>(&'a self, old: &'a Self) -> Changes<'a, T> {
+        let new = BTreeSet::from_iter(self);
+        let old = BTreeSet::from_iter(old);
+
+        let to_upsert: Vec<&T> = new.difference(&old).copied().collect();
+
+        let to_upsert = if to_upsert.is_empty() {
+            None
+        } else {
+            Some(Upserts(to_upsert))
+        };
+
+        let new_ids: BTreeSet<<T as Identifiable>::Id> = new.iter().map(|x| x.id()).collect();
+        let old_ids: BTreeSet<<T as Identifiable>::Id> = old.iter().map(|x| x.id()).collect();
+
+        let changed: BTreeSet<_> = new_ids.intersection(&old_ids).collect();
+
+        let to_remove: Vec<&T> = old
+            .difference(&new)
+            .filter(|x| {
+                let id = x.id();
+
+                changed.get(&id).is_none()
+            })
+            .copied()
+            .collect();
+
+        let to_remove = if to_remove.is_empty() {
+            None
+        } else {
+            Some(Deletions(to_remove))
+        };
+
+        (to_upsert, to_remove)
+    }
+}

--- a/iml-change/src/lib.rs
+++ b/iml-change/src/lib.rs
@@ -111,67 +111,85 @@ mod tests {
                 col1: "mickey".into(),
                 col2: "mouse".into(),
                 age: 16,
-                amount: 27
-            },
-            Item {
-                col1: "minnie".into(),
-                col2: "mouse".into(),
-                age: 17,
-                amount: 32
-            },
-            Item {
-                col1: "All your base".into(),
-                col2: "Are belong to us".into(),
-                age: 54,
-                amount: 0
-            }
-        ].into_iter().collect::<Vec<Item>>();
-
-        let items2 = vec![
-            Item {
-                col1: "mickey".into(),
-                col2: "mouse".into(),
-                age: 16,
-                amount: 27
-            },
-            Item {
-                col1: "minnie".into(),
-                col2: "mouse".into(),
-                age: 23,
-                amount: 32
-            },
-            Item {
-                col1: "donald".into(),
-                col2: "duck".into(),
-                age: 7,
-                amount: 18
-            },
-        ].into_iter().collect::<Vec<Item>>();
-
-        let (upserts, deletions) = items1.get_changes(&items2);
-
-        assert_eq!(upserts.unwrap().0.into_iter().cloned().collect::<Vec<Item>>(), vec![
-            Item {
-                col1: "All your base".into(),
-                col2: "Are belong to us".into(),
-                age: 54,
-                amount: 0,
+                amount: 27,
             },
             Item {
                 col1: "minnie".into(),
                 col2: "mouse".into(),
                 age: 17,
                 amount: 32,
-            }
-        ]);
+            },
+            Item {
+                col1: "All your base".into(),
+                col2: "Are belong to us".into(),
+                age: 54,
+                amount: 0,
+            },
+        ]
+        .into_iter()
+        .collect::<Vec<Item>>();
 
-        assert_eq!(deletions.unwrap().0.into_iter().cloned().collect::<Vec<Item>>(), vec![
+        let items2 = vec![
+            Item {
+                col1: "mickey".into(),
+                col2: "mouse".into(),
+                age: 16,
+                amount: 27,
+            },
+            Item {
+                col1: "minnie".into(),
+                col2: "mouse".into(),
+                age: 23,
+                amount: 32,
+            },
             Item {
                 col1: "donald".into(),
                 col2: "duck".into(),
                 age: 7,
                 amount: 18,
-            }
-        ]);
+            },
+        ]
+        .into_iter()
+        .collect::<Vec<Item>>();
+
+        let (upserts, deletions) = items1.get_changes(&items2);
+
+        assert_eq!(
+            upserts
+                .unwrap()
+                .0
+                .into_iter()
+                .cloned()
+                .collect::<Vec<Item>>(),
+            vec![
+                Item {
+                    col1: "All your base".into(),
+                    col2: "Are belong to us".into(),
+                    age: 54,
+                    amount: 0,
+                },
+                Item {
+                    col1: "minnie".into(),
+                    col2: "mouse".into(),
+                    age: 17,
+                    amount: 32,
+                }
+            ]
+        );
+
+        assert_eq!(
+            deletions
+                .unwrap()
+                .0
+                .into_iter()
+                .cloned()
+                .collect::<Vec<Item>>(),
+            vec![Item {
+                col1: "donald".into(),
+                col2: "duck".into(),
+                age: 7,
+                amount: 18,
+            }]
+        );
     }
 }


### PR DESCRIPTION
This patch adds the `iml-change` crate that can be used to compare
collections for things that should be upserted or deleted.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2171)
<!-- Reviewable:end -->
