### PR TITLE
Extract command polling logic to it's own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iml-command-utils"
+version = "0.3.0"
+dependencies = [
+ "futures",
+ "iml-manager-client",
+ "iml-tracing",
+ "iml-wire-types",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "iml-corosync"
 version = "0.3.0"
 dependencies = [
@@ -1708,6 +1720,7 @@ dependencies = [
  "futures",
  "hostlist-parser",
  "iml-api-utils",
+ "iml-command-utils",
  "iml-graphql-queries",
  "iml-influx",
  "iml-manager-client",
@@ -2059,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a68371cf417889c9d7f98235b7102ea7c54fc59bcbd22f3dea785be9d27e40"
+checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
  "console 0.12.0",
  "lazy_static",
@@ -2217,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "lapin"
-version = "1.2.4"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d3e4d31709ab4340ac6f270d440c59d1e1014890af5d9392ee882bd4ee3e3c"
+checksum = "3cefdb65897723ab87b96a152f3872f8e77fcc0f6c075b61233fab05d14c513a"
 dependencies = [
  "amq-protocol",
  "async-task",
@@ -2861,9 +2874,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinky-swear"
-version = "4.3.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e5cf8b99d12fdd41b2be5ee172f74c69526eda68417c6a440c9fa6079f0f2a"
+checksum = "9bf8cda6f8e1500338634e4e3ce90ac59eb7929a1e088b6946c742be1cc44dc1"
 dependencies = [
  "doc-comment",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   'iml-cmd',
   'iml-fs',
   'iml-graphql-queries',
+  'iml-command-utils',
   'iml-influx',
   'iml-job-scheduler-rpc',
   'iml-mailbox',

--- a/iml-command-utils/Cargo.toml
+++ b/iml-command-utils/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+name = "iml-command-utils"
+version = "0.3.0"
+
+[dependencies]
+futures = "0.3"
+iml-manager-client = {path = "../iml-manager-client", version = "0.3"}
+iml-tracing = {version = "0.2", path = "../iml-tracing"}
+iml-wire-types = {path = "../iml-wire-types", version = "0.3"}
+thiserror = "1.0"
+tokio = {version = "0.2", features = ["macros", "io-std", "io-util", "fs", "rt-threaded"]}

--- a/iml-command-utils/src/lib.rs
+++ b/iml-command-utils/src/lib.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use futures::channel::mpsc;
+use iml_tracing::tracing;
+use iml_wire_types::{ApiList, Command, EndpointName as _};
+use std::{collections::HashSet, iter, time::Duration};
+use tokio::time::delay_for;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CmdUtilError {
+    #[error(transparent)]
+    ImlManagerClientError(#[from] iml_manager_client::ImlManagerClientError),
+}
+
+pub enum Progress {
+    Update(i32),
+    Complete(Command),
+}
+
+pub async fn wait_for_cmds_progress(
+    cmds: &[Command],
+    tx: Option<mpsc::UnboundedSender<Progress>>,
+) -> Result<Vec<Command>, CmdUtilError> {
+    let mut state: HashSet<_> = cmds.iter().map(|x| x.id).collect();
+    let mut settled_commands = vec![];
+
+    loop {
+        if state.is_empty() {
+            tracing::debug!("All commands complete. Returning");
+            return Ok(settled_commands);
+        }
+
+        delay_for(Duration::from_millis(1000)).await;
+
+        let query: Vec<_> = state
+            .iter()
+            .map(|x| ["id__in".into(), x.to_string()])
+            .chain(iter::once(["limit".into(), "0".into()]))
+            .collect();
+
+        let client = iml_manager_client::get_client()?;
+
+        let cmds: ApiList<Command> =
+            iml_manager_client::get(client, Command::endpoint_name(), query).await?;
+
+        for cmd in cmds.objects {
+            if cmd_finished(&cmd) {
+                state.remove(&cmd.id);
+
+                if let Some(tx) = tx.as_ref() {
+                    let _ = tx.unbounded_send(Progress::Complete(cmd.clone()));
+                }
+
+                settled_commands.push(cmd);
+            } else if let Some(tx) = tx.as_ref() {
+                let _ = tx.unbounded_send(Progress::Update(cmd.id));
+            }
+        }
+    }
+}
+
+fn cmd_finished(cmd: &Command) -> bool {
+    cmd.complete
+}

--- a/iml-manager-cli/Cargo.toml
+++ b/iml-manager-cli/Cargo.toml
@@ -12,13 +12,14 @@ dotenv = "0.15"
 futures = "0.3"
 hostlist-parser = "0.1.3"
 iml-api-utils = {path = "../iml-api-utils", version = "0.3"}
+iml-command-utils = {path = "../iml-command-utils", version = "0.3"}
 iml-graphql-queries = {path = "../iml-graphql-queries", version = "0.1"}
 iml-influx = {path = "../iml-influx", version = "0.1"}
 iml-manager-client = {path = "../iml-manager-client", version = "0.3"}
 iml-postgres = {path = "../iml-postgres", version = "0.3"}
 iml-tracing = {version = "0.2", path = "../iml-tracing"}
 iml-wire-types = {path = "../iml-wire-types", version = "0.3", features = ["cli"]}
-indicatif = "0.14"
+indicatif = "0.15"
 lazy_static = "1.4"
 number-formatter = {path = "../number-formatter", version = "0.1"}
 prettytable-rs = "0.8"

--- a/iml-manager-cli/src/error.rs
+++ b/iml-manager-cli/src/error.rs
@@ -60,10 +60,12 @@ impl std::error::Error for DurationParseError {}
 pub enum ImlManagerCliError {
     ApiError(String),
     ClientRequestError(#[from] iml_manager_client::ImlManagerClientError),
+    CmdUtilError(#[from] iml_command_utils::CmdUtilError),
     CombineEasyError(combine::stream::easy::Errors<char, &'static str, usize>),
     DoesNotExist(&'static str),
     FailedCommandError(Vec<Command>),
     FromUtf8Error(#[from] std::string::FromUtf8Error),
+    Infallible(#[from] std::convert::Infallible),
     ImlGraphqlQueriesErrors(#[from] iml_graphql_queries::Errors),
     IntParseError(#[from] std::num::ParseIntError),
     IoError(#[from] std::io::Error),
@@ -81,6 +83,7 @@ impl std::fmt::Display for ImlManagerCliError {
         match *self {
             ImlManagerCliError::ApiError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::ClientRequestError(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::CmdUtilError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::CombineEasyError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::DoesNotExist(ref err) => write!(f, "{} does not exist", err),
             ImlManagerCliError::FailedCommandError(ref xs) => {
@@ -93,6 +96,9 @@ impl std::fmt::Display for ImlManagerCliError {
             }
             ImlManagerCliError::FromUtf8Error(ref err) => write!(f, "{}", err),
             ImlManagerCliError::ImlGraphqlQueriesErrors(ref err) => write!(f, "{}", err),
+            ImlManagerCliError::Infallible(_) => {
+                write!(f, "A (supposedly) impossible situation has occurred")
+            }
             ImlManagerCliError::IntParseError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::IoError(ref err) => write!(f, "{}", err),
             ImlManagerCliError::ParseDurationError(ref err) => write!(f, "{}", err),


### PR DESCRIPTION
This patch extracts the command polling logic to it's own crate.
It doesn't use any feature flags, and does not duplicate the polling
logic.

The internal behavior is delegated to a mpsc channel, where the caller
can decide how to process completions and updates.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2251)
<!-- Reviewable:end -->
