### PR TITLE
Add corosync daemon plugin to Rust

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -38,24 +38,25 @@ srpm:
 	mkdir -p ${TMPDIR}/_topdir/{SOURCES,SPECS}
 	mkdir -p ${TMPDIR}/release/rust-iml
 	cargo build --release
-	cp ${TARGET}/release/iml-{action-runner,agent,agent-comms,agent-daemon,api,device,journal,mailbox,ntp,ostpool,postoffice,report,sfa,stats,task-runner,warp-drive} \
-		iml-agent-comms.service \
-		iml-mailbox.service \
-		iml-postoffice.service \
-		iml-ostpool.service \
-		iml-report.service \
-		iml-api.service \
-		iml-rust-stats.service \
-		iml-device.service \
-		iml-task-runner.service \
-		iml-journal.service \
+	cp ${TARGET}/release/iml-{action-runner,agent,agent-comms,agent-daemon,api,corosync,device,journal,mailbox,ntp,ostpool,postoffice,report,sfa,stats,task-runner,warp-drive} \
 		iml-action-runner.service \
+		iml-agent-comms.service \
+		iml-api.service \
+		iml-device.service \
+		iml-journal.service \
+		iml-mailbox.service \
+		iml-ntp.service \
+		iml-ostpool.service \
+		iml-postoffice.service \
+		iml-report.service \
+		iml-rust-corosync.service \
+		iml-rust-stats.service \
+		iml-sfa.service \
+		iml-task-runner.service \
 		iml-action-runner.socket \
 		iml-agent/systemd-units/* \
 		iml-warp-drive/systemd-units/* \
 		iml-report.conf \
-		iml-ntp.service \
-		iml-sfa.service \
 		${TMPDIR}/release/rust-iml
 	cp ${TARGET}/release/iml ${TMPDIR}/release/rust-iml
 	cp ${TARGET}/release/iml-config ${TMPDIR}/release/rust-iml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,6 +1472,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "iml-corosync"
+version = "0.3.0"
+dependencies = [
+ "futures",
+ "iml-change",
+ "iml-manager-env",
+ "iml-postgres",
+ "iml-rabbit",
+ "iml-service-queue",
+ "iml-tracing",
+ "iml-wire-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "iml-device"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   'iml-services/iml-service-queue',
   'iml-services/iml-stats',
   'iml-services/iml-journal',
+  'iml-services/iml-corosync',
   'iml-sfa',
   'iml-system-test-utils',
   'iml-systemd',

--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ nuke_db:
 
 migrate_db:
 	psql chroma -c "CREATE EXTENSION IF NOT EXISTS btree_gist;"
-	cargo sqlx migrate run
 	@./manage.py migrate
+	cargo sqlx migrate run
 
 
 nuke_logs:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -139,6 +139,17 @@ services:
       - RUST_LOG=info,sqlx::query=warn
     volumes:
       - "manager-config:/var/lib/chroma"
+  iml-corosync:
+    image: "imlteam/corosync:6.2.0-dev"
+    hostname: "iml-corosync"
+    build:
+      context: ../
+      dockerfile: ./docker/iml-corosync.dockerfile
+    deploy: *default-deploy
+    environment:
+      - RUST_LOG=info,sqlx::query=warn
+    volumes:
+      - "manager-config:/var/lib/chroma"
   ntp:
     image: "imlteam/ntp:6.2.0-dev"
     hostname: "iml-ntp"
@@ -164,7 +175,7 @@ services:
     volumes:
       - "manager-config:/var/lib/chroma"
     environment:
-      - RUST_LOG=info
+      - RUST_LOG=info,sqlx::query=warn
       - SFA_ENDPOINTS_1
   corosync:
     image: "imlteam/manager-corosync:6.2.0-dev"

--- a/docker/iml-corosync.dockerfile
+++ b/docker/iml-corosync.dockerfile
@@ -1,0 +1,8 @@
+FROM rust-iml-base as builder
+FROM imlteam/rust-service-base:6.2.0-dev
+
+COPY --from=builder /build/target/release/iml-corosync /usr/local/bin
+COPY docker/wait-for-dependencies-postgres.sh /usr/local/bin
+
+ENTRYPOINT [ "wait-for-dependencies-postgres.sh" ]
+CMD ["iml-corosync"]

--- a/iml-agent/src/daemon_plugins/corosync.rs
+++ b/iml-agent/src/daemon_plugins/corosync.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{
+    agent_error::ImlAgentError,
+    crm_reader::get_crm_mon,
+    daemon_plugins::{DaemonPlugin, Output},
+};
+use futures::{Future, FutureExt};
+use std::pin::Pin;
+
+#[derive(Debug)]
+struct Corosync {}
+
+pub fn create() -> impl DaemonPlugin {
+    Corosync {}
+}
+
+impl DaemonPlugin for Corosync {
+    fn start_session(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Output, ImlAgentError>> + Send>> {
+        self.update_session()
+    }
+
+    fn update_session(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Output, ImlAgentError>> + Send>> {
+        async move {
+            let x = get_crm_mon().await?;
+
+            let x = x.map(|x| serde_json::to_value(x)).transpose()?;
+
+            Ok(x)
+        }
+        .boxed()
+    }
+}

--- a/iml-agent/src/daemon_plugins/daemon_plugin.rs
+++ b/iml-agent/src/daemon_plugins/daemon_plugin.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     agent_error::{NoPluginError, Result},
-    daemon_plugins::{action_runner, device, journal, ntp, ostpool, postoffice, stats},
+    daemon_plugins::{action_runner, corosync, device, journal, ntp, ostpool, postoffice, stats},
 };
 use async_trait::async_trait;
 use futures::{future, Future, FutureExt};
@@ -72,6 +72,7 @@ pub fn plugin_registry() -> DaemonPlugins {
         ("stats".into(), mk_callback(stats::create)),
         ("device".into(), mk_callback(device::create)),
         ("journal".into(), mk_callback(journal::create)),
+        ("corosync".into(), mk_callback(corosync::create)),
     ]
     .into_iter()
     .collect();

--- a/iml-agent/src/daemon_plugins/mod.rs
+++ b/iml-agent/src/daemon_plugins/mod.rs
@@ -10,6 +10,7 @@
 //! Each plugin is wrapped in a session which provides a connection guarantee with the IML manager.
 
 pub mod action_runner;
+pub mod corosync;
 pub mod daemon_plugin;
 pub mod device;
 pub mod journal;

--- a/iml-manager.target
+++ b/iml-manager.target
@@ -85,6 +85,9 @@ After=grafana-server.service
 Requires=iml-device.service
 After=iml-device.service
 
+Requires=iml-rust-corosync.service
+After=iml-rust-corosync.service
+
 After=network.target
 
 [Install]
@@ -108,6 +111,7 @@ Also=iml-journal.service
 Also=iml-ntp.service
 Also=iml-update-handler.socket
 Also=iml-warp-drive.service
+Also=iml-rust-corosync.service
 Also=influxdb.service
 Also=nginx.service
 Also=postgresql-9.6.service

--- a/iml-rust-corosync.service
+++ b/iml-rust-corosync.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=IML Rust Corosync Service
+PartOf=iml-manager.target
+Before=nginx.service
+After=rabbitmq-server.service
+After=postgresql-9.6.service
+After=iml-settings-populator.service
+Requires=iml-settings-populator.service
+
+
+[Service]
+Type=simple
+Environment=RUST_LOG=info,sqlx::query=warn
+EnvironmentFile=/var/lib/chroma/iml-settings.conf
+EnvironmentFile=-/var/lib/chroma/overrides.conf
+ExecStart=/bin/iml-corosync
+Restart=always
+RestartSec=2
+StandardOutput=journal
+StandardError=journal

--- a/iml-services/iml-corosync/Cargo.toml
+++ b/iml-services/iml-corosync/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+name = "iml-corosync"
+version = "0.3.0"
+
+[dependencies]
+futures = "0.3"
+iml-change = {path = "../../iml-change", version = "0.1"}
+iml-manager-env = {path = "../../iml-manager-env", version = "0.3"}
+iml-postgres = {path = "../../iml-postgres", version = "0.3"}
+iml-rabbit = {path = "../../iml-rabbit", version = "0.3"}
+iml-service-queue = {path = "../iml-service-queue", version = "0.3"}
+iml-tracing = {version = "0.2", path = "../../iml-tracing"}
+iml-wire-types = {path = "../../iml-wire-types", version = "0.3"}
+serde = {version = "1", features = ["derive"]}
+serde_json = "1.0"
+thiserror = "1.0"
+tokio = {version = "0.2", features = ["macros", "rt-threaded"]}

--- a/iml-services/iml-corosync/src/main.rs
+++ b/iml-services/iml-corosync/src/main.rs
@@ -1,0 +1,248 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use futures::TryStreamExt;
+use iml_manager_env::get_pool_limit;
+use iml_postgres::{get_db_pool, sqlx, PgPool};
+use iml_service_queue::service_queue::consume_data;
+use iml_service_queue::service_queue::ImlServiceQueueError;
+use iml_tracing::tracing;
+use iml_wire_types::{
+    high_availability::{Cluster, Node},
+    Fqdn,
+};
+use thiserror::Error;
+
+// Default pool limit if not overridden by POOL_LIMIT
+const DEFAULT_POOL_LIMIT: u32 = 2;
+
+#[tokio::main]
+async fn main() -> Result<(), ImlCorosyncError> {
+    iml_tracing::init();
+
+    let rabbit_pool = iml_rabbit::connect_to_rabbit(1);
+
+    let conn = iml_rabbit::get_conn(rabbit_pool).await?;
+
+    let ch = iml_rabbit::create_channel(&conn).await?;
+
+    let mut s = consume_data::<Cluster>(&ch, "rust_agent_corosync_rx");
+
+    let pool = get_db_pool(get_pool_limit().unwrap_or(DEFAULT_POOL_LIMIT)).await?;
+
+    sqlx::migrate!("../../migrations").run(&pool).await?;
+
+    while let Some((fqdn, cluster)) = s.try_next().await? {
+        let host_id = get_host_id_by_fqdn(&fqdn, &pool).await?;
+
+        let host_id = match host_id {
+            Some(id) => id,
+            None => {
+                tracing::warn!("Host '{}' is unknown, discarding incoming data", fqdn);
+
+                continue;
+            }
+        };
+
+        let (node_ids, node_names): (Vec<String>, Vec<String>) = cluster
+            .nodes
+            .iter()
+            .map(|x| (x.id.to_string(), x.name.to_string()))
+            .unzip();
+
+        // Delete old rows
+        sqlx::query!(
+            r#"
+            DELETE FROM corosync_node
+            USING corosync_node_managed_host
+            WHERE id = corosync_node_id AND name = corosync_node_name
+            AND corosync_node_id != ALL($1)
+            AND corosync_node_name != ALL($2)
+            AND host_id = $3
+        "#,
+            &node_ids,
+            &node_names,
+            host_id
+        )
+        .execute(&pool)
+        .await?;
+
+        // Upsert the rest
+        upsert_cluster_nodes(cluster.nodes, &pool).await?;
+
+        sqlx::query!(
+            r#"
+            INSERT INTO corosync_node_managed_host (host_id, corosync_node_id, corosync_node_name)
+            SELECT $1, corosync_node_id, corosync_node_name FROM UNNEST($2::text[], $3::text[])
+            AS t(corosync_node_id, corosync_node_name)
+            ON CONFLICT (host_id, corosync_node_id, corosync_node_name)
+            DO NOTHING
+            "#,
+            host_id,
+            &node_ids,
+            &node_names
+        )
+        .execute(&pool)
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+pub enum ImlCorosyncError {
+    #[error(transparent)]
+    ImlRabbitError(#[from] iml_rabbit::ImlRabbitError),
+    #[error(transparent)]
+    ImlServiceQueueError(#[from] ImlServiceQueueError),
+    #[error(transparent)]
+    SerdeJsonError(#[from] serde_json::Error),
+    #[error(transparent)]
+    SqlxCoreError(#[from] sqlx::Error),
+    #[error(transparent)]
+    SqlxMigrateError(#[from] sqlx::migrate::MigrateError),
+}
+
+async fn get_host_id_by_fqdn(fqdn: &Fqdn, pool: &PgPool) -> Result<Option<i32>, ImlCorosyncError> {
+    let id = sqlx::query!(
+        "select id from chroma_core_managedhost where fqdn = $1 and not_deleted = 't'",
+        fqdn.to_string()
+    )
+    .fetch_optional(pool)
+    .await?
+    .map(|x| x.id);
+
+    Ok(id)
+}
+
+async fn upsert_cluster_nodes(nodes: Vec<Node>, pool: &PgPool) -> Result<(), ImlCorosyncError> {
+    let x = nodes.into_iter().fold(
+        (
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ),
+        |mut acc, x| {
+            acc.0.push(x.name);
+            acc.1.push(x.id);
+            acc.2.push(x.online);
+            acc.3.push(x.standby);
+            acc.4.push(x.standby_onfail);
+            acc.5.push(x.maintenance);
+            acc.6.push(x.pending);
+            acc.7.push(x.unclean);
+            acc.8.push(x.shutdown);
+            acc.9.push(x.expected_up);
+            acc.10.push(x.is_dc);
+            acc.11.push(x.resources_running as i32);
+            acc.12.push(x.r#type.to_string());
+
+            acc
+        },
+    );
+
+    sqlx::query!(
+        r#"
+            INSERT INTO corosync_node (
+                name,
+                id,
+                online,
+                standby,
+                standby_onfail,
+                maintenance,
+                pending,
+                unclean,
+                shutdown,
+                expected_up,
+                is_dc,
+                resources_running,
+                type
+            )
+            SELECT
+                name,
+                id,
+                online,
+                standby,
+                standby_onfail,
+                maintenance,
+                pending,
+                unclean,
+                shutdown,
+                expected_up,
+                is_dc,
+                resources_running,
+                type
+            FROM UNNEST(
+                $1::text[],
+                $2::text[],
+                $3::bool[],
+                $4::bool[],
+                $5::bool[],
+                $6::bool[],
+                $7::bool[],
+                $8::bool[],
+                $9::bool[],
+                $10::bool[],
+                $11::bool[],
+                $12::int[],
+                $13::text[]
+            )
+            AS t(
+                name,
+                id,
+                online,
+                standby,
+                standby_onfail,
+                maintenance,
+                pending,
+                unclean,
+                shutdown,
+                expected_up,
+                is_dc,
+                resources_running,
+                type
+            )
+            ON CONFLICT (id, name) DO UPDATE
+            SET
+                online = excluded.online,
+                standby = excluded.standby,
+                standby_onfail = excluded.standby_onfail,
+                maintenance = excluded.maintenance,
+                pending = excluded.pending,
+                unclean = excluded.unclean,
+                shutdown = excluded.shutdown,
+                expected_up = excluded.expected_up,
+                is_dc = excluded.is_dc,
+                resources_running = excluded.resources_running,
+                type = excluded.type
+        "#,
+        &x.0,
+        &x.1,
+        &x.2,
+        &x.3,
+        &x.4,
+        &x.5,
+        &x.6,
+        &x.7,
+        &x.8,
+        &x.9,
+        &x.10,
+        &x.11,
+        &x.12,
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}

--- a/iml-wire-types/src/high_availability.rs
+++ b/iml-wire-types/src/high_availability.rs
@@ -2,7 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use std::{convert::TryFrom, io};
+use std::{
+    convert::TryFrom,
+    fmt::{self, Display},
+    io,
+};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum NodeType {
@@ -26,6 +30,19 @@ impl TryFrom<&str> for NodeType {
                 format!("Invalid node type {}", x),
             )),
         }
+    }
+}
+
+impl Display for NodeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let x = match self {
+            NodeType::Unknown => "unknown",
+            NodeType::Member => "member",
+            NodeType::Remote => "remote",
+            NodeType::Ping => "ping",
+        };
+
+        write!(f, "{}", x)
     }
 }
 

--- a/migrations/20200824170157_corosync_node.sql
+++ b/migrations/20200824170157_corosync_node.sql
@@ -1,0 +1,26 @@
+CREATE TABLE corosync_node (
+    id text NOT NULL,
+    name text NOT NULL,
+    online boolean NOT NULL,
+    standby boolean NOT NULL,
+    standby_onfail boolean NOT NULL,
+    maintenance boolean NOT NULL,
+    pending boolean NOT NULL,
+    unclean boolean NOT NULL,
+    shutdown boolean NOT NULL,
+    expected_up boolean NOT NULL,
+    is_dc boolean NOT NULL,
+    resources_running int NOT NULL,
+    type text NOT NULL,
+    UNIQUE (id, name)
+);
+
+CREATE UNIQUE INDEX id_idx ON corosync_node (id, name);
+
+CREATE TABLE corosync_node_managed_host (
+    host_id int NOT NULL REFERENCES chroma_core_managedhost (id),
+    corosync_node_id text,
+    corosync_node_name text,
+    FOREIGN KEY (corosync_node_id, corosync_node_name) REFERENCES corosync_node (id, name) ON DELETE CASCADE,
+    UNIQUE (host_id, corosync_node_id, corosync_node_name)
+);

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -81,6 +81,7 @@ Requires:       python2-massiviu >= 0.1.0-2
 Requires:       rust-iml-action-runner >= 0.3.0
 Requires:       rust-iml-agent-comms >= 0.3.0
 Requires:       rust-iml-api >= 0.3.0
+Requires:       rust-iml-corosync >= 0.3.0
 Requires:       rust-iml-cli >= 0.3.0
 Requires:       rust-iml-gui >= 0.2.0
 Requires:       rust-iml-mailbox >= 0.3.0

--- a/rust-iml.spec
+++ b/rust-iml.spec
@@ -28,39 +28,41 @@ ExclusiveArch: x86_64
 %install
 mkdir -p %{buildroot}%{_bindir}
 cp iml %{buildroot}%{_bindir}
-cp iml-config %{buildroot}%{_bindir}
+cp iml-action-runner %{buildroot}%{_bindir}
 cp iml-agent %{buildroot}%{_bindir}
+cp iml-agent-comms %{buildroot}%{_bindir}
 cp iml-agent-daemon %{buildroot}%{_bindir}
 cp iml-api %{buildroot}%{_bindir}
-cp iml-ostpool %{buildroot}%{_bindir}
+cp iml-config %{buildroot}%{_bindir}
+cp iml-corosync %{buildroot}%{_bindir}
 cp iml-device %{buildroot}%{_bindir}
 cp iml-journal %{buildroot}%{_bindir}
-cp iml-stats %{buildroot}%{_bindir}
-cp iml-agent-comms %{buildroot}%{_bindir}
-cp iml-action-runner %{buildroot}%{_bindir}
-cp iml-task-runner %{buildroot}%{_bindir}
-cp iml-warp-drive %{buildroot}%{_bindir}
 cp iml-mailbox %{buildroot}%{_bindir}
 cp iml-ntp %{buildroot}%{_bindir}
+cp iml-ostpool %{buildroot}%{_bindir}
 cp iml-postoffice %{buildroot}%{_bindir}
 cp iml-report %{buildroot}%{_bindir}
 cp iml-sfa %{buildroot}%{_bindir}
+cp iml-stats %{buildroot}%{_bindir}
+cp iml-task-runner %{buildroot}%{_bindir}
+cp iml-warp-drive %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_unitdir}
+cp iml-action-runner.{socket,service} %{buildroot}%{_unitdir}
+cp iml-agent-comms.service %{buildroot}%{_unitdir}
 cp iml-api.service %{buildroot}%{_unitdir}
+cp iml-rust-corosync.service %{buildroot}%{_unitdir}
 cp iml-device.service %{buildroot}%{_unitdir}
 cp iml-journal.service %{buildroot}%{_unitdir}
-cp iml-ostpool.service %{buildroot}%{_unitdir}
-cp iml-rust-stats.service %{buildroot}%{_unitdir}
-cp iml-agent-comms.service %{buildroot}%{_unitdir}
-cp iml-task-runner.service %{buildroot}%{_unitdir}
-cp iml-action-runner.{socket,service} %{buildroot}%{_unitdir}
-cp rust-iml-agent.{service,path} %{buildroot}%{_unitdir}
-cp iml-warp-drive.service %{buildroot}%{_unitdir}
 cp iml-mailbox.service %{buildroot}%{_unitdir}
 cp iml-ntp.service %{buildroot}%{_unitdir}
+cp iml-ostpool.service %{buildroot}%{_unitdir}
 cp iml-postoffice.service %{buildroot}%{_unitdir}
 cp iml-report.service %{buildroot}%{_unitdir}
+cp iml-rust-stats.service %{buildroot}%{_unitdir}
 cp iml-sfa.service %{buildroot}%{_unitdir}
+cp iml-task-runner.service %{buildroot}%{_unitdir}
+cp iml-warp-drive.service %{buildroot}%{_unitdir}
+cp rust-iml-agent.{service,path} %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_tmpfilesdir}
 cp iml-report.conf %{buildroot}%{_tmpfilesdir}
 cp tmpfiles.conf %{buildroot}%{_tmpfilesdir}/iml-agent.conf
@@ -428,6 +430,28 @@ Requires: rust-iml-agent-comms
 %files journal
 %{_bindir}/iml-journal
 %attr(0644,root,root)%{_unitdir}/iml-journal.service
+
+%package corosync
+Summary: Consumer of corosync updates
+License: MIT
+Group: System Environment/Libraries
+Requires: rust-iml-agent-comms
+
+%description corosync
+%{summary}
+
+%post corosync
+%systemd_post iml-rust-corosync.service
+
+%preun corosync
+%systemd_preun iml-rust-corosync.service
+
+%postun corosync
+%systemd_postun_with_restart iml-rust-corosync.service
+
+%files corosync
+%{_bindir}/iml-corosync
+%attr(0644,root,root)%{_unitdir}/iml-rust-corosync.service
 
 %changelog
 * Wed Sep 18 2019 Will Johnson <wjohnson@whamcloud.com> - 0.2.0-1 

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -488,6 +488,20 @@
       ]
     }
   },
+  "3f3223ba965d969cb1a389c2527484fdd4ef6363e464ad07443bec9416006928": {
+    "query": "\n            INSERT INTO corosync_node_managed_host (host_id, corosync_node_id, corosync_node_name)\n            SELECT $1, corosync_node_id, corosync_node_name FROM UNNEST($2::text[], $3::text[])\n            AS t(corosync_node_id, corosync_node_name)\n            ON CONFLICT (host_id, corosync_node_id, corosync_node_name)\n            DO NOTHING\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "TextArray",
+          "TextArray"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "414a5b7c63ec04ad876c282460de775c0e919c1063c46c7a49704b3ccd87ab3f": {
     "query": "\n        INSERT INTO chroma_core_sfacontroller\n        (\n            index,\n            enclosure_index,\n            health_state,\n            health_state_reason,\n            child_health_state,\n            storage_system\n        )\n        SELECT * FROM UNNEST(\n            $1::int[],\n            $2::int[],\n            $3::smallint[],\n            $4::text[],\n            $5::smallint[],\n            $6::text[]\n        )\n        ON CONFLICT (index, storage_system) DO UPDATE\n        SET\n            enclosure_index = excluded.enclosure_index,\n            health_state = excluded.health_state,\n            health_state_reason = excluded.health_state_reason,\n            child_health_state = excluded.child_health_state\n    ",
     "describe": {
@@ -499,6 +513,44 @@
           "Int2Array",
           "TextArray",
           "Int2Array",
+          "TextArray"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "48243eeece8f3c8e07580762b3fc8b3581703da49f72d84a43d449342a5765ff": {
+    "query": "\n            DELETE FROM corosync_node\n            USING corosync_node_managed_host\n            WHERE id = corosync_node_id AND name = corosync_node_name\n            AND corosync_node_id != ALL($1)\n            AND corosync_node_name != ALL($2)\n            AND host_id = $3\n        ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "TextArray",
+          "TextArray",
+          "Int4"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "4f5aafc25fd6352f79be610c0eb35a32397c2f5b87276be03b02a9d2022002ce": {
+    "query": "\n            INSERT INTO corosync_node (\n                name,\n                id,\n                online,\n                standby,\n                standby_onfail,\n                maintenance,\n                pending,\n                unclean,\n                shutdown,\n                expected_up,\n                is_dc,\n                resources_running,\n                type\n            )\n            SELECT\n                name,\n                id,\n                online,\n                standby,\n                standby_onfail,\n                maintenance,\n                pending,\n                unclean,\n                shutdown,\n                expected_up,\n                is_dc,\n                resources_running,\n                type\n            FROM UNNEST(\n                $1::text[],\n                $2::text[],\n                $3::bool[],\n                $4::bool[],\n                $5::bool[],\n                $6::bool[],\n                $7::bool[],\n                $8::bool[],\n                $9::bool[],\n                $10::bool[],\n                $11::bool[],\n                $12::int[],\n                $13::text[]\n            )\n            AS t(\n                name,\n                id,\n                online,\n                standby,\n                standby_onfail,\n                maintenance,\n                pending,\n                unclean,\n                shutdown,\n                expected_up,\n                is_dc,\n                resources_running,\n                type\n            )\n            ON CONFLICT (id, name) DO UPDATE\n            SET\n                online = excluded.online,\n                standby = excluded.standby,\n                standby_onfail = excluded.standby_onfail,\n                maintenance = excluded.maintenance,\n                pending = excluded.pending,\n                unclean = excluded.unclean,\n                shutdown = excluded.shutdown,\n                expected_up = excluded.expected_up,\n                is_dc = excluded.is_dc,\n                resources_running = excluded.resources_running,\n                type = excluded.type\n        ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "TextArray",
+          "TextArray",
+          "BoolArray",
+          "BoolArray",
+          "BoolArray",
+          "BoolArray",
+          "BoolArray",
+          "BoolArray",
+          "BoolArray",
+          "BoolArray",
+          "BoolArray",
+          "Int4Array",
           "TextArray"
         ]
       },

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -128,7 +128,7 @@ EOF
 rm -rf /tmp/{manager,agent}-rpms
 mkdir -p /tmp/{manager,agent}-rpms
 
-cp /tmp/iml/_topdir/RPMS/rust-iml-{action-runner,agent-comms,api,cli,config-cli,journal,mailbox,ntp,ostpool,postoffice,report,sfa,stats,task-runner,device,warp-drive}-*.rpm /tmp/manager-rpms/
+cp /tmp/iml/_topdir/RPMS/rust-iml-{action-runner,agent-comms,api,cli,corosync,config-cli,journal,mailbox,ntp,ostpool,postoffice,report,sfa,stats,task-runner,device,warp-drive}-*.rpm /tmp/manager-rpms/
 cp /tmp/iml/_topdir/RPMS/python2-iml-manager-*.rpm /tmp/manager-rpms/
 cp /tmp/iml/_topdir/RPMS/rust-iml-agent-[0-9]*.rpm /tmp/agent-rpms
 cp /tmp/iml/_topdir/RPMS/iml-device-scanner-*.rpm /tmp/agent-rpms


### PR DESCRIPTION
Add a new daemon / service to Rust that will
continually get node info for any existing clusters.

Fixes #2139.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2184)
<!-- Reviewable:end -->
