### PR TITLE
Make task remove idempotent

### DIFF
--- a/chroma_core/models/task.py
+++ b/chroma_core/models/task.py
@@ -122,8 +122,9 @@ class RemoveTaskJob(AdvertisedJob):
 
     def get_steps(self):
         steps = []
-        for host in self.task.filesystem.get_servers():
-            steps.append((RemoveTaskStep, {"task": self.task.name, "host": host.fqdn}))
+        if self.task.state != "removed":
+            for host in self.task.filesystem.get_servers():
+                steps.append((RemoveTaskStep, {"task": self.task.name, "host": host.fqdn}))
 
         return steps
 


### PR DESCRIPTION
Only call RemoteTaskStep if state is not already removed.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2260)
<!-- Reviewable:end -->
