### PR TITLE
Add ability to skip snapshots in integration testing

### DIFF
--- a/iml-system-docker-tests/src/lib.rs
+++ b/iml-system-docker-tests/src/lib.rs
@@ -12,32 +12,42 @@ pub async fn run_fs_test(config: Config) -> Result<Config, TestError> {
 
     let snapshot_map = snapshots::get_snapshots().await?;
     let graph = snapshots::create_graph(&snapshot_map["iscsi"]);
-    let active_snapshots = snapshots::get_active_snapshots(&config, &graph);
-    let target_snapshot = active_snapshots.last().expect("target snapshot not found.");
-    println!("target snapshot: {:?}", target_snapshot);
+    
+    let (active_snapshots, target_snapshot) = if config.use_snapshots {
+        let active_snapshots = snapshots::get_active_snapshots(&config, &graph);
+        let target_snapshot = active_snapshots.last().expect("target snapshot not found.");
+        println!("target snapshot: {:?}", target_snapshot);
 
-    if target_snapshot.name != snapshots::SnapshotName::Init {
-        vagrant::halt()
-            .await?
-            .args(&config.all_hosts())
-            .checked_status()
-            .await?;
-
-        for host in config.all_hosts() {
-            let result = vagrant::snapshot_restore(host, target_snapshot.name.to_string().as_str())
+        if target_snapshot.name != snapshots::SnapshotName::Init {
+            vagrant::halt()
                 .await?
+                .args(&config.all_hosts())
                 .checked_status()
-                .await;
+                .await?;
 
-            if result.is_err() {
-                println!(
-                    "Snapshot {} not available on host {}. Skipping.",
-                    target_snapshot.name.to_string(),
-                    host
-                );
+            for host in config.all_hosts() {
+                let result = vagrant::snapshot_restore(host, target_snapshot.name.to_string().as_str())
+                    .await?
+                    .checked_status()
+                    .await;
+
+                if result.is_err() {
+                    println!(
+                        "Snapshot {} not available on host {}. Skipping.",
+                        target_snapshot.name.to_string(),
+                        host
+                    );
+                }
             }
         }
-    }
+    } else {
+        let target_snapshot = snapshots::Snapshot {
+            name: snapshots::SnapshotName::Init,
+            available: true,
+        };
+
+        (vec![], target_snapshot)
+    };
 
     let actions = snapshots::get_active_test_path(&config, &graph, &target_snapshot.name);
 

--- a/iml-system-docker-tests/tests/ldiskfs_test.rs
+++ b/iml-system-docker-tests/tests/ldiskfs_test.rs
@@ -15,6 +15,7 @@ async fn test_docker_ldiskfs_setup() -> Result<(), TestError> {
         ],
         test_type: TestType::Docker,
         ntp_server: NtpServer::HostOnly,
+        use_snapshots: use_snapshots(),
         ..config
     };
 

--- a/iml-system-docker-tests/tests/stratagem_test.rs
+++ b/iml-system-docker-tests/tests/stratagem_test.rs
@@ -18,6 +18,7 @@ async fn test_docker_stratagem_setup() -> Result<(), TestError> {
         branding: iml_wire_types::Branding::DDN(iml_wire_types::DdnBranding::Exascaler),
         test_type: TestType::Docker,
         ntp_server: NtpServer::HostOnly,
+        use_snapshots: use_snapshots(),
         ..config
     };
 

--- a/iml-system-docker-tests/tests/zfs_test.rs
+++ b/iml-system-docker-tests/tests/zfs_test.rs
@@ -16,6 +16,7 @@ async fn test_docker_zfs_setup() -> Result<(), TestError> {
         test_type: TestType::Docker,
         ntp_server: NtpServer::HostOnly,
         fs_type: FsType::ZFS,
+        use_snapshots: use_snapshots(),
         ..config
     };
 

--- a/iml-system-rpm-tests/tests/ldiskfs_test.rs
+++ b/iml-system-rpm-tests/tests/ldiskfs_test.rs
@@ -14,6 +14,7 @@ async fn test_ldiskfs_setup() -> Result<(), TestError> {
             ("base_monitored".into(), config.storage_servers()),
             ("base_client".into(), config.client_servers()),
         ],
+        use_snapshots: use_snapshots(),
         ..config
     };
 

--- a/iml-system-rpm-tests/tests/stratagem_test.rs
+++ b/iml-system-rpm-tests/tests/stratagem_test.rs
@@ -16,6 +16,7 @@ async fn test_stratagem_setup() -> Result<(), TestError> {
         ],
         branding: iml_wire_types::Branding::DDN(iml_wire_types::DdnBranding::Exascaler),
         use_stratagem: true,
+        use_snapshots: use_snapshots(),
         ..config
     };
 

--- a/iml-system-rpm-tests/tests/zfs_test.rs
+++ b/iml-system-rpm-tests/tests/zfs_test.rs
@@ -14,6 +14,7 @@ async fn test_zfs_setup() -> Result<(), TestError> {
             ("base_client".into(), config.client_servers()),
         ],
         fs_type: FsType::ZFS,
+        use_snapshots: use_snapshots(),
         ..config
     };
 


### PR DESCRIPTION
This will be useful when setting up clusters using a single test. It
will skip taking snapshots (if the environment variable is set) and
finish the single test quicker.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2254)
<!-- Reviewable:end -->
