### PR TITLE
Implement graphql queries for all snapshot queries and mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,7 +1665,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.2.18",
+ "time 0.2.19",
  "tokio",
 ]
 
@@ -1700,6 +1700,7 @@ dependencies = [
  "futures",
  "hostlist-parser",
  "iml-api-utils",
+ "iml-graphql-queries",
  "iml-influx",
  "iml-manager-client",
  "iml-postgres",
@@ -2168,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "juniper"
 version = "0.14.2"
-source = "git+https://github.com/graphql-rust/juniper#092a9851fbad5e848167b61dccfe48101cd6eea7"
+source = "git+https://github.com/graphql-rust/juniper#8b79f5b1f1e7969f92467db62a9d128fec58b1f2"
 dependencies = [
  "bson",
  "chrono",
@@ -2187,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "juniper_codegen"
 version = "0.14.2"
-source = "git+https://github.com/graphql-rust/juniper#092a9851fbad5e848167b61dccfe48101cd6eea7"
+source = "git+https://github.com/graphql-rust/juniper#8b79f5b1f1e7969f92467db62a9d128fec58b1f2"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.21",
@@ -3489,18 +3490,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
@@ -3752,7 +3753,7 @@ dependencies = [
  "sqlx-rt",
  "stringprep",
  "thiserror",
- "time 0.2.18",
+ "time 0.2.19",
  "url",
  "whoami",
 ]
@@ -4127,9 +4128,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12785163ae8a1cbb52a5db39af4a5baabd3fe49f07f76f952f89d7e89e5ce531"
+checksum = "80c1a1fd93112fc50b11c43a1def21f926be3c18884fad676ea879572da070a1"
 dependencies = [
  "const_fn",
  "libc",
@@ -4377,9 +4378,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
  "serde",
  "tracing-core",
@@ -4387,9 +4388,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd165311cc4d7a555ad11cc77a37756df836182db0d81aac908c8184c584f40"
+checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",

--- a/iml-graphql-queries/src/snapshot.rs
+++ b/iml-graphql-queries/src/snapshot.rs
@@ -22,7 +22,7 @@ pub mod create {
             }
         "#;
 
-    #[derive(serde::Serialize)]
+    #[derive(Debug, serde::Serialize)]
     pub struct Vars {
         fsname: String,
         name: String,
@@ -51,5 +51,189 @@ pub mod create {
     pub struct Resp {
         #[serde(rename(deserialize = "createSnapshot"))]
         pub create_snapshot: Command,
+    }
+}
+
+pub mod destroy {
+    use crate::Query;
+    use iml_wire_types::Command;
+
+    pub static QUERY: &str = r#"
+        mutation DestroySnapshot($fsname: String!, $name: String!, $force: Boolean!) {
+            destroySnapshot(fsname: $fsname, name: $name, force: $force) {
+                cancelled
+                complete
+                created_at: createdAt
+                errored
+                id
+                jobs
+                logs
+                message
+                resource_uri: resourceUri
+            }
+        }
+    "#;
+
+    #[derive(Debug, serde::Serialize)]
+    pub struct Vars {
+        fsname: String,
+        name: String,
+        force: bool,
+    }
+
+    pub fn build(fsname: impl ToString, name: impl ToString, force: bool) -> Query<Vars> {
+        Query {
+            query: QUERY.to_string(),
+            variables: Some(Vars {
+                fsname: fsname.to_string(),
+                name: name.to_string(),
+                force,
+            }),
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize)]
+    pub struct Resp {
+        #[serde(rename(deserialize = "destroySnapshot"))]
+        pub destroy_snapshot: Command,
+    }
+}
+
+pub mod mount {
+    use crate::Query;
+    use iml_wire_types::Command;
+
+    pub static QUERY: &str = r#"
+        mutation MountSnapshot($fsname: String!, $name: String!) {
+          mountSnapshot(fsname: $fsname, name: $name) {
+            cancelled
+            complete
+            created_at: createdAt
+            errored
+            id
+            jobs
+            logs
+            message
+            resource_uri: resourceUri
+          }
+        }
+    "#;
+
+    #[derive(Debug, serde::Serialize)]
+    pub struct Vars {
+        fsname: String,
+        name: String,
+    }
+
+    pub fn build(fsname: impl ToString, name: impl ToString) -> Query<Vars> {
+        Query {
+            query: QUERY.to_string(),
+            variables: Some(Vars {
+                fsname: fsname.to_string(),
+                name: name.to_string(),
+            }),
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize)]
+    pub struct Resp {
+        #[serde(rename(deserialize = "mountSnapshot"))]
+        pub mount_snapshot: Command,
+    }
+}
+
+pub mod unmount {
+    use crate::Query;
+    use iml_wire_types::Command;
+
+    pub static QUERY: &str = r#"
+        mutation UnmountSnapshot($fsname: String!, $name: String!) {
+          unmountSnapshot(fsname: $fsname, name: $name) {
+            cancelled
+            complete
+            created_at: createdAt
+            errored
+            id
+            jobs
+            logs
+            message
+            resource_uri: resourceUri
+          }
+        }
+    "#;
+
+    #[derive(Debug, serde::Serialize)]
+    pub struct Vars {
+        fsname: String,
+        name: String,
+    }
+
+    pub fn build(fsname: impl ToString, name: impl ToString) -> Query<Vars> {
+        Query {
+            query: QUERY.to_string(),
+            variables: Some(Vars {
+                fsname: fsname.to_string(),
+                name: name.to_string(),
+            }),
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize)]
+    pub struct Resp {
+        #[serde(rename(deserialize = "unmountSnapshot"))]
+        pub unmount_snapshot: Command,
+    }
+}
+
+pub mod list {
+    use crate::{Query, SortDir};
+    use iml_wire_types::snapshot::Snapshot;
+
+    pub static QUERY: &str = r#"
+        query Snapshots($fsname: String!, $name: String, $dir: SortDir, $offset: Int, $limit: Int) {
+          snapshots(fsname: $fsname, name: $name, dir: $dir, offset: $offset, limit: $limit) {
+            comment
+            create_time: createTime
+            filesystem_name: filesystemName
+            modify_time: modifyTime
+            mounted
+            snapshot_fsname: snapshotFsname
+            snapshot_name: snapshotName
+          }
+        }
+    "#;
+
+    #[derive(Debug, serde::Serialize)]
+    pub struct Vars {
+        fsname: String,
+        name: Option<String>,
+        dir: Option<SortDir>,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    }
+
+    pub fn build(
+        fsname: impl ToString,
+        name: Option<&str>,
+        dir: Option<SortDir>,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> Query<Vars> {
+        Query {
+            query: QUERY.to_string(),
+            variables: Some(Vars {
+                fsname: fsname.to_string(),
+                name: name.map(|x| x.to_string()),
+                dir,
+                offset,
+                limit,
+            }),
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize)]
+    pub struct Resp {
+        #[serde(rename(deserialize = "snapshots"))]
+        pub snapshots: Vec<Snapshot>,
     }
 }

--- a/iml-manager-cli/Cargo.toml
+++ b/iml-manager-cli/Cargo.toml
@@ -12,6 +12,7 @@ dotenv = "0.15"
 futures = "0.3"
 hostlist-parser = "0.1.3"
 iml-api-utils = {path = "../iml-api-utils", version = "0.3"}
+iml-graphql-queries = {path = "../iml-graphql-queries", version = "0.1"}
 iml-influx = {path = "../iml-influx", version = "0.1"}
 iml-manager-client = {path = "../iml-manager-client", version = "0.3"}
 iml-postgres = {path = "../iml-postgres", version = "0.3"}

--- a/iml-manager-cli/src/api_utils.rs
+++ b/iml-manager-cli/src/api_utils.rs
@@ -176,13 +176,12 @@ pub async fn get<T: serde::de::DeserializeOwned + std::fmt::Debug>(
         .map_err(|e| e.into())
 }
 
-pub async fn graphql(
-    query: impl serde::Serialize,
-) -> Result<serde_json::value::Value, ImlManagerCliError> {
+pub async fn graphql<T: serde::de::DeserializeOwned + std::fmt::Debug>(
+    query: impl serde::Serialize + Debug,
+) -> Result<T, ImlManagerCliError> {
     let client = iml_manager_client::get_client()?;
 
-    let body = serde_json::json!({ "query": query });
-    iml_manager_client::graphql(client, body)
+    iml_manager_client::graphql(client, query)
         .await
         .map_err(|e| e.into())
 }

--- a/iml-manager-cli/src/error.rs
+++ b/iml-manager-cli/src/error.rs
@@ -64,6 +64,7 @@ pub enum ImlManagerCliError {
     DoesNotExist(&'static str),
     FailedCommandError(Vec<Command>),
     FromUtf8Error(#[from] std::string::FromUtf8Error),
+    ImlGraphqlQueriesErrors(#[from] iml_graphql_queries::Errors),
     IntParseError(#[from] std::num::ParseIntError),
     IoError(#[from] std::io::Error),
     ParseDurationError(#[from] DurationParseError),
@@ -91,6 +92,7 @@ impl std::fmt::Display for ImlManagerCliError {
                 write!(f, "{}", failed_msg)
             }
             ImlManagerCliError::FromUtf8Error(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::ImlGraphqlQueriesErrors(ref err) => write!(f, "{}", err),
             ImlManagerCliError::IntParseError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::IoError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::ParseDurationError(ref err) => write!(f, "{}", err),


### PR DESCRIPTION
This patch implements iml-graphql-queries for all
snapshot queries and mutations. It also updates the `iml snapshot list`
command to use one of these queries.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2237)
<!-- Reviewable:end -->
