### PR TITLE
Add Snapshots to iml-warp-drive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -624,12 +624,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -719,7 +719,7 @@ checksum = "3df5480412da86cdf5d6b7f3b682422c84359ff7399aa658df1d15ee83244b1d"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -818,10 +818,11 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dns-lookup"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbea23c15f7e685a7ad01c994407f3849fa7c88556aaafe4054215b6df93f78"
+checksum = "8f69635ffdfbaea44241d7cca30a5e3a2e1c892613a6a8ad8ef03deeb6803480"
 dependencies = [
+ "cfg-if",
  "libc",
  "socket2",
  "winapi 0.3.9",
@@ -928,7 +929,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -954,9 +955,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "find-crate"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e81c4ad4d20c0ce823cdf5f642cc3f58e6358096ba56e58ef20d41ae30929c38"
+checksum = "057a1d48e8ff33649ee2d7c510b79ecf1f8a52b684d446a72de600ad7e2823b6"
 dependencies = [
  "toml",
 ]
@@ -1043,14 +1044,14 @@ checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
 name = "futures-enum"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b939890c74b883c3cad11a50bcf10b63e655882f5af312e904bf6b83faa4501"
+checksum = "56b858f13b6a7a4ef32d4f7e2382ef3556f150f99ad2146e4bc481165dc2083c"
 dependencies = [
  "derive_utils",
  "find-crate",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -1079,7 +1080,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -1212,6 +1213,12 @@ dependencies = [
  "ahash",
  "autocfg 1.0.1",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 
 [[package]]
 name = "headers"
@@ -1650,7 +1657,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.2.17",
+ "time 0.2.18",
  "tokio",
 ]
 
@@ -2015,25 +2022,23 @@ dependencies = [
  "iml-api-utils",
  "iml-change",
  "juniper",
- "postgres-types",
  "serde",
  "serde_json",
  "serde_repr",
  "sqlx",
  "structopt",
  "thiserror",
- "tokio-postgres",
  "wbem-client",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e47a3566dd4fd4eec714ae6ceabdee0caec795be835c223d92c2d40f1e8cf1c"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown",
+ "hashbrown 0.9.0",
  "serde",
 ]
 
@@ -2182,7 +2187,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -2530,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
+checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2753,7 +2758,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -2812,7 +2817,7 @@ checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -2845,17 +2850,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
-name = "postgres-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c857dd221cb0e7d8414b894a0ce29eae44d453dda0baa132447878e75e701477"
-dependencies = [
- "proc-macro2 1.0.20",
- "quote 1.0.7",
- "syn 1.0.39",
-]
-
-[[package]]
 name = "postgres-protocol"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,10 +2875,7 @@ checksum = "3d14b0a4f433b0e0b565bb0fbc0ac9fc3d79ca338ba265ad0e7eef0f3bcc5e94"
 dependencies = [
  "bytes",
  "fallible-iterator",
- "postgres-derive",
  "postgres-protocol",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2922,7 +2913,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
  "version_check 0.9.2",
 ]
 
@@ -3497,7 +3488,7 @@ checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -3520,7 +3511,7 @@ checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -3723,7 +3714,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "hashbrown",
+ "hashbrown 0.8.2",
  "hex",
  "hmac",
  "itoa",
@@ -3745,7 +3736,7 @@ dependencies = [
  "sqlx-rt",
  "stringprep",
  "thiserror",
- "time 0.2.17",
+ "time 0.2.18",
  "url",
  "whoami",
 ]
@@ -3769,7 +3760,7 @@ dependencies = [
  "sha2",
  "sqlx-core",
  "sqlx-rt",
- "syn 1.0.39",
+ "syn 1.0.40",
  "url",
 ]
 
@@ -3823,7 +3814,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -3839,7 +3830,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -3928,7 +3919,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -3966,9 +3957,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
@@ -4095,7 +4086,7 @@ checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -4120,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7ec98a72285d12e0febb26f0847b12d54be24577618719df654c66cadab55d"
+checksum = "12785163ae8a1cbb52a5db39af4a5baabd3fe49f07f76f952f89d7e89e5ce531"
 dependencies = [
  "const_fn",
  "libc",
@@ -4154,7 +4145,7 @@ dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
  "standback",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -4205,7 +4196,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -4335,7 +4326,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -4525,7 +4516,7 @@ checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
 ]
 
 [[package]]
@@ -4677,7 +4668,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
  "wasm-bindgen-shared",
 ]
 
@@ -4711,7 +4702,7 @@ checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
- "syn 1.0.39",
+ "syn 1.0.40",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -445,8 +445,8 @@ async fn active_mgs_host_fqdn(
     let fsnames = &[fsname.into()][..];
     let maybe_active_mgs_host_id = sqlx::query!(
         r#"
-            select active_host_id from targets where filesystems @> $1 and name='MGS'
-            "#,
+            SELECT active_host_id from target WHERE filesystems @> $1 and name='MGS'
+        "#,
         fsnames
     )
     .fetch_optional(pool)
@@ -458,8 +458,8 @@ async fn active_mgs_host_fqdn(
     if let Some(active_mgs_host_id) = maybe_active_mgs_host_id {
         let active_mgs_host_fqdn = sqlx::query!(
             r#"
-                select fqdn from chroma_core_managedhost where id=$1 and not_deleted = 't'
-                "#,
+                SELECT fqdn FROM chroma_core_managedhost WHERE id=$1 and not_deleted = 't'
+            "#,
             active_mgs_host_id
         )
         .fetch_one(pool)

--- a/iml-gui/crate/Cargo.lock
+++ b/iml-gui/crate/Cargo.lock
@@ -134,9 +134,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -193,11 +193,8 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "idna"
@@ -293,11 +290,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -395,9 +392,9 @@ name = "pin-project-internal"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -417,7 +414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -439,7 +436,7 @@ name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -489,7 +486,7 @@ dependencies = [
  "enclose 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gloo-timers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -513,9 +510,9 @@ name = "serde_derive"
 version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -533,9 +530,9 @@ name = "serde_repr"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -565,10 +562,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -681,9 +678,9 @@ dependencies = [
  "bumpalo 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -712,9 +709,9 @@ name = "wasm-bindgen-macro-support"
 version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -742,7 +739,7 @@ name = "wasm-bindgen-test-macro"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -798,11 +795,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 "checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum gloo-timers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
-"checksum hashbrown 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+"checksum hashbrown 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum im 15.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
-"checksum indexmap 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
+"checksum indexmap 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 "checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum js-sys 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)" = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -821,7 +818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pin-utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 "checksum proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)" = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 "checksum proc-macro-nested 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
-"checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+"checksum proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
 "checksum pulldown-cmark 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1c205cc82214f3594e2d50686730314f817c67ffa80fe800cf0db78c3c2b9d9e"
 "checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -838,7 +835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sized-chunks 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+"checksum syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
 "checksum time 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 "checksum tinyvec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 "checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"

--- a/iml-gui/crate/src/components/stratagem/mod.rs
+++ b/iml-gui/crate/src/components/stratagem/mod.rs
@@ -165,14 +165,14 @@ fn can_enable(fs: &Arc<Filesystem>, cache: &ArcCache) -> bool {
 fn handle_stratagem_config_update(config: &mut Config, conf: &Arc<StratagemConfiguration>) {
     config.id = Some(conf.id);
 
-    duration_picker::calculate_value_and_unit(&mut config.scan_duration_picker, conf.interval);
+    duration_picker::calculate_value_and_unit(&mut config.scan_duration_picker, conf.interval as u64);
 
     match conf.report_duration {
         None => {
             config.report_duration_picker.value = None;
         }
         Some(x) => {
-            duration_picker::calculate_value_and_unit(&mut config.report_duration_picker, x);
+            duration_picker::calculate_value_and_unit(&mut config.report_duration_picker, x as u64);
         }
     }
 
@@ -181,13 +181,13 @@ fn handle_stratagem_config_update(config: &mut Config, conf: &Arc<StratagemConfi
             config.purge_duration_picker.value = None;
         }
         Some(x) => {
-            duration_picker::calculate_value_and_unit(&mut config.purge_duration_picker, x);
+            duration_picker::calculate_value_and_unit(&mut config.purge_duration_picker, x as u64);
         }
     }
 
-    if conf.interval == config.target_config.interval
-        && conf.report_duration == config.target_config.report_duration
-        && conf.purge_duration == config.target_config.purge_duration
+    if conf.interval as u64 == config.target_config.interval
+        && conf.report_duration.map(|x| x as u64) == config.target_config.report_duration
+        && conf.purge_duration.map(|x| x as u64) == config.target_config.purge_duration
     {
         config.disabled = false;
     }

--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -694,6 +694,9 @@ fn handle_record_change(
                 ArcRecord::SfaController(x) => {
                     model.records.sfa_controller.insert(x.id, Arc::clone(&x));
                 }
+                ArcRecord::Snapshot(x) => {
+                    model.records.snapshot.insert(x.id, Arc::clone(&x));
+                }
                 ArcRecord::StratagemConfig(x) => {
                     model.records.stratagem_config.insert(x.id, Arc::clone(&x));
 

--- a/iml-gui/crate/src/test_utils/fixtures.rs
+++ b/iml-gui/crate/src/test_utils/fixtures.rs
@@ -15,6 +15,7 @@ pub(crate) fn get_cache() -> Cache {
   "sfa_job": {},
   "sfa_power_supply": {},
   "sfa_controller": {},
+  "snapshot": {},
   "active_alert": {
     "577": {
       "_message": "Updates are ready for server oss1.local",
@@ -546,7 +547,8 @@ pub(crate) fn get_cache() -> Cache {
       "host_id": 1,
       "immutable_state": false,
       "not_deleted": true,
-      "content_type_id": 52
+      "content_type_id": 52,
+      "state_modified_at": "1990-12-31T23:59:60Z"
     },
     "2": {
       "id": 2,
@@ -554,7 +556,8 @@ pub(crate) fn get_cache() -> Cache {
       "host_id": 2,
       "immutable_state": false,
       "not_deleted": true,
-      "content_type_id": 52
+      "content_type_id": 52,
+      "state_modified_at": "1990-12-31T23:59:60Z"
     },
     "3": {
       "id": 3,
@@ -562,7 +565,8 @@ pub(crate) fn get_cache() -> Cache {
       "host_id": 3,
       "immutable_state": false,
       "not_deleted": true,
-      "content_type_id": 52
+      "content_type_id": 52,
+      "state_modified_at": "1990-12-31T23:59:60Z"
     },
     "4": {
       "id": 4,
@@ -570,7 +574,8 @@ pub(crate) fn get_cache() -> Cache {
       "host_id": 4,
       "immutable_state": false,
       "not_deleted": true,
-      "content_type_id": 52
+      "content_type_id": 52,
+      "state_modified_at": "1990-12-31T23:59:60Z"
     },
     "11": {
       "id": 11,
@@ -578,7 +583,8 @@ pub(crate) fn get_cache() -> Cache {
       "host_id": 11,
       "immutable_state": false,
       "not_deleted": true,
-      "content_type_id": 52
+      "content_type_id": 52,
+      "state_modified_at": "1990-12-31T23:59:60Z"
     }
   },
   "managed_target_mount": {

--- a/iml-warp-drive/src/db_record.rs
+++ b/iml-warp-drive/src/db_record.rs
@@ -20,6 +20,7 @@ use iml_wire_types::{
         SFA_CONTROLLER_TABLE_NAME, SFA_DISK_DRIVE_TABLE_NAME, SFA_ENCLOSURE_TABLE_NAME,
         SFA_JOB_TABLE_NAME, SFA_POWER_SUPPLY_TABLE_NAME, SFA_STORAGE_SYSTEM_TABLE_NAME,
     },
+    snapshot::SnapshotRecord,
 };
 use serde::de::Error;
 use std::convert::TryFrom;
@@ -48,6 +49,7 @@ pub enum DbRecord {
     SfaJob(SfaJob),
     SfaPowerSupply(SfaPowerSupply),
     SfaController(SfaController),
+    Snapshot(SnapshotRecord),
     StratagemConfiguration(StratagemConfiguration),
     Volume(VolumeRecord),
     VolumeNode(VolumeNodeRecord),

--- a/iml-warp-drive/src/db_record.rs
+++ b/iml-warp-drive/src/db_record.rs
@@ -20,7 +20,7 @@ use iml_wire_types::{
         SFA_CONTROLLER_TABLE_NAME, SFA_DISK_DRIVE_TABLE_NAME, SFA_ENCLOSURE_TABLE_NAME,
         SFA_JOB_TABLE_NAME, SFA_POWER_SUPPLY_TABLE_NAME, SFA_STORAGE_SYSTEM_TABLE_NAME,
     },
-    snapshot::SnapshotRecord,
+    snapshot::{SnapshotRecord, SNAPSHOT_TABLE_NAME},
 };
 use serde::de::Error;
 use std::convert::TryFrom;
@@ -88,6 +88,7 @@ impl TryFrom<(TableName<'_>, serde_json::Value)> for DbRecord {
             STRATAGEM_CONFIGURATION_TABLE_NAME => {
                 serde_json::from_value(x).map(DbRecord::StratagemConfiguration)
             }
+            SNAPSHOT_TABLE_NAME => serde_json::from_value(x).map(DbRecord::Snapshot),
             LNET_CONFIGURATION_TABLE_NAME => {
                 serde_json::from_value(x).map(DbRecord::LnetConfiguration)
             }

--- a/iml-warp-drive/src/main.rs
+++ b/iml-warp-drive/src/main.rs
@@ -4,6 +4,7 @@
 
 use futures::{lock::Mutex, FutureExt, TryFutureExt, TryStreamExt};
 use iml_manager_client::get_client;
+use iml_postgres::get_db_pool;
 use iml_warp_drive::{
     cache::{populate_from_api, populate_from_db, SharedCache},
     error, listen,
@@ -79,9 +80,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Started listening to NOTIFY events");
 
     {
-        let mut c = shared_client.lock().await;
+        let pool = get_db_pool(2).await?;
 
-        populate_from_db(Arc::clone(&api_cache_state3), &mut c).await?;
+        populate_from_db(Arc::clone(&api_cache_state3), &pool).await?;
     }
 
     let pool = iml_rabbit::connect_to_rabbit(1);

--- a/iml-wire-types/Cargo.toml
+++ b/iml-wire-types/Cargo.toml
@@ -13,18 +13,16 @@ im = {version = "15.0", features = ["serde"]}
 iml-api-utils = {path = "../iml-api-utils", version = "0.3"}
 iml-change = {path = "../iml-change", version = "0.1", optional = true}
 juniper = {git = "https://github.com/graphql-rust/juniper", optional = true}
-postgres-types = {version = "0.1", features = ["derive"], optional = true}
 serde = {version = "1", features = ["derive"]}
 serde_json = "1.0"
 serde_repr = "0.1"
 sqlx = {git = "https://github.com/jgrund/sqlx", branch = "support-offline-workspaces", default-features = false, features = ["json", "macros", "offline", "postgres", "runtime-tokio", "time", "chrono"], optional = true}
 structopt = {version = "0.3", optional = true}
 thiserror = {version = "1.0", optional = true}
-tokio-postgres = {version = "0.5", features = ["with-serde_json-1"], optional = true}
 wbem-client = {path = "../wbem-client", version = "0.1", optional = true}
 
 [features]
 cli = ["structopt"]
 graphql = ["juniper"]
-postgres-interop = ["tokio-postgres", "postgres-types", "bytes", "sqlx"]
+postgres-interop = ["bytes", "sqlx"]
 wbem-interop = ["wbem-client", "thiserror", "iml-change"]

--- a/iml-wire-types/src/db.rs
+++ b/iml-wire-types/src/db.rs
@@ -4,18 +4,11 @@
 
 use crate::CompositeId;
 use crate::ToCompositeId;
-use crate::{EndpointName, Fqdn, Label};
+use crate::{EndpointName, Label};
 use chrono::{offset::Utc, DateTime};
+#[cfg(feature = "postgres-interop")]
+use std::str::FromStr;
 use std::{collections::BTreeSet, fmt, ops::Deref, path::PathBuf};
-
-#[cfg(feature = "postgres-interop")]
-use bytes::BytesMut;
-#[cfg(feature = "postgres-interop")]
-use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
-#[cfg(feature = "postgres-interop")]
-use std::{io, str::FromStr};
-#[cfg(feature = "postgres-interop")]
-use tokio_postgres::Row;
 
 pub trait Id {
     /// Returns the `Id` (`i32`).
@@ -70,17 +63,6 @@ pub const CONTENT_TYPE_TABLE_NAME: TableName = TableName("django_content_type");
 impl Name for ContentTypeRecord {
     fn table_name() -> TableName<'static> {
         CONTENT_TYPE_TABLE_NAME
-    }
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for ContentTypeRecord {
-    fn from(row: Row) -> Self {
-        ContentTypeRecord {
-            id: row.get::<_, i32>("id"),
-            app_label: row.get("app_label"),
-            model: row.get("model"),
-        }
     }
 }
 
@@ -172,7 +154,7 @@ impl Name for FsRecord {
 pub struct VolumeRecord {
     pub id: i32,
     pub storage_resource_id: Option<i32>,
-    pub size: Option<u64>,
+    pub size: Option<i64>,
     pub label: String,
     pub filesystem_type: Option<String>,
     pub not_deleted: Option<bool>,
@@ -199,21 +181,6 @@ impl Name for VolumeRecord {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for VolumeRecord {
-    fn from(row: Row) -> Self {
-        VolumeRecord {
-            id: row.get::<_, i32>("id"),
-            size: row.get::<_, Option<i64>>("size").map(|x| x as u64),
-            label: row.get("label"),
-            filesystem_type: row.get("filesystem_type"),
-            usable_for_lustre: row.get("usable_for_lustre"),
-            not_deleted: row.get("not_deleted"),
-            storage_resource_id: row.get::<_, Option<i32>>("storage_resource_id"),
-        }
-    }
-}
-
 /// Record from the `chroma_core_volumenode` table
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct VolumeNodeRecord {
@@ -223,8 +190,7 @@ pub struct VolumeNodeRecord {
     pub path: String,
     pub storage_resource_id: Option<i32>,
     pub primary: bool,
-    #[serde(rename = "use")]
-    pub _use: bool,
+    pub r#use: bool,
     pub not_deleted: Option<bool>,
 }
 
@@ -266,22 +232,6 @@ impl Name for VolumeNodeRecord {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for VolumeNodeRecord {
-    fn from(row: Row) -> Self {
-        VolumeNodeRecord {
-            id: row.get::<_, i32>("id"),
-            volume_id: row.get::<_, i32>("volume_id"),
-            host_id: row.get::<_, i32>("host_id"),
-            path: row.get("path"),
-            storage_resource_id: row.get::<_, Option<i32>>("storage_resource_id"),
-            primary: row.get("primary"),
-            _use: row.get("use"),
-            not_deleted: row.get("not_deleted"),
-        }
-    }
-}
-
 /// Record from the `chroma_core_managedtargetmount` table
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Clone, Debug)]
 pub struct ManagedTargetMountRecord {
@@ -303,21 +253,6 @@ impl Id for ManagedTargetMountRecord {
 impl NotDeleted for ManagedTargetMountRecord {
     fn not_deleted(&self) -> bool {
         not_deleted(self.not_deleted)
-    }
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for ManagedTargetMountRecord {
-    fn from(row: Row) -> Self {
-        ManagedTargetMountRecord {
-            id: row.get::<_, i32>("id"),
-            host_id: row.get::<_, i32>("host_id"),
-            mount_point: row.get("mount_point"),
-            volume_node_id: row.get::<_, i32>("volume_node_id"),
-            primary: row.get("primary"),
-            target_id: row.get::<_, i32>("target_id"),
-            not_deleted: row.get("not_deleted"),
-        }
     }
 }
 
@@ -397,19 +332,6 @@ impl NotDeleted for OstPoolRecord {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for OstPoolRecord {
-    fn from(row: Row) -> Self {
-        OstPoolRecord {
-            id: row.get::<_, i32>("id"),
-            name: row.get("name"),
-            filesystem_id: row.get::<_, i32>("filesystem_id"),
-            not_deleted: row.get("not_deleted"),
-            content_type_id: row.get::<_, Option<i32>>("content_type_id"),
-        }
-    }
-}
-
 pub const OSTPOOL_TABLE_NAME: TableName = TableName("chroma_core_ostpool");
 
 impl Name for OstPoolRecord {
@@ -441,17 +363,6 @@ pub struct OstPoolOstsRecord {
 impl Id for OstPoolOstsRecord {
     fn id(&self) -> i32 {
         self.id
-    }
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for OstPoolOstsRecord {
-    fn from(row: Row) -> Self {
-        OstPoolOstsRecord {
-            id: row.get::<_, i32>("id"),
-            ostpool_id: row.get::<_, i32>("ostpool_id"),
-            managedost_id: row.get::<_, i32>("managedost_id"),
-        }
     }
 }
 
@@ -609,32 +520,13 @@ impl Name for AlertStateRecord {
 pub struct StratagemConfiguration {
     pub id: i32,
     pub filesystem_id: i32,
-    pub interval: u64,
-    pub report_duration: Option<u64>,
-    pub purge_duration: Option<u64>,
+    pub interval: i64,
+    pub report_duration: Option<i64>,
+    pub purge_duration: Option<i64>,
     pub immutable_state: bool,
     pub not_deleted: Option<bool>,
     pub state: String,
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for StratagemConfiguration {
-    fn from(row: Row) -> Self {
-        StratagemConfiguration {
-            id: row.get::<_, i32>("id"),
-            filesystem_id: row.get::<_, i32>("filesystem_id"),
-            interval: row.get::<_, i64>("interval") as u64,
-            report_duration: row
-                .get::<_, Option<i64>>("report_duration")
-                .map(|x| x as u64),
-            purge_duration: row
-                .get::<_, Option<i64>>("purge_duration")
-                .map(|x| x as u64),
-            immutable_state: row.get("immutable_state"),
-            not_deleted: row.get("not_deleted"),
-            state: row.get("state"),
-        }
-    }
+    pub state_modified_at: DateTime<Utc>,
 }
 
 impl Id for StratagemConfiguration {
@@ -679,20 +571,7 @@ pub struct LnetConfigurationRecord {
     pub immutable_state: bool,
     pub not_deleted: Option<bool>,
     pub content_type_id: Option<i32>,
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for LnetConfigurationRecord {
-    fn from(row: Row) -> Self {
-        LnetConfigurationRecord {
-            id: row.get::<_, i32>("id"),
-            state: row.get("state"),
-            host_id: row.get::<_, i32>("host_id"),
-            immutable_state: row.get("immutable_state"),
-            not_deleted: row.get("not_deleted"),
-            content_type_id: row.get::<_, Option<i32>>("content_type_id"),
-        }
-    }
+    pub state_modified_at: DateTime<Utc>,
 }
 
 impl Id for LnetConfigurationRecord {
@@ -744,37 +623,6 @@ impl Name for LnetConfigurationRecord {
 )]
 pub struct DeviceId(String);
 
-#[cfg(feature = "postgres-interop")]
-impl ToSql for DeviceId {
-    fn to_sql(
-        &self,
-        ty: &Type,
-        w: &mut BytesMut,
-    ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
-        <&str as ToSql>::to_sql(&&*self.0, ty, w)
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <&str as ToSql>::accepts(ty)
-    }
-
-    to_sql_checked!();
-}
-
-#[cfg(feature = "postgres-interop")]
-impl<'a> FromSql<'a> for DeviceId {
-    fn from_sql(
-        ty: &Type,
-        raw: &'a [u8],
-    ) -> Result<DeviceId, Box<dyn std::error::Error + Sync + Send>> {
-        FromSql::from_sql(ty, raw).map(DeviceId)
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <String as FromSql>::accepts(ty)
-    }
-}
-
 impl Deref for DeviceId {
     type Target = String;
 
@@ -794,75 +642,8 @@ impl Deref for DeviceIds {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl ToSql for DeviceIds {
-    fn to_sql(
-        &self,
-        ty: &Type,
-        w: &mut BytesMut,
-    ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
-        let xs = self.0.iter().collect::<Vec<_>>();
-        <&[&DeviceId] as ToSql>::to_sql(&&*xs, ty, w)
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <&[&DeviceId] as ToSql>::accepts(ty)
-    }
-
-    to_sql_checked!();
-}
-
-#[cfg(feature = "postgres-interop")]
-impl<'a> FromSql<'a> for DeviceIds {
-    fn from_sql(
-        ty: &Type,
-        raw: &'a [u8],
-    ) -> Result<DeviceIds, Box<dyn std::error::Error + Sync + Send>> {
-        <Vec<DeviceId> as FromSql>::from_sql(ty, raw).map(|xs| DeviceIds(xs.into_iter().collect()))
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <Vec<DeviceId> as FromSql>::accepts(ty)
-    }
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct Size(pub u64);
-
-#[cfg(feature = "postgres-interop")]
-impl ToSql for Size {
-    fn to_sql(
-        &self,
-        ty: &Type,
-        w: &mut BytesMut,
-    ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
-        <&str as ToSql>::to_sql(&&*self.0.to_string(), ty, w)
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <&str as ToSql>::accepts(ty)
-    }
-
-    to_sql_checked!();
-}
-
-#[cfg(feature = "postgres-interop")]
-impl<'a> FromSql<'a> for Size {
-    fn from_sql(
-        ty: &Type,
-        raw: &'a [u8],
-    ) -> Result<Size, Box<dyn std::error::Error + Sync + Send>> {
-        <String as FromSql>::from_sql(ty, raw).and_then(|x| {
-            x.parse::<u64>()
-                .map(Size)
-                .map_err(|e| -> Box<dyn std::error::Error + Sync + Send> { Box::new(e) })
-        })
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <String as FromSql>::accepts(ty)
-    }
-}
 
 /// The current type of Devices we support
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
@@ -892,88 +673,6 @@ impl std::fmt::Display for DeviceType {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl ToSql for DeviceType {
-    fn to_sql(
-        &self,
-        ty: &Type,
-        w: &mut BytesMut,
-    ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
-        <String as ToSql>::to_sql(&format!("{}", self), ty, w)
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <String as ToSql>::accepts(ty)
-    }
-
-    to_sql_checked!();
-}
-
-#[cfg(feature = "postgres-interop")]
-impl<'a> FromSql<'a> for DeviceType {
-    fn from_sql(
-        ty: &Type,
-        raw: &'a [u8],
-    ) -> Result<DeviceType, Box<dyn std::error::Error + Sync + Send>> {
-        FromSql::from_sql(ty, raw).and_then(|x| match x {
-            "scsi" => Ok(DeviceType::ScsiDevice),
-            "partition" => Ok(DeviceType::Partition),
-            "mdraid" => Ok(DeviceType::MdRaid),
-            "mpath" => Ok(DeviceType::Mpath),
-            "vg" => Ok(DeviceType::VolumeGroup),
-            "lv" => Ok(DeviceType::LogicalVolume),
-            "zpool" => Ok(DeviceType::Zpool),
-            "dataset" => Ok(DeviceType::Dataset),
-            _ => {
-                let e: Box<dyn std::error::Error + Sync + Send> = Box::new(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "Unknown DeviceType variant",
-                ));
-
-                Err(e)
-            }
-        })
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <String as FromSql>::accepts(ty)
-    }
-}
-
-/// A device (Block or Virtual).
-/// These should be unique per cluster
-#[derive(Debug, PartialEq, Eq)]
-pub struct Device {
-    pub id: DeviceId,
-    pub size: Size,
-    pub usable_for_lustre: bool,
-    pub device_type: DeviceType,
-    pub parents: DeviceIds,
-    pub children: DeviceIds,
-}
-
-pub const DEVICE_TABLE_NAME: TableName = TableName("chroma_core_device");
-
-impl Name for Device {
-    fn table_name() -> TableName<'static> {
-        DEVICE_TABLE_NAME
-    }
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for Device {
-    fn from(row: Row) -> Self {
-        Device {
-            id: row.get("id"),
-            size: row.get("size"),
-            usable_for_lustre: row.get("usable_for_lustre"),
-            device_type: row.get("device_type"),
-            parents: row.get("parents"),
-            children: row.get("children"),
-        }
-    }
-}
-
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Command {
     pub id: i32,
@@ -995,62 +694,8 @@ impl Deref for Paths {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl ToSql for Paths {
-    fn to_sql(
-        &self,
-        ty: &Type,
-        w: &mut BytesMut,
-    ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
-        let xs = self.iter().map(|x| x.to_string_lossy()).collect::<Vec<_>>();
-        <&[std::borrow::Cow<'_, str>] as ToSql>::to_sql(&&*xs, ty, w)
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <&[std::borrow::Cow<'_, str>] as ToSql>::accepts(ty)
-    }
-
-    to_sql_checked!();
-}
-
-#[cfg(feature = "postgres-interop")]
-impl<'a> FromSql<'a> for Paths {
-    fn from_sql(
-        ty: &Type,
-        raw: &'a [u8],
-    ) -> Result<Paths, Box<dyn std::error::Error + Sync + Send>> {
-        <Vec<String> as FromSql>::from_sql(ty, raw)
-            .map(|xs| Paths(xs.into_iter().map(PathBuf::from).collect()))
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <Vec<String> as FromSql>::accepts(ty)
-    }
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct MountPath(pub Option<PathBuf>);
-
-#[cfg(feature = "postgres-interop")]
-impl ToSql for MountPath {
-    fn to_sql(
-        &self,
-        ty: &Type,
-        w: &mut BytesMut,
-    ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
-        <&Option<String> as ToSql>::to_sql(
-            &&self.0.clone().map(|x| x.to_string_lossy().into_owned()),
-            ty,
-            w,
-        )
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        <&Option<String> as ToSql>::accepts(ty)
-    }
-
-    to_sql_checked!();
-}
 
 #[cfg(feature = "postgres-interop")]
 impl Deref for MountPath {
@@ -1058,47 +703,6 @@ impl Deref for MountPath {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-/// A pointer to a `Device` present on a host.
-/// Stores mount_path and paths to reach the pointed to `Device`.
-#[derive(Debug, PartialEq, Eq)]
-pub struct DeviceHost {
-    pub device_id: DeviceId,
-    pub fqdn: Fqdn,
-    pub local: bool,
-    pub paths: Paths,
-    pub mount_path: MountPath,
-    pub fs_type: Option<String>,
-    pub fs_label: Option<String>,
-    pub fs_uuid: Option<String>,
-}
-
-pub const DEVICE_HOST_TABLE_NAME: TableName = TableName("chroma_core_devicehost");
-
-impl Name for DeviceHost {
-    fn table_name() -> TableName<'static> {
-        DEVICE_HOST_TABLE_NAME
-    }
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for DeviceHost {
-    fn from(row: Row) -> Self {
-        DeviceHost {
-            device_id: row.get("device_id"),
-            fqdn: Fqdn(row.get::<_, String>("fqdn")),
-            local: row.get("local"),
-            paths: row.get("paths"),
-            mount_path: MountPath(
-                row.get::<_, Option<String>>("mount_path")
-                    .map(PathBuf::from),
-            ),
-            fs_type: row.get::<_, Option<String>>("fs_type"),
-            fs_label: row.get::<_, Option<String>>("fs_label"),
-            fs_uuid: row.get::<_, Option<String>>("fs_uuid"),
-        }
     }
 }
 
@@ -1129,22 +733,6 @@ impl Id for AuthUserRecord {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for AuthUserRecord {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            is_superuser: row.get("is_superuser"),
-            username: row.get("username"),
-            first_name: row.get("first_name"),
-            last_name: row.get("last_name"),
-            email: row.get("email"),
-            is_staff: row.get("is_staff"),
-            is_active: row.get("is_active"),
-        }
-    }
-}
-
 /// Record from the `auth_user_groups` table
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct AuthUserGroupRecord {
@@ -1164,17 +752,6 @@ impl Name for AuthUserGroupRecord {
 impl Id for AuthUserGroupRecord {
     fn id(&self) -> i32 {
         self.id
-    }
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for AuthUserGroupRecord {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            user_id: row.get::<_, i32>("user_id"),
-            group_id: row.get::<_, i32>("group_id"),
-        }
     }
 }
 
@@ -1199,21 +776,12 @@ impl Id for AuthGroupRecord {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for AuthGroupRecord {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            name: row.get("name"),
-        }
-    }
-}
-
 /// Record from the `chroma_core_pacemakerconfiguration` table
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct PacemakerConfigurationRecord {
     pub id: i32,
     pub state: String,
+    pub state_modified_at: DateTime<Utc>,
     pub immutable_state: bool,
     pub not_deleted: Option<bool>,
     pub content_type_id: Option<i32>,
@@ -1265,31 +833,19 @@ impl ToCompositeId for &PacemakerConfigurationRecord {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for PacemakerConfigurationRecord {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            state: row.get("state"),
-            immutable_state: row.get("immutable_state"),
-            not_deleted: row.get("not_deleted"),
-            content_type_id: row.get::<_, Option<i32>>("content_type_id"),
-            host_id: row.get::<_, i32>("host_id"),
-        }
-    }
-}
-
 /// Record from the `chroma_core_corosyncconfiguration` table
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CorosyncConfigurationRecord {
     pub id: i32,
     pub state: String,
+    pub state_modified_at: DateTime<Utc>,
     pub immutable_state: bool,
     pub not_deleted: Option<bool>,
     pub mcast_port: Option<i32>,
     pub corosync_reported_up: bool,
     pub content_type_id: Option<i32>,
     pub host_id: i32,
+    pub record_type: String,
 }
 
 pub const COROSYNC_CONFIGURATION_TABLE_NAME: TableName =
@@ -1334,21 +890,5 @@ impl ToCompositeId for CorosyncConfigurationRecord {
 impl ToCompositeId for &CorosyncConfigurationRecord {
     fn composite_id(&self) -> CompositeId {
         CompositeId(self.content_type_id.unwrap(), self.id)
-    }
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for CorosyncConfigurationRecord {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            state: row.get("state"),
-            immutable_state: row.get("immutable_state"),
-            not_deleted: row.get("not_deleted"),
-            mcast_port: row.get::<_, Option<i32>>("mcast_port"),
-            corosync_reported_up: row.get("corosync_reported_up"),
-            content_type_id: row.get::<_, Option<i32>>("content_type_id"),
-            host_id: row.get::<_, i32>("host_id"),
-        }
     }
 }

--- a/iml-wire-types/src/sfa.rs
+++ b/iml-wire-types/src/sfa.rs
@@ -7,11 +7,7 @@ use crate::{
     Label,
 };
 use serde_repr::{Deserialize_repr, Serialize_repr};
-#[cfg(feature = "postgres-interop")]
-use std::convert::TryInto;
 use std::{convert::TryFrom, io};
-#[cfg(feature = "postgres-interop")]
-use tokio_postgres::Row;
 
 #[cfg(feature = "wbem-interop")]
 pub mod wbem_interop {
@@ -771,26 +767,6 @@ impl Label for SfaStorageSystem {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for SfaStorageSystem {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            child_health_state: row
-                .get::<_, i16>("child_health_state")
-                .try_into()
-                .unwrap_or_default(),
-            health_state_reason: row.get("health_state_reason"),
-            health_state: row
-                .get::<_, i16>("health_state")
-                .try_into()
-                .unwrap_or_default(),
-            uuid: row.get("uuid"),
-            platform: row.get("platform"),
-        }
-    }
-}
-
 pub const SFA_ENCLOSURE_TABLE_NAME: TableName = TableName("chroma_core_sfaenclosure");
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -823,34 +799,6 @@ impl Id for SfaEnclosure {
 impl Label for SfaEnclosure {
     fn label(&self) -> &str {
         "SFA enclosure"
-    }
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for SfaEnclosure {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            index: row.get::<_, i32>("index"),
-            element_name: row.get("element_name"),
-            health_state: row
-                .get::<_, i16>("health_state")
-                .try_into()
-                .unwrap_or_default(),
-            health_state_reason: row.get("health_state_reason"),
-            child_health_state: row
-                .get::<_, i16>("child_health_state")
-                .try_into()
-                .unwrap_or_default(),
-            model: row.get("model"),
-            position: row.get::<_, i16>("position"),
-            enclosure_type: row
-                .get::<_, i16>("enclosure_type")
-                .try_into()
-                .unwrap_or_default(),
-            storage_system: row.get("storage_system"),
-            canister_location: row.get("canister_location"),
-        }
     }
 }
 
@@ -891,30 +839,6 @@ impl Label for SfaDiskDrive {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for SfaDiskDrive {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            index: row.get::<_, i32>("index"),
-            failed: row.get("failed"),
-            health_state_reason: row.get("health_state_reason"),
-            health_state: row
-                .get::<_, i16>("health_state")
-                .try_into()
-                .unwrap_or_default(),
-            member_index: row.get::<_, Option<i16>>("member_index"),
-            member_state: row
-                .get::<_, i16>("member_state")
-                .try_into()
-                .unwrap_or_default(),
-            enclosure_index: row.get::<_, i32>("enclosure_index"),
-            slot_number: row.get::<_, i32>("slot_number"),
-            storage_system: row.get("storage_system"),
-        }
-    }
-}
-
 pub const SFA_JOB_TABLE_NAME: TableName = TableName("chroma_core_sfajob");
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -943,23 +867,6 @@ impl Id for SfaJob {
 impl Label for SfaJob {
     fn label(&self) -> &str {
         "SFA Job"
-    }
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for SfaJob {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            index: row.get::<_, i32>("index"),
-            sub_target_index: row.get::<_, Option<i32>>("sub_target_index"),
-            sub_target_type: row
-                .get::<_, Option<i16>>("sub_target_type")
-                .map(|x| x.try_into().unwrap_or_default()),
-            job_type: row.get::<_, i16>("job_type").try_into().unwrap_or_default(),
-            state: row.get::<_, i16>("state").try_into().unwrap_or_default(),
-            storage_system: row.get("storage_system"),
-        }
     }
 }
 
@@ -994,24 +901,6 @@ impl Label for SfaPowerSupply {
     }
 }
 
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for SfaPowerSupply {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            index: row.get::<_, i32>("index"),
-            health_state: row
-                .get::<_, i16>("health_state")
-                .try_into()
-                .unwrap_or_default(),
-            health_state_reason: row.get("health_state_reason"),
-            enclosure_index: row.get::<_, i32>("enclosure_index"),
-            position: row.get::<_, i16>("position"),
-            storage_system: row.get("storage_system"),
-        }
-    }
-}
-
 pub const SFA_CONTROLLER_TABLE_NAME: TableName = TableName("chroma_core_sfacontroller");
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -1040,26 +929,5 @@ impl Id for SfaController {
 impl Label for SfaController {
     fn label(&self) -> &str {
         "SFA Controller"
-    }
-}
-
-#[cfg(feature = "postgres-interop")]
-impl From<Row> for SfaController {
-    fn from(row: Row) -> Self {
-        Self {
-            id: row.get::<_, i32>("id"),
-            index: row.get::<_, i32>("index"),
-            enclosure_index: row.get::<_, i32>("enclosure_index"),
-            health_state: row
-                .get::<_, i16>("health_state")
-                .try_into()
-                .unwrap_or_default(),
-            health_state_reason: row.get("health_state_reason"),
-            child_health_state: row
-                .get::<_, i16>("child_health_state")
-                .try_into()
-                .unwrap_or_default(),
-            storage_system: row.get("storage_system"),
-        }
     }
 }

--- a/iml-wire-types/src/snapshot.rs
+++ b/iml-wire-types/src/snapshot.rs
@@ -4,6 +4,7 @@
 
 //! Data structures for communicating with the agent regarding lustre snapshots.
 
+use crate::db::Id;
 use chrono::offset::Utc;
 use chrono::DateTime;
 #[cfg(feature = "cli")]
@@ -32,6 +33,24 @@ pub struct Snapshot {
     pub mounted: Option<bool>,
     /// Optional comment for the snapshot
     pub comment: Option<String>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, PartialEq, Debug)]
+pub struct SnapshotRecord {
+    pub id: i32,
+    pub filesystem_name: String,
+    pub snapshot_name: String,
+    pub modify_time: DateTime<Utc>,
+    pub create_time: DateTime<Utc>,
+    pub snapshot_fsname: String,
+    pub mounted: Option<bool>,
+    pub comment: Option<String>,
+}
+
+impl Id for SnapshotRecord {
+    fn id(&self) -> i32 {
+        self.id
+    }
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/iml-wire-types/src/snapshot.rs
+++ b/iml-wire-types/src/snapshot.rs
@@ -4,7 +4,7 @@
 
 //! Data structures for communicating with the agent regarding lustre snapshots.
 
-use crate::db::Id;
+use crate::db::{Id, TableName};
 use chrono::offset::Utc;
 use chrono::DateTime;
 #[cfg(feature = "cli")]
@@ -52,6 +52,8 @@ impl Id for SnapshotRecord {
         self.id
     }
 }
+
+pub const SNAPSHOT_TABLE_NAME: TableName = TableName("snapshot");
 
 #[derive(serde::Deserialize, Debug)]
 #[cfg_attr(feature = "cli", derive(StructOpt))]

--- a/iml-wire-types/src/warp_drive.rs
+++ b/iml-wire-types/src/warp_drive.rs
@@ -10,6 +10,7 @@ use crate::{
         VolumeNodeRecord, VolumeRecord,
     },
     sfa::{SfaController, SfaDiskDrive, SfaEnclosure, SfaJob, SfaPowerSupply, SfaStorageSystem},
+    snapshot::SnapshotRecord,
     Alert, CompositeId, EndpointNameSelf, Filesystem, Host, Label, LockChange, Target,
     TargetConfParam, ToCompositeId,
 };
@@ -107,6 +108,7 @@ pub struct Cache {
     pub sfa_power_supply: HashMap<i32, SfaPowerSupply>,
     pub sfa_storage_system: HashMap<i32, SfaStorageSystem>,
     pub sfa_controller: HashMap<i32, SfaController>,
+    pub snapshot: HashMap<i32, SnapshotRecord>,
     pub stratagem_config: HashMap<i32, StratagemConfiguration>,
     pub target: HashMap<i32, Target<TargetConfParam>>,
     pub user: HashMap<i32, AuthUserRecord>,
@@ -135,6 +137,7 @@ pub struct ArcCache {
     pub sfa_job: HashMap<i32, Arc<SfaJob>>,
     pub sfa_power_supply: HashMap<i32, Arc<SfaPowerSupply>>,
     pub sfa_controller: HashMap<i32, Arc<SfaController>>,
+    pub snapshot: HashMap<i32, Arc<SnapshotRecord>>,
     pub stratagem_config: HashMap<i32, Arc<StratagemConfiguration>>,
     pub target: HashMap<i32, Arc<Target<TargetConfParam>>>,
     pub user: HashMap<i32, Arc<AuthUserRecord>>,
@@ -169,6 +172,7 @@ impl Cache {
             RecordId::SfaPowerSupply(id) => self.sfa_power_supply.remove(&id).is_some(),
             RecordId::SfaController(id) => self.sfa_controller.remove(&id).is_some(),
             RecordId::StratagemConfig(id) => self.stratagem_config.remove(&id).is_some(),
+            RecordId::Snapshot(id) => self.snapshot.remove(&id).is_some(),
             RecordId::Target(id) => self.target.remove(&id).is_some(),
             RecordId::User(id) => self.user.remove(&id).is_some(),
             RecordId::UserGroup(id) => self.user_group.remove(&id).is_some(),
@@ -230,6 +234,9 @@ impl Cache {
             Record::SfaController(x) => {
                 self.sfa_controller.insert(x.id, x);
             }
+            Record::Snapshot(x) => {
+                self.snapshot.insert(x.id, x);
+            }
             Record::StratagemConfig(x) => {
                 self.stratagem_config.insert(x.id(), x);
             }
@@ -287,6 +294,7 @@ impl ArcCache {
             RecordId::SfaJob(id) => self.sfa_job.remove(&id).is_some(),
             RecordId::SfaPowerSupply(id) => self.sfa_power_supply.remove(&id).is_some(),
             RecordId::SfaController(id) => self.sfa_controller.remove(&id).is_some(),
+            RecordId::Snapshot(id) => self.snapshot.remove(&id).is_some(),
             RecordId::StratagemConfig(id) => self.stratagem_config.remove(&id).is_some(),
             RecordId::Target(id) => self.target.remove(&id).is_some(),
             RecordId::User(id) => self.user.remove(&id).is_some(),
@@ -348,6 +356,9 @@ impl ArcCache {
             }
             Record::SfaController(x) => {
                 self.sfa_controller.insert(x.id(), Arc::new(x));
+            }
+            Record::Snapshot(x) => {
+                self.snapshot.insert(x.id, Arc::new(x));
             }
             Record::StratagemConfig(x) => {
                 self.stratagem_config.insert(x.id(), Arc::new(x));
@@ -420,6 +431,7 @@ impl From<&Cache> for ArcCache {
             sfa_job: hashmap_to_arc_hashmap(&cache.sfa_job),
             sfa_power_supply: hashmap_to_arc_hashmap(&cache.sfa_power_supply),
             sfa_controller: hashmap_to_arc_hashmap(&cache.sfa_controller),
+            snapshot: hashmap_to_arc_hashmap(&cache.snapshot),
             stratagem_config: hashmap_to_arc_hashmap(&cache.stratagem_config),
             target: hashmap_to_arc_hashmap(&cache.target),
             user: hashmap_to_arc_hashmap(&cache.user),
@@ -450,6 +462,7 @@ impl From<&ArcCache> for Cache {
             sfa_job: arc_hashmap_to_hashmap(&cache.sfa_job),
             sfa_power_supply: arc_hashmap_to_hashmap(&cache.sfa_power_supply),
             sfa_controller: arc_hashmap_to_hashmap(&cache.sfa_controller),
+            snapshot: arc_hashmap_to_hashmap(&cache.snapshot),
             stratagem_config: arc_hashmap_to_hashmap(&cache.stratagem_config),
             target: arc_hashmap_to_hashmap(&cache.target),
             user: arc_hashmap_to_hashmap(&cache.user),
@@ -481,6 +494,7 @@ pub enum Record {
     SfaJob(SfaJob),
     SfaPowerSupply(SfaPowerSupply),
     SfaController(SfaController),
+    Snapshot(SnapshotRecord),
     StratagemConfig(StratagemConfiguration),
     Target(Target<TargetConfParam>),
     User(AuthUserRecord),
@@ -508,6 +522,7 @@ pub enum ArcRecord {
     SfaJob(Arc<SfaJob>),
     SfaPowerSupply(Arc<SfaPowerSupply>),
     SfaController(Arc<SfaController>),
+    Snapshot(Arc<SnapshotRecord>),
     StratagemConfig(Arc<StratagemConfiguration>),
     Target(Arc<Target<TargetConfParam>>),
     User(Arc<AuthUserRecord>),
@@ -537,6 +552,7 @@ impl From<Record> for ArcRecord {
             Record::SfaPowerSupply(x) => Self::SfaPowerSupply(Arc::new(x)),
             Record::SfaController(x) => Self::SfaController(Arc::new(x)),
             Record::StratagemConfig(x) => Self::StratagemConfig(Arc::new(x)),
+            Record::Snapshot(x) => Self::Snapshot(Arc::new(x)),
             Record::Target(x) => Self::Target(Arc::new(x)),
             Record::User(x) => Self::User(Arc::new(x)),
             Record::UserGroup(x) => Self::UserGroup(Arc::new(x)),
@@ -567,6 +583,7 @@ pub enum RecordId {
     SfaPowerSupply(i32),
     SfaController(i32),
     StratagemConfig(i32),
+    Snapshot(i32),
     Target(i32),
     User(i32),
     UserGroup(i32),
@@ -595,6 +612,7 @@ impl Deref for RecordId {
             | Self::SfaJob(x)
             | Self::SfaPowerSupply(x)
             | Self::SfaController(x)
+            | Self::Snapshot(x)
             | Self::StratagemConfig(x)
             | Self::Target(x)
             | Self::User(x)

--- a/migrations/20200831174542_snapshot.sql
+++ b/migrations/20200831174542_snapshot.sql
@@ -1,4 +1,5 @@
-CREATE TABLE snapshot (
+CREATE TABLE IF NOT EXISTS snapshot (
+  id serial PRIMARY KEY,
   filesystem_name TEXT NOT NULL,
   snapshot_name TEXT NOT NULL,
   create_time TIMESTAMP WITH TIME ZONE NOT NULL,

--- a/migrations/20200831174542_snapshot.sql
+++ b/migrations/20200831174542_snapshot.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS snapshot (
   mounted BOOLEAN NULL,
   comment TEXT NULL,
   UNIQUE (filesystem_name, snapshot_name)
-)
+);
 
 CREATE OR REPLACE FUNCTION table_snapshot_update_notify() RETURNS TRIGGER AS $$
 BEGIN

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -858,6 +858,26 @@
       "nullable": []
     }
   },
+  "45af175923382837733407cab5f3fa02f1a14ea460d607407d742dabda0c14ff": {
+    "query": "\n            SELECT active_host_id from target WHERE filesystems @> $1 and name='MGS'\n        ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "active_host_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "TextArray"
+        ]
+      },
+      "nullable": [
+        true
+      ]
+    }
+  },
   "4eb28fbaf2c42bbcc852c074ade355c4f29c318def54af2290a05f37e90a3b23": {
     "query": "\n            INSERT INTO corosync_node (\n                id,\n                cluster_id,\n                online,\n                standby,\n                standby_onfail,\n                maintenance,\n                pending,\n                unclean,\n                shutdown,\n                expected_up,\n                is_dc,\n                resources_running,\n                type\n            )\n            SELECT\n                id::corosync_node_key,\n                $13,\n                online,\n                standby,\n                standby_onfail,\n                maintenance,\n                pending,\n                unclean,\n                shutdown,\n                expected_up,\n                is_dc,\n                resources_running,\n                type\n            FROM UNNEST(\n                $1::text[],\n                $2::bool[],\n                $3::bool[],\n                $4::bool[],\n                $5::bool[],\n                $6::bool[],\n                $7::bool[],\n                $8::bool[],\n                $9::bool[],\n                $10::bool[],\n                $11::int[],\n                $12::text[]\n            )\n            AS t(\n                id,\n                online,\n                standby,\n                standby_onfail,\n                maintenance,\n                pending,\n                unclean,\n                shutdown,\n                expected_up,\n                is_dc,\n                resources_running,\n                type\n            )\n            ON CONFLICT (id, cluster_id) DO UPDATE\n            SET\n                online = excluded.online,\n                standby = excluded.standby,\n                standby_onfail = excluded.standby_onfail,\n                maintenance = excluded.maintenance,\n                pending = excluded.pending,\n                unclean = excluded.unclean,\n                shutdown = excluded.shutdown,\n                expected_up = excluded.expected_up,\n                is_dc = excluded.is_dc,\n                resources_running = excluded.resources_running,\n                type = excluded.type\n        ",
     "describe": {
@@ -932,26 +952,6 @@
       },
       "nullable": [
         false
-      ]
-    }
-  },
-  "552ba77218026a2b80300ef6e297f69fb8c0bf09d5ba26f8dc430bbb5ae28cd9": {
-    "query": "\n            select active_host_id from targets where filesystems @> $1 and name='MGS'\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "active_host_id",
-          "type_info": "Int4"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "TextArray"
-        ]
-      },
-      "nullable": [
-        true
       ]
     }
   },
@@ -1361,26 +1361,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "641f50e14815d8ac40fe7500617b12d3ecc461bf026355bf373f2dd0eb5d8ef9": {
-    "query": "\n                select fqdn from chroma_core_managedhost where id=$1 and not_deleted = 't'\n                ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "fqdn",
-          "type_info": "Varchar"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int4"
-        ]
-      },
-      "nullable": [
-        false
-      ]
     }
   },
   "681d997bb965a228c0aa75d93d09faefe5412daaf3e7bda3630df319fb9edabb": {
@@ -2100,60 +2080,6 @@
         true,
         false,
         true,
-        true
-      ]
-    }
-  },
-  "9c17bcb36d43a3176bf1bc3893fa8729f636139574013f8fe422a51cd0ddcfde": {
-    "query": "select * from targets",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "state",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "active_host_id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 3,
-          "name": "host_ids",
-          "type_info": "Int4Array"
-        },
-        {
-          "ordinal": 4,
-          "name": "filesystems",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 5,
-          "name": "uuid",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "mount_path",
-          "type_info": "Text"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
         true
       ]
     }
@@ -3526,6 +3452,26 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "f7cb59fe7a6bc5dde5fe7f15025161aa8d6e7ba933bb963fcfe8d9afeee26945": {
+    "query": "\n                SELECT fqdn FROM chroma_core_managedhost WHERE id=$1 and not_deleted = 't'\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "fqdn",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false
+      ]
     }
   },
   "f8cd2baf66e0d74fea5babd851be21a3badca94a53aee6bac038141cece53646": {

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -98,6 +98,30 @@
       "nullable": []
     }
   },
+  "119d6b04e15aa7721612d1b1340fc63d629274d06eee8cdac23e79bf63c09cb5": {
+    "query": "select * from auth_group",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "name",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
   "12b85bdac2a34efedc73bb817f38fd589a8e2754392d863cf4211e169e935153": {
     "query": "\n        INSERT INTO chroma_core_sfadiskdrive\n        (\n            index,\n            enclosure_index,\n            failed,\n            slot_number,\n            health_state,\n            health_state_reason,\n            member_index,\n            member_state,\n            storage_system\n        )\n        SELECT * FROM UNNEST(\n            $1::integer[],\n            $2::integer[],\n            $3::bool[],\n            $4::integer[],\n            $5::smallint[],\n            $6::text[],\n            $7::smallint[],\n            $8::smallint[],\n            $9::text[]\n        )\n        ON CONFLICT (index, storage_system) DO UPDATE\n        SET\n            enclosure_index = excluded.enclosure_index,\n            failed = excluded.failed,\n            slot_number = excluded.slot_number,\n            health_state = excluded.health_state,\n            health_state_reason = excluded.health_state_reason,\n            member_index = excluded.member_index,\n            member_state = excluded.member_state\n    ",
     "describe": {
@@ -349,6 +373,60 @@
       ]
     }
   },
+  "26a2bb0d30e2f8220b38a06a45a02ff5791a5f3895267d58316a43dc1823af77": {
+    "query": "select * from chroma_core_pacemakerconfiguration where not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "state_modified_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 2,
+          "name": "state",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 3,
+          "name": "immutable_state",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "not_deleted",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 5,
+          "name": "content_type_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 6,
+          "name": "host_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false
+      ]
+    }
+  },
   "26c11ec900d262a2db413b7dc85660856a16b92e6a444b163c5aa727f3d99cf8": {
     "query": "\n                INSERT INTO corosync_target_resource_managed_host (host_id, cluster_id, corosync_resource_id)\n                SELECT $1, $2, corosync_resource_id FROM UNNEST($3::text[]) as corosync_resource_id\n                ON CONFLICT (host_id, corosync_resource_id, cluster_id)\n                DO NOTHING\n            ",
     "describe": {
@@ -361,6 +439,66 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "27587242d9b9eadb5c86e46d254d308068d8e5d50a4de7bad19e2e01cd39e9d2": {
+    "query": "select * from snapshot",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "filesystem_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "snapshot_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "create_time",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 4,
+          "name": "modify_time",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 5,
+          "name": "snapshot_fsname",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 6,
+          "name": "mounted",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 7,
+          "name": "comment",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true
+      ]
     }
   },
   "2c9083284f77e37686b8447e1778f2479a187909660afd592ca6272a3ac2950e": {
@@ -425,6 +563,36 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "2e06ae54254a945c17bcdc4ad3029f1e0ad7888f724e83628588f590cd8fbd0b": {
+    "query": "select * from auth_user_groups",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "user_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 2,
+          "name": "group_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false
+      ]
     }
   },
   "2eedae727c7336f9edd217051685ebfd1e7a8e28597a0803aad92147c49f6805": {
@@ -604,6 +772,72 @@
         false,
         false,
         true
+      ]
+    }
+  },
+  "3bded6ce17eeea786bb32a1c8b5fe37b40b25391f24e9bd6dd25652381f84bc8": {
+    "query": "select * from chroma_core_stratagemconfiguration where not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "state_modified_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 2,
+          "name": "state",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 3,
+          "name": "immutable_state",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "interval",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 5,
+          "name": "report_duration",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 6,
+          "name": "purge_duration",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 7,
+          "name": "not_deleted",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 8,
+          "name": "filesystem_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false
       ]
     }
   },
@@ -924,6 +1158,36 @@
       "nullable": []
     }
   },
+  "5930d6c4ec835774aa21699a4652e603493ae45899968c75d88dbe302445acbc": {
+    "query": "select * from chroma_core_ostpool_osts",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "ostpool_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 2,
+          "name": "managedost_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "5b8f7ab8db2264a517e0de4228e259e02201d0116b9235e59cd4b66df61db22e": {
     "query": "DELETE FROM chroma_core_serverprofilepackage WHERE server_profile_id = $1",
     "describe": {
@@ -951,6 +1215,126 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "5c10aa83d6be60751c3216531939d4050cffa43f5ac88f12153a9a7f1e996d78": {
+    "query": "SELECT\n            id,\n            uuid,\n            platform,\n            health_state_reason,\n            health_state as \"health_state: HealthState\",\n            child_health_state as \"child_health_state: HealthState\"\n        FROM chroma_core_sfastoragesystem\n        ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "uuid",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "platform",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "health_state_reason",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "health_state: HealthState",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 5,
+          "name": "child_health_state: HealthState",
+          "type_info": "Int2"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "5e11e0de8491ae722456167f38986de2be06ad32e48169b1758b66e1564b7c34": {
+    "query": "select * from chroma_core_corosyncconfiguration where not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "state_modified_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 2,
+          "name": "state",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 3,
+          "name": "immutable_state",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "not_deleted",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 5,
+          "name": "mcast_port",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 6,
+          "name": "corosync_reported_up",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 7,
+          "name": "record_type",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 8,
+          "name": "content_type_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 9,
+          "name": "host_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false
+      ]
     }
   },
   "61e498856043c03a2b0ca70544b3973f25ab9154985fd6a2078b46436a42c8f2": {
@@ -995,6 +1379,36 @@
         ]
       },
       "nullable": [
+        false
+      ]
+    }
+  },
+  "681d997bb965a228c0aa75d93d09faefe5412daaf3e7bda3630df319fb9edabb": {
+    "query": "select * from django_content_type",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "app_label",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 2,
+          "name": "model",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
         false
       ]
     }
@@ -1186,6 +1600,138 @@
       "nullable": []
     }
   },
+  "808baf8439b048c53e177a52f7b24bef71bef70781424741f355c2efb239e52d": {
+    "query": "SELECT\n            id,\n            index,\n            enclosure_index,\n            health_state as \"health_state: HealthState\",\n            health_state_reason,\n            child_health_state as \"child_health_state: HealthState\",\n            storage_system\n        FROM chroma_core_sfacontroller\n        ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "index",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 2,
+          "name": "enclosure_index",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 3,
+          "name": "health_state: HealthState",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 4,
+          "name": "health_state_reason",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "child_health_state: HealthState",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 6,
+          "name": "storage_system",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "80e0fc9b1b45fb3488bed52b35e7f54cc7f8cb08003caffe344baf2094b25cd9": {
+    "query": "SELECT\n            id,\n            index,\n            element_name,\n            health_state as \"health_state: HealthState\",\n            health_state_reason,\n            child_health_state as \"child_health_state: HealthState\",\n            model,\n            position,\n            enclosure_type as \"enclosure_type: EnclosureType\",\n            canister_location,\n            storage_system\n        FROM chroma_core_sfaenclosure\n        ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "index",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 2,
+          "name": "element_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "health_state: HealthState",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 4,
+          "name": "health_state_reason",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "child_health_state: HealthState",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 6,
+          "name": "model",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "position",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 8,
+          "name": "enclosure_type: EnclosureType",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 9,
+          "name": "canister_location",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 10,
+          "name": "storage_system",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "82099090aa05b7da19e94f69e680755c22ef1812f11407eaafaf4db520fb9c69": {
     "query": "SELECT * FROM chroma_core_command WHERE id = $1",
     "describe": {
@@ -1232,6 +1778,60 @@
         false,
         false,
         false,
+        false
+      ]
+    }
+  },
+  "857ec5f2517d25f901399ddfb8efa1ab3f73ed8c8f899692c071172b61179d1a": {
+    "query": "select * from chroma_core_lnetconfiguration where not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "state_modified_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 2,
+          "name": "state",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 3,
+          "name": "immutable_state",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "not_deleted",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 5,
+          "name": "content_type_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 6,
+          "name": "host_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
         false
       ]
     }
@@ -1450,6 +2050,114 @@
       ]
     }
   },
+  "9a4c05da9d9233e6b3fa63ca2f50cf90feb0c305b1cc05e0eb2edcf2572db4ba": {
+    "query": "select * from chroma_core_volume where not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "size",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 2,
+          "name": "label",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 3,
+          "name": "filesystem_type",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 4,
+          "name": "usable_for_lustre",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 5,
+          "name": "not_deleted",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 6,
+          "name": "storage_resource_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true
+      ]
+    }
+  },
+  "9c17bcb36d43a3176bf1bc3893fa8729f636139574013f8fe422a51cd0ddcfde": {
+    "query": "select * from targets",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "state",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 1,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "active_host_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 3,
+          "name": "host_ids",
+          "type_info": "Int4Array"
+        },
+        {
+          "ordinal": 4,
+          "name": "filesystems",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 5,
+          "name": "uuid",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 6,
+          "name": "mount_path",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true
+      ]
+    }
+  },
   "9edb0846023aa1a9250204fb686d5b95a95962ce20aab75cec2e906edad8eec7": {
     "query": "\n            SELECT * from chroma_core_stepresult\n            WHERE job_id = ANY($1)\n            ORDER BY modified_at DESC\n    ",
     "describe": {
@@ -1538,6 +2246,78 @@
         false,
         false,
         true,
+        false
+      ]
+    }
+  },
+  "a3269a5f7c491a332facfcf86c576350f4b9e7c14638a26d0bd17daef52c0613": {
+    "query": "SELECT\n            id,\n            index,\n            enclosure_index,\n            failed,\n            slot_number,\n            health_state as \"health_state: HealthState\",\n            health_state_reason,\n            member_index,\n            member_state as \"member_state: MemberState\",\n            storage_system\n        FROM chroma_core_sfadiskdrive\n        ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "index",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 2,
+          "name": "enclosure_index",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 3,
+          "name": "failed",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "slot_number",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 5,
+          "name": "health_state: HealthState",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 6,
+          "name": "health_state_reason",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "member_index",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 8,
+          "name": "member_state: MemberState",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 9,
+          "name": "storage_system",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
         false
       ]
     }
@@ -1710,6 +2490,66 @@
       "nullable": []
     }
   },
+  "adec7f8e00d15a6c5209443c43b80c59bcb85ea726dbc88628978571ea91b5ba": {
+    "query": "\n        SELECT \n            id, \n            is_superuser,\n            username,\n            first_name,\n            last_name,\n            email,\n            is_staff,\n            is_active \n        FROM auth_user\n    ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "is_superuser",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 2,
+          "name": "username",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 3,
+          "name": "first_name",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 4,
+          "name": "last_name",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 5,
+          "name": "email",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 6,
+          "name": "is_staff",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 7,
+          "name": "is_active",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "b04b6d9456e4fbd6b7c97cb633393b8971701303845f99a716f581b6ee0eb481": {
     "query": "SELECT repo_name from chroma_core_repo where repo_name = ANY($1)",
     "describe": {
@@ -1741,6 +2581,60 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "b14693e89ec9b45e2f3dafa0e4ea7298618ea6536f6b97fcfcf3975b859e842f": {
+    "query": "SELECT\n            id,\n            index,\n            sub_target_index,\n            sub_target_type as \"sub_target_type: SubTargetType\",\n            job_type as \"job_type: JobType\",\n            state as \"state: JobState\",\n            storage_system\n        FROM chroma_core_sfajob\n        ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "index",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 2,
+          "name": "sub_target_index",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 3,
+          "name": "sub_target_type: SubTargetType",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 4,
+          "name": "job_type: JobType",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 5,
+          "name": "state: JobState",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 6,
+          "name": "storage_system",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false
+      ]
     }
   },
   "b4865dbd455de729bbadd116bf6bf72108582704f5d559691c3821a54290bb0c": {
@@ -1990,6 +2884,66 @@
       ]
     }
   },
+  "d33734c74af7b4fb31773ae83cd10abc34f2946eb0095cda181a9c0cc21800f3": {
+    "query": "select * from chroma_core_volumenode where not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "path",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 2,
+          "name": "primary",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 3,
+          "name": "use",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "not_deleted",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 5,
+          "name": "host_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 6,
+          "name": "storage_resource_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 7,
+          "name": "volume_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false
+      ]
+    }
+  },
   "d39baa07d0445a4eba48fc86c3b328706606d65b2f36f29fca00bbb771c9aa90": {
     "query": "INSERT INTO chroma_core_alertstate\n        (\n            record_type,\n            variant,\n            alert_item_id,\n            alert_type,\n            begin,\n            message,\n            active,\n            dismissed,\n            severity,\n            lustre_pid,\n            alert_item_type_id\n        )\n        VALUES ($1, '{}', $2, $1, now(), $3, true, false, $4, $5, $6)\n        ON CONFLICT DO NOTHING\n        ",
     "describe": {
@@ -2040,6 +2994,60 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "d7098e256b9c915f2ac0a8ddf278468e824bce89875dabbddac063383f51224f": {
+    "query": "SELECT\n            id,\n            index,\n            enclosure_index,\n            health_state as \"health_state: HealthState\",\n            health_state_reason,\n            position,\n            storage_system\n        FROM chroma_core_sfapowersupply\n        ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "index",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 2,
+          "name": "enclosure_index",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 3,
+          "name": "health_state: HealthState",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 4,
+          "name": "health_state_reason",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "position",
+          "type_info": "Int2"
+        },
+        {
+          "ordinal": 6,
+          "name": "storage_system",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
     }
   },
   "d7d2f630597f24da27fd997508e60805e8e626e78775dd524b8de3bbf517e624": {
@@ -2192,6 +3200,48 @@
         false,
         false,
         true
+      ]
+    }
+  },
+  "e0f0ada5205a6f2d4f62861c2f7f5eb3c7d227588e25f056038bd1f87f7a2ff3": {
+    "query": "select * from chroma_core_ostpool where not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "name",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 2,
+          "name": "not_deleted",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 3,
+          "name": "content_type_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 4,
+          "name": "filesystem_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        false
       ]
     }
   },
@@ -2476,6 +3526,60 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "f8cd2baf66e0d74fea5babd851be21a3badca94a53aee6bac038141cece53646": {
+    "query": "select * from chroma_core_managedtargetmount where not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "mount_point",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 2,
+          "name": "primary",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 3,
+          "name": "not_deleted",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "host_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 5,
+          "name": "target_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 6,
+          "name": "volume_node_id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false
+      ]
     }
   },
   "fa7bdf3c5e49361f1afaa6a2075745f0943c461aa87a97854e3004c75c5f6367": {


### PR DESCRIPTION
This patch adds snapshots to iml-warp-drive.

It also removes the dependency on tokio_postgres to fill initial cache
in favor or using sqlx to do so.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2225)
<!-- Reviewable:end -->
