### PR TITLE
Fix docker releases so older compose is used

### DIFF
--- a/.github/workflows/devel-release.yml
+++ b/.github/workflows/devel-release.yml
@@ -70,6 +70,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v1
 
+      - name: Fetch older docker-compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.26.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+
       - name: Build the iml images
         working-directory: ./docker
         run: |

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -69,6 +69,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v1
 
+      - name: Fetch older docker-compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.26.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+
       - name: Build the iml images
         working-directory: ./docker
         run: |


### PR DESCRIPTION
Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2252)
<!-- Reviewable:end -->
