### PR TITLE
EX-1629 - Ensure client-mounts do not pickup snapshot mounts

### DIFF
--- a/iml-services/iml-device/src/lib.rs
+++ b/iml-services/iml-device/src/lib.rs
@@ -344,7 +344,7 @@ pub fn find_targets<'a>(
         .map(|(k, xs)| xs.into_iter().map(move |x| (k, x)))
         .flatten()
         .filter(|(_, x)| x.fs_type.0 == "lustre")
-        .filter(|(_, x)| x.opts.0.split(',').find(|x| x == &"nomgs").is_some())
+        .filter(|(_, x)| x.opts.0.split(',').any(|x| x == "nomgs"))
         .filter_map(|(_, x)| {
             let s = x.opts.0.split(',').find(|x| x.starts_with("svname="))?;
 

--- a/iml-services/iml-device/src/main.rs
+++ b/iml-services/iml-device/src/main.rs
@@ -134,7 +134,7 @@ async fn main() -> Result<(), ImlDeviceError> {
                 .await?;
 
         let target_to_fs_map = get_target_filesystem_map(&influx_client).await?;
-        let mgs_targets_to_fs_map = get_mgs_filesystem_map(&influx_client).await?;
+        let mgs_targets_to_fs_map = get_mgs_filesystem_map(&influx_client, &mount_cache).await?;
         let target_to_fs_map: TargetFsRecord = target_to_fs_map
             .into_iter()
             .chain(mgs_targets_to_fs_map)


### PR DESCRIPTION
ref:
```
chroma=> select * from chroma_core_lustreclientmount;
 id |       state_modified_at       |  state  | immutable_state | not_deleted | content_type_id | filesystem | host_id | mountpoints
----+-------------------------------+---------+-----------------+-------------+-----------------+------------+---------+--------------
  1 | 2020-08-28 20:04:24.747547+00 | mounted | f               | t           |              41 | 35efda93   |       5 | {/mnt/wut}
  2 | 2020-08-28 20:04:24.755229+00 | mounted | f               | t           |              41 | zfsmo      |       5 | {/mnt/zfsmo}
(2 rows)
``` 
The first mount here is a snapshot mount and should not make it into this table.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2203)
<!-- Reviewable:end -->
