### PR TITLE
Add snapshot configuration API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,9 +848,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "either"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 dependencies = [
  "serde",
 ]
@@ -1672,7 +1672,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.2.19",
+ "time 0.2.20",
  "tokio",
 ]
 
@@ -2216,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "lapin"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8cb60a56834fe9aca919f0ed6fcf635163510bb9a393107cbee566f170282d"
+checksum = "81d3e4d31709ab4340ac6f270d440c59d1e1014890af5d9392ee882bd4ee3e3c"
 dependencies = [
  "amq-protocol",
  "async-task",
@@ -2860,9 +2860,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinky-swear"
-version = "4.2.3"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad7206f2f15c2fa06e8d01026e305cd67a1d408967865870c0b6f0ebda05c23"
+checksum = "40e5cf8b99d12fdd41b2be5ee172f74c69526eda68417c6a440c9fa6079f0f2a"
 dependencies = [
  "doc-comment",
  "parking_lot",
@@ -3762,7 +3762,7 @@ dependencies = [
  "sqlx-rt",
  "stringprep",
  "thiserror",
- "time 0.2.19",
+ "time 0.2.20",
  "url",
  "whoami",
 ]
@@ -4137,9 +4137,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c1a1fd93112fc50b11c43a1def21f926be3c18884fad676ea879572da070a1"
+checksum = "0d4953c513c9bf1b97e9cdd83f11d60c4b0a83462880a360d80d96953a953fee"
 dependencies = [
  "const_fn",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
+checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 
 [[package]]
 name = "cexpr"
@@ -719,7 +719,7 @@ checksum = "3df5480412da86cdf5d6b7f3b682422c84359ff7399aa658df1d15ee83244b1d"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -887,7 +887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log",
  "regex",
  "termcolor",
@@ -929,7 +929,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -1051,7 +1051,7 @@ dependencies = [
  "derive_utils",
  "find-crate",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -1080,7 +1080,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -1326,6 +1326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+
+[[package]]
 name = "hyper"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,6 +1526,7 @@ name = "iml-api"
 version = "0.3.0"
 dependencies = [
  "futures",
+ "humantime 2.0.1",
  "iml-job-scheduler-rpc",
  "iml-manager-env",
  "iml-postgres",
@@ -2024,6 +2031,7 @@ version = "0.3.0"
 dependencies = [
  "bytes",
  "chrono",
+ "humantime 2.0.1",
  "im",
  "iml-api-utils",
  "iml-change",
@@ -2193,7 +2201,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2776,7 +2784,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2835,7 +2843,7 @@ checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -2931,7 +2939,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "version_check 0.9.2",
 ]
 
@@ -3506,7 +3514,7 @@ checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -3529,7 +3537,7 @@ checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -3778,7 +3786,7 @@ dependencies = [
  "sha2",
  "sqlx-core",
  "sqlx-rt",
- "syn 1.0.40",
+ "syn 1.0.41",
  "url",
 ]
 
@@ -3832,7 +3840,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -3848,7 +3856,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -3937,7 +3945,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -3975,9 +3983,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
@@ -4104,7 +4112,7 @@ checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -4163,7 +4171,7 @@ dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
  "standback",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -4214,7 +4222,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -4344,7 +4352,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -4534,7 +4542,7 @@ checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
 ]
 
 [[package]]
@@ -4686,7 +4694,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "wasm-bindgen-shared",
 ]
 
@@ -4720,7 +4728,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.40",
+ "syn 1.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,6 +1627,7 @@ dependencies = [
 name = "iml-graphql-queries"
 version = "0.1.0"
 dependencies = [
+ "humantime 2.0.1",
  "iml-wire-types",
  "serde",
  "serde_json",

--- a/iml-api/Cargo.toml
+++ b/iml-api/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.3.0"
 
 [dependencies]
 futures = "0.3"
+humantime = "2.0"
 iml-job-scheduler-rpc = {path = "../iml-job-scheduler-rpc", version = "0.3"}
 iml-manager-env = {path = "../iml-manager-env", version = "0.3"}
 iml-postgres = {path = "../iml-postgres", version = "0.3"}

--- a/iml-graphql-queries/Cargo.toml
+++ b/iml-graphql-queries/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+humantime = "2.0"
 iml-wire-types = {version = "0.3", path = "../iml-wire-types"}
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/iml-graphql-queries/src/snapshot.rs
+++ b/iml-graphql-queries/src/snapshot.rs
@@ -237,3 +237,201 @@ pub mod list {
         pub snapshots: Vec<Snapshot>,
     }
 }
+
+pub mod create_interval {
+    use crate::Query;
+    use std::time::Duration;
+
+    pub static QUERY: &str = r#"
+        mutation CreateSnapshotInterval($fsname: String!, $interval: Duration!, $use_barrier: Boolean) {
+            createSnapshotInterval(fsname: $fsname, interval: $interval, useBarrier: $use_barrier)
+        }
+    "#;
+
+    #[derive(Debug, serde::Serialize)]
+    pub struct Vars {
+        fsname: String,
+        interval: String,
+        use_barrier: Option<bool>,
+    }
+
+    pub fn build(
+        fsname: impl ToString,
+        interval: Duration,
+        use_barrier: Option<bool>,
+    ) -> Query<Vars> {
+        Query {
+            query: QUERY.to_string(),
+            variables: Some(Vars {
+                fsname: fsname.to_string(),
+                interval: humantime::format_duration(interval).to_string(),
+                use_barrier,
+            }),
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize)]
+    pub struct Resp {
+        #[serde(rename(deserialize = "createSnapshotInterval"))]
+        pub create_snapshot_interval: bool,
+    }
+}
+
+pub mod remove_interval {
+    use crate::Query;
+
+    pub static QUERY: &str = r#"
+        mutation RemoveSnapshotInterval($id: Int!) {
+          removeSnapshotInterval(id: $id)
+        }
+    "#;
+
+    #[derive(Debug, serde::Serialize)]
+    pub struct Vars {
+        id: u32,
+    }
+
+    pub fn build(id: u32) -> Query<Vars> {
+        Query {
+            query: QUERY.to_string(),
+            variables: Some(Vars { id }),
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize)]
+    pub struct Resp {
+        #[serde(rename(deserialize = "removeSnapshotInterval"))]
+        pub remove_snapshot_interval: bool,
+    }
+}
+
+pub mod list_intervals {
+    use crate::Query;
+    use iml_wire_types::snapshot::SnapshotInterval;
+
+    pub static QUERY: &str = r#"
+        query SnapshotIntervals {
+          snapshotIntervals {
+            id
+            filesystemName
+            useBarrier
+            interval
+            lastRun
+          }
+        }
+    "#;
+
+    pub fn build() -> Query<()> {
+        Query {
+            query: QUERY.to_string(),
+            variables: None,
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize)]
+    pub struct Resp {
+        #[serde(rename(deserialize = "snapshotIntervals"))]
+        pub snapshot_intervals: Vec<SnapshotInterval>,
+    }
+}
+
+pub mod create_retention {
+    use crate::Query;
+    use iml_wire_types::snapshot::DeleteUnit;
+
+    pub static QUERY: &str = r#"
+        mutation CreateSnapshotRetention($fsname: String!, $delete_num: Int!, $delete_unit: DeleteUnit!, $keep_num: Int!) {
+            createSnapshotRetention(fsname: $fsname, deleteNum: $delete_num, deleteUnit: $delete_unit, keepNum: $keep_num)
+        }
+    "#;
+
+    #[derive(Debug, serde::Serialize)]
+    pub struct Vars {
+        fsname: String,
+        delete_num: u32,
+        delete_unit: DeleteUnit,
+        keep_num: u32,
+    }
+
+    pub fn build(
+        fsname: impl ToString,
+        delete_num: u32,
+        delete_unit: DeleteUnit,
+        keep_num: u32,
+    ) -> Query<Vars> {
+        Query {
+            query: QUERY.to_string(),
+            variables: Some(Vars {
+                fsname: fsname.to_string(),
+                delete_num,
+                delete_unit,
+                keep_num,
+            }),
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize)]
+    pub struct Resp {
+        #[serde(rename(deserialize = "createSnapshotRetention"))]
+        pub create_snapshot_retention: bool,
+    }
+}
+
+pub mod remove_retention {
+    use crate::Query;
+
+    pub static QUERY: &str = r#"
+        mutation RemoveSnapshotRetention($id: Int!) {
+          removeSnapshotRetention(id: $id)
+        }
+    "#;
+
+    #[derive(Debug, serde::Serialize)]
+    pub struct Vars {
+        id: u32,
+    }
+
+    pub fn build(id: u32) -> Query<Vars> {
+        Query {
+            query: QUERY.to_string(),
+            variables: Some(Vars { id }),
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize)]
+    pub struct Resp {
+        #[serde(rename(deserialize = "removeSnapshotRetention"))]
+        pub remove_snapshot_retention: bool,
+    }
+}
+
+pub mod list_retentions {
+    use crate::Query;
+    use iml_wire_types::snapshot::SnapshotRetention;
+
+    pub static QUERY: &str = r#"
+        query SnapshotRetentionPolicies {
+          snapshotRetentionPolicies {
+            id
+            filesystemName
+            deleteNum
+            deleteUnit
+            lastRun
+            keepNum
+          }
+        }
+    "#;
+
+    pub fn build() -> Query<()> {
+        Query {
+            query: QUERY.to_string(),
+            variables: None,
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize)]
+    pub struct Resp {
+        #[serde(rename(deserialize = "snapshotRetentionPolicies"))]
+        pub snapshot_retention_policies: Vec<SnapshotRetention>,
+    }
+}

--- a/iml-gui/crate/Cargo.lock
+++ b/iml-gui/crate/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
  "proc-macro-hack 0.5.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -198,6 +198,11 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humantime"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -284,6 +289,7 @@ name = "iml-wire-types"
 version = "0.3.0"
 dependencies = [
  "chrono 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "im 15.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-api-utils 0.3.0",
  "serde 1.0.116 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -397,7 +403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -515,7 +521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -535,7 +541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -565,7 +571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -673,7 +679,7 @@ dependencies = [
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -704,7 +710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -789,6 +795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum gloo-timers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
 "checksum hashbrown 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
+"checksum humantime 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum im 15.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
 "checksum indexmap 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
@@ -827,7 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_urlencoded 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 "checksum sized-chunks 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
+"checksum syn 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 "checksum time 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 "checksum tinyvec 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 "checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"

--- a/iml-gui/crate/Cargo.lock
+++ b/iml-gui/crate/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
 name = "iml-graphql-queries"
 version = "0.1.0"
 dependencies = [
+ "humantime 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iml-wire-types 0.3.0",
  "serde 1.0.116 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -697,6 +697,12 @@ fn handle_record_change(
                 ArcRecord::Snapshot(x) => {
                     model.records.snapshot.insert(x.id, Arc::clone(&x));
                 }
+                ArcRecord::SnapshotInterval(x) => {
+                    model.records.snapshot_interval.insert(x.id, Arc::clone(&x));
+                }
+                ArcRecord::SnapshotRetention(x) => {
+                    model.records.snapshot_retention.insert(x.id, Arc::clone(&x));
+                }
                 ArcRecord::StratagemConfig(x) => {
                     model.records.stratagem_config.insert(x.id, Arc::clone(&x));
 

--- a/iml-gui/crate/src/test_utils/fixtures.rs
+++ b/iml-gui/crate/src/test_utils/fixtures.rs
@@ -16,6 +16,8 @@ pub(crate) fn get_cache() -> Cache {
   "sfa_power_supply": {},
   "sfa_controller": {},
   "snapshot": {},
+  "snapshot_interval": {},
+  "snapshot_retention": {},
   "active_alert": {
     "577": {
       "_message": "Updates are ready for server oss1.local",

--- a/iml-warp-drive/src/cache.rs
+++ b/iml-warp-drive/src/cache.rs
@@ -18,7 +18,7 @@ use iml_wire_types::{
         EnclosureType, HealthState, JobState, JobType, MemberState, SfaController, SfaDiskDrive,
         SfaEnclosure, SfaJob, SfaPowerSupply, SfaStorageSystem, SubTargetType,
     },
-    snapshot::SnapshotRecord,
+    snapshot::{DeleteUnit, DeleteWhen, SnapshotInterval, SnapshotRecord, SnapshotRetention},
     warp_drive::{Cache, Record, RecordChange, RecordId},
     Alert, ApiList, EndpointName, Filesystem, FlatQuery, Host, Target, TargetConfParam,
 };
@@ -184,6 +184,18 @@ pub async fn db_record_to_change_record(
             (MessageType::Delete, x) => Ok(RecordChange::Delete(RecordId::Snapshot(x.id))),
             (MessageType::Insert, x) | (MessageType::Update, x) => {
                 Ok(RecordChange::Update(Record::Snapshot(x)))
+            }
+        },
+        DbRecord::SnapshotInterval(x) => match (msg_type, x) {
+            (MessageType::Delete, x) => Ok(RecordChange::Delete(RecordId::SnapshotInterval(x.id))),
+            (MessageType::Insert, x) | (MessageType::Update, x) => {
+                Ok(RecordChange::Update(Record::SnapshotInterval(x)))
+            }
+        },
+        DbRecord::SnapshotRetention(x) => match (msg_type, x) {
+            (MessageType::Delete, x) => Ok(RecordChange::Delete(RecordId::SnapshotRetention(x.id))),
+            (MessageType::Insert, x) | (MessageType::Update, x) => {
+                Ok(RecordChange::Update(Record::SnapshotRetention(x)))
             }
         },
         DbRecord::LnetConfiguration(x) => match (msg_type, x) {
@@ -498,6 +510,54 @@ pub async fn populate_from_db(
         .try_collect()
         .await?;
 
+    cache.snapshot_interval = sqlx::query!("SELECT * FROM snapshot_interval")
+        .fetch(pool)
+        .map_ok(|x| {
+            (
+                x.id,
+                SnapshotInterval {
+                    id: x.id,
+                    filesystem_name: x.filesystem_name,
+                    use_barrier: x.use_barrier,
+                    interval: x.interval.into(),
+                    last_run: x.last_run,
+                },
+            )
+        })
+        .try_collect()
+        .await?;
+
+    cache.snapshot_retention = sqlx::query!(
+        r#"
+        SELECT
+            id,
+            filesystem_name,
+            delete_num,
+            delete_unit as "delete_unit:DeleteUnit",
+            last_run,
+            keep_num
+        FROM snapshot_retention
+    "#
+    )
+    .fetch(pool)
+    .map_ok(|x| {
+        (
+            x.id,
+            SnapshotRetention {
+                id: x.id,
+                filesystem_name: x.filesystem_name,
+                delete_when: DeleteWhen {
+                    value: x.delete_num,
+                    unit: x.delete_unit,
+                },
+                last_run: x.last_run,
+                keep_num: x.keep_num,
+            },
+        )
+    })
+    .try_collect()
+    .await?;
+
     cache.stratagem_config = sqlx::query_as!(
         StratagemConfiguration,
         "select * from chroma_core_stratagemconfiguration where not_deleted = 't'"
@@ -510,8 +570,8 @@ pub async fn populate_from_db(
     cache.user = sqlx::query_as!(
         AuthUserRecord,
         r#"
-        SELECT 
-            id, 
+        SELECT
+            id,
             is_superuser,
             username,
             first_name,

--- a/iml-warp-drive/src/cache.rs
+++ b/iml-warp-drive/src/cache.rs
@@ -18,7 +18,7 @@ use iml_wire_types::{
         EnclosureType, HealthState, JobState, JobType, MemberState, SfaController, SfaDiskDrive,
         SfaEnclosure, SfaJob, SfaPowerSupply, SfaStorageSystem, SubTargetType,
     },
-    snapshot::{DeleteUnit, DeleteWhen, SnapshotInterval, SnapshotRecord, SnapshotRetention},
+    snapshot::{DeleteUnit, SnapshotInterval, SnapshotRecord, SnapshotRetention},
     warp_drive::{Cache, Record, RecordChange, RecordId},
     Alert, ApiList, EndpointName, Filesystem, FlatQuery, Host, Target, TargetConfParam,
 };
@@ -527,7 +527,8 @@ pub async fn populate_from_db(
         .try_collect()
         .await?;
 
-    cache.snapshot_retention = sqlx::query!(
+    cache.snapshot_retention = sqlx::query_as!(
+        SnapshotRetention,
         r#"
         SELECT
             id,
@@ -540,21 +541,7 @@ pub async fn populate_from_db(
     "#
     )
     .fetch(pool)
-    .map_ok(|x| {
-        (
-            x.id,
-            SnapshotRetention {
-                id: x.id,
-                filesystem_name: x.filesystem_name,
-                delete_when: DeleteWhen {
-                    value: x.delete_num,
-                    unit: x.delete_unit,
-                },
-                last_run: x.last_run,
-                keep_num: x.keep_num,
-            },
-        )
-    })
+    .map_ok(|x| (x.id, x))
     .try_collect()
     .await?;
 

--- a/iml-warp-drive/src/db_record.rs
+++ b/iml-warp-drive/src/db_record.rs
@@ -20,7 +20,10 @@ use iml_wire_types::{
         SFA_CONTROLLER_TABLE_NAME, SFA_DISK_DRIVE_TABLE_NAME, SFA_ENCLOSURE_TABLE_NAME,
         SFA_JOB_TABLE_NAME, SFA_POWER_SUPPLY_TABLE_NAME, SFA_STORAGE_SYSTEM_TABLE_NAME,
     },
-    snapshot::{SnapshotRecord, SNAPSHOT_TABLE_NAME},
+    snapshot::{
+        SnapshotInterval, SnapshotRecord, SnapshotRetention, SNAPSHOT_INTERVAL_TABLE_NAME,
+        SNAPSHOT_RETENTION_TABLE_NAME, SNAPSHOT_TABLE_NAME,
+    },
 };
 use serde::de::Error;
 use std::convert::TryFrom;
@@ -50,6 +53,8 @@ pub enum DbRecord {
     SfaPowerSupply(SfaPowerSupply),
     SfaController(SfaController),
     Snapshot(SnapshotRecord),
+    SnapshotInterval(SnapshotInterval),
+    SnapshotRetention(SnapshotRetention),
     StratagemConfiguration(StratagemConfiguration),
     Volume(VolumeRecord),
     VolumeNode(VolumeNodeRecord),
@@ -89,6 +94,12 @@ impl TryFrom<(TableName<'_>, serde_json::Value)> for DbRecord {
                 serde_json::from_value(x).map(DbRecord::StratagemConfiguration)
             }
             SNAPSHOT_TABLE_NAME => serde_json::from_value(x).map(DbRecord::Snapshot),
+            SNAPSHOT_INTERVAL_TABLE_NAME => {
+                serde_json::from_value(x).map(DbRecord::SnapshotInterval)
+            }
+            SNAPSHOT_RETENTION_TABLE_NAME => {
+                serde_json::from_value(x).map(DbRecord::SnapshotRetention)
+            }
             LNET_CONFIGURATION_TABLE_NAME => {
                 serde_json::from_value(x).map(DbRecord::LnetConfiguration)
             }

--- a/iml-wire-types/Cargo.toml
+++ b/iml-wire-types/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.3.0"
 [dependencies]
 bytes = {version = "0.5", optional = true}
 chrono = {version = "0.4", features = ["wasmbind", "serde"]}
+humantime = "2.0"
 im = {version = "15.0", features = ["serde"]}
 iml-api-utils = {path = "../iml-api-utils", version = "0.3"}
 iml-change = {path = "../iml-change", version = "0.1", optional = true}

--- a/iml-wire-types/src/graphql_duration.rs
+++ b/iml-wire-types/src/graphql_duration.rs
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use humantime;
 #[cfg(feature = "postgres-interop")]
 use sqlx::postgres::types::PgInterval;
-use std::{convert::TryFrom, convert::TryInto, fmt, time::Duration};
+#[cfg(feature = "graphql")]
+use std::convert::TryInto;
+use std::{convert::TryFrom, fmt, time::Duration};
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, PartialEq, Debug)]
 #[serde(try_from = "String", into = "String")]

--- a/iml-wire-types/src/graphql_duration.rs
+++ b/iml-wire-types/src/graphql_duration.rs
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use humantime;
+#[cfg(feature = "postgres-interop")]
+use sqlx::postgres::types::PgInterval;
+use std::{convert::TryFrom, convert::TryInto, fmt, time::Duration};
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, PartialEq, Debug)]
+#[serde(try_from = "String", into = "String")]
+pub struct GraphQLDuration(pub Duration);
+
+#[cfg(feature = "graphql")]
+#[juniper::graphql_scalar(
+    name = "Duration",
+    description = "Duration in human-readable form, like '15min 2ms'"
+)]
+impl<S> GraphQLScalar for GraphQLDuration
+where
+    S: juniper::ScalarValue,
+{
+    fn resolve(&self) -> juniper::Value {
+        juniper::Value::scalar(humantime::format_duration(self.0).to_string())
+    }
+
+    fn from_input_value(value: &juniper::InputValue) -> Option<GraphQLDuration> {
+        value.as_string_value()?.to_string().try_into().ok()
+    }
+
+    fn from_str<'a>(value: juniper::ScalarToken<'a>) -> juniper::ParseScalarResult<'a, S> {
+        <String as juniper::ParseScalarValue<S>>::from_str(value)
+    }
+}
+
+#[cfg(feature = "postgres-interop")]
+impl From<PgInterval> for GraphQLDuration {
+    fn from(x: PgInterval) -> Self {
+        GraphQLDuration(Duration::from_micros(x.microseconds as u64))
+    }
+}
+
+impl TryFrom<String> for GraphQLDuration {
+    type Error = humantime::DurationError;
+
+    fn try_from(x: String) -> Result<Self, Self::Error> {
+        x.parse::<humantime::Duration>()
+            .map(|x| GraphQLDuration(x.into()))
+    }
+}
+
+impl From<GraphQLDuration> for String {
+    fn from(x: GraphQLDuration) -> Self {
+        x.to_string()
+    }
+}
+
+impl fmt::Display for GraphQLDuration {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", humantime::format_duration(self.0).to_string())
+    }
+}

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod client;
 pub mod db;
+pub mod graphql_duration;
 pub mod high_availability;
 pub mod sfa;
 pub mod snapshot;

--- a/iml-wire-types/src/snapshot.rs
+++ b/iml-wire-types/src/snapshot.rs
@@ -86,7 +86,8 @@ pub const SNAPSHOT_INTERVAL_TABLE_NAME: TableName = TableName("snapshot_interval
 pub struct SnapshotRetention {
     pub id: i32,
     pub filesystem_name: String,
-    pub delete_when: DeleteWhen,
+    pub delete_num: i32,
+    pub delete_unit: DeleteUnit,
     pub last_run: Option<DateTime<Utc>>,
     /// Number of snapshots to keep
     pub keep_num: Option<i32>,
@@ -99,13 +100,6 @@ impl Id for SnapshotRetention {
 }
 
 pub const SNAPSHOT_RETENTION_TABLE_NAME: TableName = TableName("snapshot_retention");
-
-#[cfg_attr(feature = "graphql", derive(juniper::GraphQLObject))]
-#[derive(serde::Deserialize, serde::Serialize, Clone, PartialEq, Debug)]
-pub struct DeleteWhen {
-    pub value: i32,
-    pub unit: DeleteUnit,
-}
 
 #[cfg_attr(feature = "graphql", derive(juniper::GraphQLEnum))]
 #[cfg_attr(feature = "postgres-interop", derive(sqlx::Type))]

--- a/iml-wire-types/src/snapshot.rs
+++ b/iml-wire-types/src/snapshot.rs
@@ -108,8 +108,10 @@ pub struct DeleteWhen {
 }
 
 #[cfg_attr(feature = "graphql", derive(juniper::GraphQLEnum))]
-#[cfg_attr(feature = "postgres-interop", sqlx(rename = "snapshot_delete_unit"))]
 #[cfg_attr(feature = "postgres-interop", derive(sqlx::Type))]
+#[cfg_attr(feature = "postgres-interop", sqlx(rename = "snapshot_delete_unit"))]
+#[cfg_attr(feature = "postgres-interop", sqlx(rename_all = "lowercase"))]
+#[serde(rename_all = "lowercase")]
 #[derive(serde::Deserialize, serde::Serialize, Clone, PartialEq, Debug)]
 pub enum DeleteUnit {
     Percent,

--- a/migrations/20200817164118_utils.sql
+++ b/migrations/20200817164118_utils.sql
@@ -1,3 +1,9 @@
+-- Make sure we can create composite types with non-null text
+DO $$ BEGIN
+    CREATE DOMAIN non_null_text AS Text NOT NULL;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
 -- Convert an interval to a humantime understandable string
 CREATE OR REPLACE FUNCTION interval_to_seconds(interval) RETURNS text
   AS $$ select EXTRACT(EPOCH FROM $1) ||'s' $$

--- a/migrations/20200817164118_utils.sql
+++ b/migrations/20200817164118_utils.sql
@@ -1,0 +1,28 @@
+-- Convert an interval to a humantime understandable string
+CREATE OR REPLACE FUNCTION interval_to_seconds(interval) RETURNS text
+  AS $$ select EXTRACT(EPOCH FROM $1) ||'s' $$
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+
+-- Create the akward concatenation of a notify row
+CREATE OR REPLACE FUNCTION notify_row(text, text, json) RETURNS text
+  AS $$ 
+  BEGIN
+    RETURN '[ "' || $1 || '", "' || $2 || '", ' || $3 || ']'; 
+  END;
+  $$ LANGUAGE plpgsql;
+
+-- Covers the 90% case of notifications
+CREATE OR REPLACE FUNCTION table_update_notify() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    PERFORM pg_notify('table_update', notify_row(TG_OP, TG_TABLE_NAME, row_to_json(NEW)));
+  ELSEIF TG_OP = 'UPDATE' AND OLD IS DISTINCT FROM NEW THEN
+    PERFORM pg_notify('table_update', notify_row(TG_OP, TG_TABLE_NAME, row_to_json(NEW)));
+  ELSE
+    PERFORM pg_notify('table_update', notify_row(TG_OP, TG_TABLE_NAME, row_to_json(OLD)));
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/20200824170157_corosync.sql
+++ b/migrations/20200824170157_corosync.sql
@@ -1,15 +1,6 @@
-DO $$ BEGIN CREATE DOMAIN non_null_text AS Text NOT NULL;
-
-EXCEPTION
-WHEN duplicate_object THEN NULL;
-
-END $$;
-
-DO $$ BEGIN CREATE TYPE corosync_node_key AS (id non_null_text, NAME non_null_text);
-
-EXCEPTION
-WHEN duplicate_object THEN NULL;
-
+DO $$ BEGIN
+  CREATE TYPE corosync_node_key AS (id non_null_text, NAME non_null_text);
+  EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 
 CREATE TABLE IF NOT EXISTS corosync_cluster (

--- a/migrations/20200831174542_snapshot.sql
+++ b/migrations/20200831174542_snapshot.sql
@@ -45,7 +45,8 @@ CREATE TABLE IF NOT EXISTS snapshot_interval (
   filesystem_name TEXT NOT NULL,
   use_barrier BOOLEAN NOT NULL,
   last_run TIMESTAMP WITH TIME ZONE,
-  interval INTERVAL NOT NULL
+  interval INTERVAL NOT NULL,
+  UNIQUE (filesystem_name, interval)
 );
 
 DROP TRIGGER IF EXISTS snapshot_interval_notify_update ON snapshot_interval;
@@ -69,7 +70,7 @@ CREATE TYPE snapshot_delete_unit AS ENUM ('percent', 'gibibytes', 'tebibytes');
 
 CREATE TABLE IF NOT EXISTS snapshot_retention (
   id serial PRIMARY KEY,
-  filesystem_name TEXT NOT NULL,
+  filesystem_name TEXT NOT NULL UNIQUE,
   delete_num INT NOT NULL,
   delete_unit snapshot_delete_unit NOT NULL,
   keep_num INT,

--- a/migrations/20200831174542_snapshot.sql
+++ b/migrations/20200831174542_snapshot.sql
@@ -10,19 +10,6 @@ CREATE TABLE IF NOT EXISTS snapshot (
   UNIQUE (filesystem_name, snapshot_name)
 );
 
-CREATE OR REPLACE FUNCTION table_update_notify() RETURNS TRIGGER AS $$
-BEGIN
-  IF TG_OP = 'INSERT' THEN
-    PERFORM pg_notify('table_update', '[ "' || TG_OP || '", "' || TG_TABLE_NAME || '", ' || row_to_json(NEW) || ']');
-  ELSEIF TG_OP = 'UPDATE' AND OLD IS DISTINCT FROM NEW THEN
-    PERFORM pg_notify('table_update', '[ "' || TG_OP || '", "' || TG_TABLE_NAME || '", ' || row_to_json(NEW) || ']');
-  ELSE
-    PERFORM pg_notify('table_update','[ "' || TG_OP || '", "' || TG_TABLE_NAME || '", ' || row_to_json(OLD) || ']');
-  END IF;
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
 DROP TRIGGER IF EXISTS snapshot_notify_update ON snapshot;
 
 DROP TRIGGER IF EXISTS snapshot_notify_insert ON snapshot;
@@ -49,6 +36,27 @@ CREATE TABLE IF NOT EXISTS snapshot_interval (
   UNIQUE (filesystem_name, interval)
 );
 
+CREATE OR REPLACE FUNCTION table_update_notify_snapshot_interval() RETURNS TRIGGER 
+  AS $$
+    BEGIN
+      IF TG_OP = 'INSERT' THEN PERFORM pg_notify(
+        'table_update',
+        notify_row(TG_OP, TG_TABLE_NAME, json_build_object('id', NEW.id, 'filesystem_name', NEW.filesystem_name, 'use_barrier', NEW.use_barrier, 'last_run', NEW.last_run, 'interval', interval_to_seconds(NEW.interval)))
+      );
+      ELSEIF TG_OP = 'UPDATE' AND OLD IS DISTINCT FROM NEW THEN PERFORM pg_notify(
+        'table_update',
+        notify_row(TG_OP, TG_TABLE_NAME, json_build_object('id', NEW.id, 'filesystem_name', NEW.filesystem_name, 'use_barrier', NEW.use_barrier, 'last_run', NEW.last_run, 'interval', interval_to_seconds(NEW.interval)))
+      );
+      ELSE PERFORM pg_notify(
+        'table_update',
+        notify_row(TG_OP, TG_TABLE_NAME, json_build_object('id', OLD.id, 'filesystem_name', OLD.filesystem_name, 'use_barrier', OLD.use_barrier, 'last_run', OLD.last_run, 'interval', interval_to_seconds(OLD.interval)))
+      );
+      END IF;
+
+      RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
 DROP TRIGGER IF EXISTS snapshot_interval_notify_update ON snapshot_interval;
 
 DROP TRIGGER IF EXISTS snapshot_interval_notify_insert ON snapshot_interval;
@@ -57,14 +65,14 @@ DROP TRIGGER IF EXISTS snapshot_interval_notify_delete ON snapshot_interval;
 
 CREATE TRIGGER snapshot_interval_notify_update
 AFTER
-UPDATE ON snapshot_interval FOR EACH ROW EXECUTE PROCEDURE table_update_notify();
+UPDATE ON snapshot_interval FOR EACH ROW EXECUTE PROCEDURE table_update_notify_snapshot_interval();
 
 CREATE TRIGGER snapshot_interval_notify_insert
 AFTER
-INSERT ON snapshot_interval FOR EACH ROW EXECUTE PROCEDURE table_update_notify();
+INSERT ON snapshot_interval FOR EACH ROW EXECUTE PROCEDURE table_update_notify_snapshot_interval();
 
 CREATE TRIGGER snapshot_interval_notify_delete
-AFTER DELETE ON snapshot_interval FOR EACH ROW EXECUTE PROCEDURE table_update_notify();
+AFTER DELETE ON snapshot_interval FOR EACH ROW EXECUTE PROCEDURE table_update_notify_snapshot_interval();
 
 CREATE TYPE snapshot_delete_unit AS ENUM ('percent', 'gibibytes', 'tebibytes');
 

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -926,6 +926,48 @@
       ]
     }
   },
+  "46a7815b904eddf8c5b3f77e9c9623806ba3e0a0247080ac9900adaad6b3ce11": {
+    "query": "SELECT * FROM snapshot_interval",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "filesystem_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "use_barrier",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 3,
+          "name": "last_run",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 4,
+          "name": "interval",
+          "type_info": "Interval"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        false
+      ]
+    }
+  },
   "4eb28fbaf2c42bbcc852c074ade355c4f29c318def54af2290a05f37e90a3b23": {
     "query": "\n            INSERT INTO corosync_node (\n                id,\n                cluster_id,\n                online,\n                standby,\n                standby_onfail,\n                maintenance,\n                pending,\n                unclean,\n                shutdown,\n                expected_up,\n                is_dc,\n                resources_running,\n                type\n            )\n            SELECT\n                id::corosync_node_key,\n                $13,\n                online,\n                standby,\n                standby_onfail,\n                maintenance,\n                pending,\n                unclean,\n                shutdown,\n                expected_up,\n                is_dc,\n                resources_running,\n                type\n            FROM UNNEST(\n                $1::text[],\n                $2::bool[],\n                $3::bool[],\n                $4::bool[],\n                $5::bool[],\n                $6::bool[],\n                $7::bool[],\n                $8::bool[],\n                $9::bool[],\n                $10::bool[],\n                $11::int[],\n                $12::text[]\n            )\n            AS t(\n                id,\n                online,\n                standby,\n                standby_onfail,\n                maintenance,\n                pending,\n                unclean,\n                shutdown,\n                expected_up,\n                is_dc,\n                resources_running,\n                type\n            )\n            ON CONFLICT (id, cluster_id) DO UPDATE\n            SET\n                online = excluded.online,\n                standby = excluded.standby,\n                standby_onfail = excluded.standby_onfail,\n                maintenance = excluded.maintenance,\n                pending = excluded.pending,\n                unclean = excluded.unclean,\n                shutdown = excluded.shutdown,\n                expected_up = excluded.expected_up,\n                is_dc = excluded.is_dc,\n                resources_running = excluded.resources_running,\n                type = excluded.type\n        ",
     "describe": {
@@ -1428,6 +1470,32 @@
       "nullable": []
     }
   },
+  "6eee04350f715395f806e84340c0ad004b16582d8ff6c461801db8c897edf9c7": {
+    "query": "\n                INSERT INTO snapshot_retention (\n                    filesystem_name,\n                    delete_num,\n                    delete_unit,\n                    keep_num\n                )\n                VALUES ($1, $2, $3, $4)\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Int4",
+          {
+            "Custom": {
+              "name": "snapshot_delete_unit",
+              "kind": {
+                "Enum": [
+                  "percent",
+                  "gibibytes",
+                  "tebibytes"
+                ]
+              }
+            }
+          },
+          "Int4"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "7bee1c38d05ac3f8bcf4d48b375c740341121c04d2f5b04ceb1d58ef0a006c08": {
     "query": "\n        SELECT * FROM chroma_core_lustreclientmount\n        WHERE\n            state = 'mounted'\n            AND not_deleted = 't'\n            AND id != ALL($1)\n        LIMIT $2\n        ",
     "describe": {
@@ -1820,6 +1888,20 @@
       ]
     }
   },
+  "8908ebc23c19d58d61a7b05512385d7fe3e1702a31f6f9de3d6e071514383c5b": {
+    "query": "\n                INSERT INTO snapshot_interval (\n                    filesystem_name,\n                    use_barrier,\n                    interval\n                )\n                VALUES ($1, $2, $3)\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Bool",
+          "Interval"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "89a7a37f26d89b7def2d6f7273fee79cd4c7fc7070343e4a4197c4080ded5003": {
     "query": "SELECT * FROM chroma_core_task WHERE name = $1",
     "describe": {
@@ -1998,6 +2080,66 @@
       ]
     }
   },
+  "90cdeeec70b23ba73cae07b3adcee6243c657bc922448cfacf703cf1072f3181": {
+    "query": "\n        SELECT\n            id,\n            is_superuser,\n            username,\n            first_name,\n            last_name,\n            email,\n            is_staff,\n            is_active \n        FROM auth_user\n    ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "is_superuser",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 2,
+          "name": "username",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 3,
+          "name": "first_name",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 4,
+          "name": "last_name",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 5,
+          "name": "email",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 6,
+          "name": "is_staff",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 7,
+          "name": "is_active",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "922e7457db1e165807273def66a5ecc6b22be1a849f5e4b06d5149ec00b5e8aa": {
     "query": "\n                DELETE FROM chroma_core_logmessage\n                WHERE id in ( \n                    SELECT id FROM chroma_core_logmessage ORDER BY id LIMIT $1\n                )\n            ",
     "describe": {
@@ -2005,6 +2147,18 @@
       "parameters": {
         "Left": [
           "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "93e2695978ceecbebff40c31f2f58bf6fd5351869d3b279adc5ad1f7436a25e9": {
+    "query": "DELETE FROM snapshot_interval WHERE id=$1",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int4"
         ]
       },
       "nullable": []
@@ -2480,66 +2634,6 @@
       "nullable": []
     }
   },
-  "adec7f8e00d15a6c5209443c43b80c59bcb85ea726dbc88628978571ea91b5ba": {
-    "query": "\n        SELECT \n            id, \n            is_superuser,\n            username,\n            first_name,\n            last_name,\n            email,\n            is_staff,\n            is_active \n        FROM auth_user\n    ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 1,
-          "name": "is_superuser",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 2,
-          "name": "username",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 3,
-          "name": "first_name",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 4,
-          "name": "last_name",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 5,
-          "name": "email",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 6,
-          "name": "is_staff",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 7,
-          "name": "is_active",
-          "type_info": "Bool"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "b04b6d9456e4fbd6b7c97cb633393b8971701303845f99a716f581b6ee0eb481": {
     "query": "SELECT repo_name from chroma_core_repo where repo_name = ANY($1)",
     "describe": {
@@ -2865,6 +2959,65 @@
       ]
     }
   },
+  "c75c539a2ccc3227051a44e3b391307df54a1ac61eb5a8fb8cd7870ce0ea26dd": {
+    "query": "\n                SELECT\n                    id,\n                    filesystem_name,\n                    delete_num,\n                    delete_unit as \"delete_unit:DeleteUnit\",\n                    last_run,\n                    keep_num\n                FROM snapshot_retention\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "filesystem_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "delete_num",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 3,
+          "name": "delete_unit:DeleteUnit",
+          "type_info": {
+            "Custom": {
+              "name": "snapshot_delete_unit",
+              "kind": {
+                "Enum": [
+                  "percent",
+                  "gibibytes",
+                  "tebibytes"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "ordinal": 4,
+          "name": "last_run",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 5,
+          "name": "keep_num",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        true
+      ]
+    }
+  },
   "c794f65b5ef4d77224667f77df480d76eaee130d7dc4ddde13d9330f5479595d": {
     "query": "\n            DELETE from chroma_core_sfaenclosure\n            WHERE (index, storage_system)\n            IN (\n                SELECT *\n                FROM UNNEST($1::int[], $2::text[])\n            )\n        ",
     "describe": {
@@ -2873,6 +3026,18 @@
         "Left": [
           "Int4Array",
           "TextArray"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "c92c006232fff5c4ba37894b349d63142824fc0141a156f06114fa113ed36fa7": {
+    "query": "DELETE FROM snapshot_retention WHERE id=$1",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int4"
         ]
       },
       "nullable": []
@@ -3407,6 +3572,65 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "e992bff12ae00cc8a7ee249be24096d3a308a2551f5caf95446da7b462837548": {
+    "query": "\n        SELECT\n            id,\n            filesystem_name,\n            delete_num,\n            delete_unit as \"delete_unit:DeleteUnit\",\n            last_run,\n            keep_num\n        FROM snapshot_retention\n    ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "filesystem_name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "delete_num",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 3,
+          "name": "delete_unit:DeleteUnit",
+          "type_info": {
+            "Custom": {
+              "name": "snapshot_delete_unit",
+              "kind": {
+                "Enum": [
+                  "percent",
+                  "gibibytes",
+                  "tebibytes"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "ordinal": 4,
+          "name": "last_run",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 5,
+          "name": "keep_num",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        true
+      ]
     }
   },
   "ec70b9a5caeadc31f5d1359737cc1c6da64e41db8315a81d81420d3b37b182c5": {

--- a/tests/unit/lib/iml_unit_test_case.py
+++ b/tests/unit/lib/iml_unit_test_case.py
@@ -12,13 +12,17 @@ class IMLUnitTestCase(TestCase):
     def setUp(self):
         super(IMLUnitTestCase, self).setUp()
 
-        with open("./migrations/20200824170157_corosync.sql", "r") as f:
+        with open("./migrations/20200817164118_utils.sql", "r") as f:
             sql = f.read()
+
+        with open("./migrations/20200824170157_corosync.sql", "r") as f:
+            sql2 = f.read()
 
         from django.db import connection
 
         with connection.cursor() as cursor:
             cursor.execute(sql)
+            cursor.execute(sql2)
 
         mock.patch("chroma_core.services.job_scheduler.job_scheduler.LockQueue.put").start()
         mock.patch("chroma_core.services.dbutils.exit_if_in_transaction").start()

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -46,6 +46,7 @@ The IML Team typically uses [Vagrant](https://www.vagrantup.com) and [VirtualBox
    ```
 
 1. Install IML. IML Can be installed using either rpm-based / systemd or docker. Install IML by using one of the following provisioning scripts:
+
    1. Latest RPM from [copr-devel](https://copr.fedorainfracloud.org/coprs/managerforlustre/manager-for-lustre-devel/)
 
       ```sh
@@ -80,25 +81,28 @@ The IML Team typically uses [Vagrant](https://www.vagrantup.com) and [VirtualBox
 
 1. Setup the clients
 
-    ```sh
+   ```sh
    vagrant provision --provision-with=install-lustre-client,configure-lustre-client-network
    ```
 
 1. Mount the clients:
+
    - ldiskfs or lvm based
-      ```sh
-      vagrant provision --provision-with=mount-lustre-client
-      ```
+
+     ```sh
+     vagrant provision --provision-with=mount-lustre-client
+     ```
 
    - Second ldiskfs filesystem
-      ```sh
-      vagrant provision --provision-with=mount-lustre-client-fs2
-      ```
+
+     ```sh
+     vagrant provision --provision-with=mount-lustre-client-fs2
+     ```
 
    - ZFS backed filesystem
-      ```sh
-      vagrant provision --provision-with=mount-lustre-client-zfs
-      ```
+     ```sh
+     vagrant provision --provision-with=mount-lustre-client-zfs
+     ```
 
 At this point you should be able to access the IML GUI on your host at https://localhost:8443
 
@@ -139,6 +143,7 @@ From here you can decide what type of setup to run.
   ```
 
 1. Setup and mount the clients
+
    ```sh
    vagrant provision --provision-with=install-lustre-client,configure-lustre-client-network,mount-lustre-client
    ```


### PR DESCRIPTION
This patch adds support for creating and deleting snapshot intervals
and snapshot retention rules via the API.

It also adds support for these tables to warp-drive.

![Screen Shot 2020-09-16 at 10 08 02 AM](https://user-images.githubusercontent.com/458717/93368146-8ce75e00-f81b-11ea-9b49-2614f2616a06.png)

![Screen Shot 2020-09-16 at 10 17 30 AM](https://user-images.githubusercontent.com/458717/93368169-97a1f300-f81b-11ea-89c8-58cf2b7efcc7.png)


Signed-off-by: Joe Grund <jgrund@whamcloud.io>
Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2247)
<!-- Reviewable:end -->
