### PR TITLE
Remove Device scanner make command from local build

### DIFF
--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -120,7 +120,7 @@ su -l mocker << EOF
 mock -r /etc/mock/iml.cfg --init
 mock -r /etc/mock/iml.cfg --copyin /integrated-manager-for-lustre /iml
 mock -r /etc/mock/iml.cfg -i cargo git ed epel-release python-setuptools gcc openssl-devel python2-devel python2-setuptools ed zfs libzfs2-devel
-mock -r /etc/mock/iml.cfg --shell 'export CARGO_HOME=/tmp/.cargo CARGO_TARGET_DIR=/tmp/target && cd /iml && make device-scanner-rpms && make local'
+mock -r /etc/mock/iml.cfg --shell 'export CARGO_HOME=/tmp/.cargo CARGO_TARGET_DIR=/tmp/target && cd /iml && make local'
 mock -r /etc/mock/iml.cfg --copyout /iml/_topdir /tmp/iml/_topdir
 mock -r /etc/mock/iml.cfg --copyout /iml/chroma_support.repo /tmp/iml/
 EOF


### PR DESCRIPTION
It's already in `make local`

Fixes #2191.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2192)
<!-- Reviewable:end -->
