### PR TITLE
Fix docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -289,8 +289,8 @@ services:
     volumes:
       - "manager-config:/var/lib/chroma"
     environment:
-      - PROXY_HOST=iml-warp-drive,sqlx::query=warn
-      - RUST_LOG=info
+      - PROXY_HOST=iml-warp-drive
+      - RUST_LOG=info,sqlx::query=warn
   iml-action-runner:
     image: "imlteam/iml-action-runner:6.2.0-dev"
     hostname: "iml-action-runner"


### PR DESCRIPTION
`sqlx::query=warn` was being tacked on to the wrong environment
variable, which is causing warp-drive to break in docker.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2183)
<!-- Reviewable:end -->
