### PR TITLE
Add debugql subcommand to manager

### DIFF
--- a/iml-graphql-queries/src/lib.rs
+++ b/iml-graphql-queries/src/lib.rs
@@ -10,8 +10,8 @@ use std::fmt;
 /// to the graphql server
 #[derive(serde::Serialize, Debug)]
 pub struct Query<T: serde::Serialize> {
-    query: String,
-    variables: Option<T>,
+    pub query: String,
+    pub variables: Option<T>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]

--- a/iml-manager-cli/src/api.rs
+++ b/iml-manager-cli/src/api.rs
@@ -4,6 +4,8 @@
 
 use crate::error::ImlManagerCliError;
 use console::Term;
+use iml_graphql_queries::Query;
+use iml_manager_client::Url;
 use structopt::{clap::arg_enum, StructOpt};
 use tokio::io::{stdin, AsyncReadExt};
 
@@ -31,12 +33,42 @@ pub struct ApiCommand {
     body: Option<String>,
 }
 
+#[derive(Debug, StructOpt)]
+pub struct GraphQlCommand {
+    #[structopt(possible_values = &ApiMethod::variants(), case_insensitive = true)]
+    method: ApiMethod,
+
+    query: String,
+
+    variables: Option<String>,
+}
+
 pub async fn api_cli(command: ApiCommand) -> Result<(), ImlManagerCliError> {
-    let term = Term::stdout();
-    let client = iml_manager_client::get_client()?;
     let uri = iml_manager_client::create_api_url(command.path)?;
 
-    let req = match command.method {
+    api_command(command.method, uri, command.body).await
+}
+
+pub async fn graphql_cli(command: GraphQlCommand) -> Result<(), ImlManagerCliError> {
+    let uri = iml_manager_client::create_url("/graphql")?;
+
+    let query = Query {
+        query: command.query,
+        variables: command.variables,
+    };
+
+    api_command(command.method, uri, serde_json::to_string(&query).ok()).await
+}
+
+async fn api_command(
+    method: ApiMethod,
+    uri: Url,
+    body: Option<String>,
+) -> Result<(), ImlManagerCliError> {
+    let term = Term::stdout();
+    let client = iml_manager_client::get_client()?;
+
+    let req = match method {
         ApiMethod::Delete => client.delete(uri),
         ApiMethod::Get => client.get(uri),
         ApiMethod::Head => client.head(uri),
@@ -45,16 +77,17 @@ pub async fn api_cli(command: ApiCommand) -> Result<(), ImlManagerCliError> {
         ApiMethod::Put => client.put(uri),
     };
 
-    let body: Option<serde_json::Value> = if command.body == Some("-".to_string()) {
+    let body: Option<serde_json::Value> = if body == Some("-".to_string()) {
         let mut buf: Vec<u8> = Vec::new();
         stdin().read_to_end(&mut buf).await?;
         let s = String::from_utf8_lossy(&buf);
         Some(serde_json::from_str(&s)?)
     } else {
-        command.body.map(|s| serde_json::from_str(&s)).transpose()?
+        body.map(|s| serde_json::from_str(&s)).transpose()?
     };
 
     let req = if let Some(data) = body {
+        tracing::debug!("Requesting: {}", &data);
         req.json(&data)
     } else {
         req

--- a/iml-manager-cli/src/main.rs
+++ b/iml-manager-cli/src/main.rs
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 use iml_manager_cli::{
-    api::{self, api_cli},
+    api::{self, api_cli, graphql_cli},
     display_utils::display_error,
     filesystem::{self, filesystem_cli},
     server::{self, server_cli},
@@ -50,6 +50,10 @@ pub enum App {
     #[structopt(name = "debugapi", setting = structopt::clap::AppSettings::Hidden)]
     /// Direct API Access (for testing and debug)
     DebugApi(api::ApiCommand),
+
+    #[structopt(name = "debugql", setting = structopt::clap::AppSettings::Hidden)]
+    /// Direct GraphQL Access (for testing and debug)
+    DebugQl(api::GraphQlCommand),
 }
 
 #[tokio::main]
@@ -64,6 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let r = match matches {
         App::DebugApi(command) => api_cli(command).await,
+        App::DebugQl(command) => graphql_cli(command).await,
         App::Filesystem { command } => filesystem_cli(command).await,
         App::Server { command } => server_cli(command).await,
         App::Snapshot { command } => snapshot_cli(command).await,

--- a/iml-manager-client/src/lib.rs
+++ b/iml-manager-client/src/lib.rs
@@ -82,6 +82,17 @@ pub fn get_client() -> Result<Client, ImlManagerClientError> {
         .map_err(ImlManagerClientError::Reqwest)
 }
 
+/// Given a path, constructs a url
+pub fn create_url(path: impl ToString) -> Result<Url, ImlManagerClientError> {
+    let path = path.to_string();
+
+    let url = Url::parse(&iml_manager_env::get_manager_url())?
+        .join("/")?
+        .join(path.trim_start_matches('/'))?;
+
+    Ok(url)
+}
+
 /// Given a path, constructs a full API url
 pub fn create_api_url(path: impl ToString) -> Result<Url, ImlManagerClientError> {
     let mut path = path.to_string();


### PR DESCRIPTION
The -r option will result in `iml debugapi -r POST graphql DATA`
talking to /graphql instead of /api/graphql/

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2209)
<!-- Reviewable:end -->
