### PR TITLE
Account for multiple fs with the same target name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,7 @@ name = "iml-influx"
 version = "0.1.0"
 dependencies = [
  "iml-wire-types",
+ "influx_db_client",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,7 @@ dependencies = [
  "futures",
  "im",
  "iml-change",
+ "iml-influx",
  "iml-manager-env",
  "iml-postgres",
  "iml-rabbit",
@@ -1614,6 +1615,7 @@ version = "0.1.0"
 dependencies = [
  "iml-wire-types",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a78f63c0f5687fad9e568308a0e47dbf67284169989720041a1776da2a2a54"
 dependencies = [
  "amq-protocol-uri",
- "log 0.4.11",
+ "log",
  "tcp-stream",
 ]
 
@@ -143,9 +143,9 @@ checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-trait"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1a4a2f97ce50c9d0282c1468816208588441492b40d813b2e0419c22c05e7f"
+checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
@@ -206,12 +206,6 @@ checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
 
 [[package]]
 name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
@@ -230,7 +224,7 @@ dependencies = [
  "env_logger",
  "fxhash",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "peeking_take_while",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
@@ -320,7 +314,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11f16001d679cb13d14b2c93c7d0fa13bb484a87c34a6c4c39707ad936499b5"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "chrono",
  "hex",
  "lazy_static",
@@ -708,7 +702,7 @@ dependencies = [
  "deadpool",
  "futures",
  "lapin",
- "log 0.4.11",
+ "log",
 ]
 
 [[package]]
@@ -887,7 +881,7 @@ checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.11",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -1219,12 +1213,12 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "bitflags",
  "bytes",
  "headers-core",
  "http",
- "mime 0.3.16",
+ "mime",
  "sha-1 0.8.2",
  "time 0.1.44",
 ]
@@ -1351,7 +1345,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "hyper",
- "log 0.4.11",
+ "log",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -2142,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "juniper"
 version = "0.14.2"
-source = "git+https://github.com/graphql-rust/juniper#368ea6f96f375e03d596cb848975264662e28ba2"
+source = "git+https://github.com/graphql-rust/juniper#2ab00f55d620c51b8732c97c90f8f3349c2e6a0b"
 dependencies = [
  "bson",
  "chrono",
@@ -2161,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "juniper_codegen"
 version = "0.14.2"
-source = "git+https://github.com/graphql-rust/juniper#368ea6f96f375e03d596cb848975264662e28ba2"
+source = "git+https://github.com/graphql-rust/juniper#2ab00f55d620c51b8732c97c90f8f3349c2e6a0b"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.19",
@@ -2189,7 +2183,7 @@ dependencies = [
  "async-task",
  "crossbeam-channel",
  "futures-core",
- "log 0.4.11",
+ "log",
  "mio 0.7.0",
  "parking_lot",
  "pinky-swear",
@@ -2276,15 +2270,6 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.11",
-]
-
-[[package]]
-name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
@@ -2366,30 +2351,9 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "mime"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-dependencies = [
- "log 0.3.9",
-]
-
-[[package]]
-name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "mime_guess"
-version = "1.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216929a5ee4dd316b1702eedf5e74548c123d370f47841ceaac38ca154690ca3"
-dependencies = [
- "mime 0.2.6",
- "phf 0.7.24",
- "phf_codegen",
- "unicase 1.4.2",
-]
 
 [[package]]
 name = "mime_guess"
@@ -2397,8 +2361,8 @@ version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
- "mime 0.3.16",
- "unicase 2.6.0",
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -2422,7 +2386,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.11",
+ "log",
  "miow 0.2.1",
  "net2",
  "slab",
@@ -2437,7 +2401,7 @@ checksum = "6e9971bc8349a361217a8f2a41f5d011274686bd4436465ba51730921039d7fb"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.11",
+ "log",
  "miow 0.3.5",
  "ntapi",
  "winapi 0.3.9",
@@ -2449,7 +2413,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
- "log 0.4.11",
+ "log",
  "mio 0.6.22",
  "miow 0.3.5",
  "winapi 0.3.9",
@@ -2499,7 +2463,7 @@ dependencies = [
  "difference",
  "httparse",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "rand 0.7.3",
  "regex",
  "serde_json",
@@ -2508,15 +2472,15 @@ dependencies = [
 
 [[package]]
 name = "multipart"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136eed74cadb9edd2651ffba732b19a450316b680e4f48d6c79e905799e19d01"
+checksum = "8209c33c951f07387a8497841122fc6f712165e3f9bda3e6be4645b58188f676"
 dependencies = [
  "buf_redux",
  "httparse",
- "log 0.4.11",
- "mime 0.2.6",
- "mime_guess 1.8.8",
+ "log",
+ "mime",
+ "mime_guess",
  "quick-error",
  "rand 0.6.5",
  "safemem",
@@ -2532,7 +2496,7 @@ checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.11",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2793,50 +2757,11 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.7.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
-dependencies = [
- "phf_shared 0.7.24",
-]
-
-[[package]]
-name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.7.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
-dependencies = [
- "phf_generator",
- "phf_shared 0.7.24",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.7.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
-dependencies = [
- "phf_shared 0.7.24",
- "rand 0.6.5",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.7.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
-dependencies = [
- "siphasher 0.2.3",
- "unicase 1.4.2",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2845,7 +2770,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 dependencies = [
- "siphasher 0.3.3",
+ "siphasher",
 ]
 
 [[package]]
@@ -2914,7 +2839,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81c5b25980f9a9b5ad36e9cdc855530575396d8a57f67e14691a2440ed0d9a90"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -3317,7 +3242,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3329,9 +3254,9 @@ dependencies = [
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.11",
- "mime 0.3.16",
- "mime_guess 2.0.3",
+ "log",
+ "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -3369,7 +3294,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -3396,8 +3321,8 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
- "base64 0.12.3",
- "log 0.4.11",
+ "base64",
+ "log",
  "ring",
  "sct",
  "webpki",
@@ -3409,7 +3334,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498854dcb920e6fde17046164487977a6177d1ccc5ea58379edb910e9e60a251"
 dependencies = [
- "log 0.4.11",
+ "log",
  "rustls",
  "rustls-native-certs",
  "webpki",
@@ -3671,12 +3596,6 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
-
-[[package]]
-name = "siphasher"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
@@ -3769,7 +3688,7 @@ version = "0.4.0-beta.1"
 source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#3aca4f97735624a3b9aee8574deb035190f6881b"
 dependencies = [
  "atoi",
- "base64 0.12.3",
+ "base64",
  "bitflags",
  "byteorder",
  "bytes",
@@ -3787,7 +3706,7 @@ dependencies = [
  "hmac",
  "itoa",
  "libc",
- "log 0.4.11",
+ "log",
  "lru-cache",
  "md-5",
  "memchr",
@@ -3945,7 +3864,7 @@ checksum = "2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "phf_shared 0.8.0",
+ "phf_shared",
  "precomputed-hash",
  "serde",
 ]
@@ -4288,10 +4207,10 @@ dependencies = [
  "bytes",
  "fallible-iterator",
  "futures",
- "log 0.4.11",
+ "log",
  "parking_lot",
  "percent-encoding",
- "phf 0.8.0",
+ "phf",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
@@ -4311,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228139ddd4fea3fa345a29233009635235833e52807af7ea6448ead03890d6a9"
+checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
@@ -4334,12 +4253,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
+checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
 dependencies = [
- "futures",
- "log 0.4.11",
+ "futures-util",
+ "log",
  "pin-project",
  "tokio",
  "tungstenite",
@@ -4354,7 +4273,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log 0.4.11",
+ "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -4381,7 +4300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
  "cfg-if",
- "log 0.4.11",
+ "log",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -4423,7 +4342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 dependencies = [
  "lazy_static",
- "log 0.4.11",
+ "log",
  "tracing-core",
 ]
 
@@ -4466,19 +4385,19 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
+checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
- "base64 0.11.0",
+ "base64",
  "byteorder",
  "bytes",
  "http",
  "httparse",
  "input_buffer",
- "log 0.4.11",
+ "log",
  "rand 0.7.3",
- "sha-1 0.8.2",
+ "sha-1 0.9.1",
  "url",
  "utf-8",
 ]
@@ -4503,15 +4422,6 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
-name = "unicase"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-dependencies = [
- "version_check 0.1.5",
-]
 
 [[package]]
 name = "unicase"
@@ -4678,24 +4588,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.11",
+ "log",
  "try-lock",
 ]
 
 [[package]]
 name = "warp"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df341dee97c9ae29dfa5e0b0fbbbf620e0d6a36686389bedf83b3daeb8b0d0ac"
+checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
 dependencies = [
  "bytes",
  "futures",
  "headers",
  "http",
  "hyper",
- "log 0.4.11",
- "mime 0.3.16",
- "mime_guess 2.0.3",
+ "log",
+ "mime",
+ "mime_guess",
  "multipart",
  "pin-project",
  "scoped-tls",
@@ -4742,7 +4652,7 @@ checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.39",
@@ -4795,7 +4705,7 @@ name = "wbem-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.12.3",
+ "base64",
  "bytes",
  "futures",
  "insta",

--- a/iml-gui/crate/Cargo.lock
+++ b/iml-gui/crate/Cargo.lock
@@ -276,6 +276,7 @@ version = "0.1.0"
 dependencies = [
  "iml-wire-types 0.3.0",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/iml-influx/Cargo.toml
+++ b/iml-influx/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 [dependencies]
 iml-wire-types = { path = "../iml-wire-types", version = "0.3" }
 serde = { version = "1", features = ['derive'] }
+serde_json = { version = "1" }

--- a/iml-influx/Cargo.toml
+++ b/iml-influx/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2018"
 iml-wire-types = { path = "../iml-wire-types", version = "0.3" }
 serde = { version = "1", features = ['derive'] }
 serde_json = { version = "1" }
+
+[dev-dependencies]
+influx_db_client = {version = "0.4", default-features = false, features = ["rustls-tls"]}

--- a/iml-influx/src/lib.rs
+++ b/iml-influx/src/lib.rs
@@ -40,3 +40,72 @@ impl From<ColVals> for serde_json::Value {
         Value::Array(xs)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use influx_db_client::keys::{Node, Series};
+    use serde_json::json;
+
+    #[test]
+    fn test_col_vals_to_value() {
+        let query_result = vec![Node {
+            statement_id: Some(0),
+            series: Some(vec![Series {
+                name: "col1".to_string(),
+                tags: None,
+                columns: vec!["time".into(), "col1".into(), "col2".into(), "col3".into()],
+                values: vec![
+                    vec![
+                        json!(1597166951257510515 as i64),
+                        json!("foo1"),
+                        json!("bar1"),
+                        json!("baz1"),
+                    ],
+                    vec![
+                        json!(1597166951257510515 as i64),
+                        json!("foo2"),
+                        json!("bar2"),
+                        json!("baz2"),
+                    ],
+                ],
+            }]),
+        }];
+
+        #[derive(Debug, serde::Deserialize, PartialEq)]
+        struct Record {
+            col1: String,
+            col2: String,
+            col3: String,
+        }
+
+        let records = query_result
+            .into_iter()
+            .filter_map(|x| x.series)
+            .flatten()
+            .map(|x| -> serde_json::Value { ColVals(x.columns, x.values).into() })
+            .map(|x| {
+                let x: Vec<Record> =
+                    serde_json::from_value(x).expect("Couldn't convert to record.");
+                x
+            })
+            .flatten()
+            .collect::<Vec<Record>>();
+
+        assert_eq!(
+            records,
+            vec![
+                Record {
+                    col1: "foo1".into(),
+                    col2: "bar1".into(),
+                    col3: "baz1".into(),
+                },
+                Record {
+                    col1: "foo2".into(),
+                    col2: "bar2".into(),
+                    col3: "baz2".into(),
+                }
+            ]
+        );
+    }
+}

--- a/iml-influx/src/lib.rs
+++ b/iml-influx/src/lib.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 pub mod filesystem;
 pub mod filesystems;
 
+use serde_json::{Map, Value};
+
 #[derive(serde::Deserialize, Clone, Debug)]
 pub struct InfluxResponse<T> {
     results: Vec<InfluxResult<T>>,
@@ -21,4 +23,20 @@ pub struct InfluxResult<T> {
 pub struct InfluxSeries<T> {
     tags: Option<HashMap<String, String>>,
     values: Vec<T>,
+}
+
+pub struct ColVals(pub Vec<String>, pub Vec<Vec<serde_json::Value>>);
+
+impl From<ColVals> for serde_json::Value {
+    fn from(ColVals(cols, vals): ColVals) -> Self {
+        let xs = vals
+            .into_iter()
+            .map(|y| -> Map<String, serde_json::Value> {
+                cols.clone().into_iter().zip(y).collect()
+            })
+            .map(Value::Object)
+            .collect();
+
+        Value::Array(xs)
+    }
 }

--- a/iml-services/iml-device/Cargo.toml
+++ b/iml-services/iml-device/Cargo.toml
@@ -9,6 +9,7 @@ device-types = {path = "../../device-scanner/device-types", version = "0.2"}
 futures = "0.3"
 im = {version = "15.0", features = ["serde"]}
 iml-change = {path = "../../iml-change", version = "0.1"}
+iml-influx = {path = "../../iml-influx", version = "0.1"}
 iml-manager-env = {path = "../../iml-manager-env", version = "0.3"}
 iml-postgres = {path = "../../iml-postgres", version = "0.3"}
 iml-rabbit = {path = "../../iml-rabbit", version = "0.3"}

--- a/iml-services/iml-device/src/lib.rs
+++ b/iml-services/iml-device/src/lib.rs
@@ -509,12 +509,15 @@ fn parse_filesystem_data(query_result: Option<Vec<Node>>) -> TargetFsRecord {
             .flatten()
             .map(|x| -> serde_json::Value { ColVals(x.columns, x.values).into() })
             .map(|x| {
-                let fs_record: FsRecord =
+                let fs_record: Vec<FsRecord> =
                     serde_json::from_value(x).expect("Couldn't convert to record.");
-
-                let filesystems: String = fs_record.filesystems();
-                let host: String = fs_record.host;
-                let target: String = fs_record.target;
+                fs_record
+            })
+            .flatten()
+            .map(|x| {
+                let filesystems: String = x.filesystems();
+                let host: String = x.host;
+                let target: String = x.target;
 
                 (
                     target,
@@ -868,6 +871,7 @@ mod tests {
         }]);
 
         let result = parse_filesystem_data(query_result);
+        println!("result: {:?}", result);
         assert_eq!(
             result,
             vec![(

--- a/iml-services/iml-device/src/snapshots/iml_device__tests__deletions_only.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__tests__deletions_only.snap
@@ -14,6 +14,8 @@ expression: xs
             "fs1",
         ],
         uuid: "123456",
-        mount_path: None,
+        mount_path: Some(
+            "/mnt/mdt1",
+        ),
     },
 ]

--- a/iml-services/iml-device/src/snapshots/iml_device__tests__upserts_and_deletions.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__tests__upserts_and_deletions.snap
@@ -14,7 +14,9 @@ expression: xs
             "fs1",
         ],
         uuid: "123456",
-        mount_path: None,
+        mount_path: Some(
+            "/mnt/mdt1",
+        ),
     },
     Target {
         state: "mounted",

--- a/iml-services/iml-stats/src/main.rs
+++ b/iml-services/iml-stats/src/main.rs
@@ -492,7 +492,7 @@ async fn main() -> Result<(), ImlStatsError> {
             get_influxdb_metrics_db(),
         );
 
-        delete_existing_mgs_fs_records(&xs, &client).await?;
+        delete_existing_mgs_fs_records(&xs, &host, &client).await?;
 
         let entries: Vec<_> = xs
             .into_iter()
@@ -525,6 +525,7 @@ async fn main() -> Result<(), ImlStatsError> {
 
 async fn delete_existing_mgs_fs_records(
     xs: &[Record],
+    host: &Fqdn,
     client: &Client,
 ) -> Result<(), ImlStatsError> {
     let filtered_records = xs
@@ -542,8 +543,9 @@ async fn delete_existing_mgs_fs_records(
         let r = client
             .query(
                 format!(
-                    "SELECT target,mgs_fs FROM target WHERE target='{}'",
-                    x.target.to_string()
+                    "SELECT target,mgs_fs FROM target WHERE target='{}' AND host='{}'",
+                    x.target.to_string(),
+                    &host.0
                 )
                 .as_str(),
                 Some(Precision::Nanoseconds),


### PR DESCRIPTION
The MGS target has the same name for multiple filesystems. As an
example, a filesystem created with an MGT on MDS1 and a filesystem
created with an MGT on OSS1 will both have a target name of `MGS`. This
needs to be accounted for when building the target table.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2196)
<!-- Reviewable:end -->
