### PR TITLE
Implement influx client extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]
@@ -1326,6 +1326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,9 +1348,9 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.13.7"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
+checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1354,10 +1360,10 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project",
  "socket2",
- "time 0.1.44",
  "tokio",
  "tower-service",
  "tracing",
@@ -1646,9 +1652,11 @@ dependencies = [
 name = "iml-influx"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "influx_db_client",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1682,7 +1690,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.2.20",
+ "time 0.2.21",
  "tokio",
 ]
 
@@ -2143,9 +2151,12 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "iovec"
@@ -2228,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "lapin"
-version = "1.2.4"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d3e4d31709ab4340ac6f270d440c59d1e1014890af5d9392ee882bd4ee3e3c"
+checksum = "3cefdb65897723ab87b96a152f3872f8e77fcc0f6c075b61233fab05d14c513a"
 dependencies = [
  "amq-protocol",
  "async-task",
@@ -2872,9 +2883,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinky-swear"
-version = "4.3.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e5cf8b99d12fdd41b2be5ee172f74c69526eda68417c6a440c9fa6079f0f2a"
+checksum = "9bf8cda6f8e1500338634e4e3ce90ac59eb7929a1e088b6946c742be1cc44dc1"
 dependencies = [
  "doc-comment",
  "parking_lot",
@@ -3774,7 +3785,7 @@ dependencies = [
  "sqlx-rt",
  "stringprep",
  "thiserror",
- "time 0.2.20",
+ "time 0.2.21",
  "url",
  "whoami",
 ]
@@ -4149,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4953c513c9bf1b97e9cdd83f11d60c4b0a83462880a360d80d96953a953fee"
+checksum = "2c2e31fb28e2a9f01f5ed6901b066c1ba2333c04b64dc61254142bafcb3feb2c"
 dependencies = [
  "const_fn",
  "libc",

--- a/iml-influx/Cargo.toml
+++ b/iml-influx/Cargo.toml
@@ -6,8 +6,14 @@ name = "iml-influx"
 version = "0.1.0"
 
 [dependencies]
+futures = {version = "0.3", optional = true}
+influx_db_client = {version = "0.4", default-features = false, features = ["rustls-tls"], optional = true}
 serde = {version = "1", features = ['derive']}
 serde_json = {version = "1"}
+thiserror = {version = "1.0", optional = true}
 
 [dev-dependencies]
 influx_db_client = {version = "0.4", default-features = false, features = ["rustls-tls"]}
+
+[features]
+with-db-client = ["influx_db_client", "futures", "thiserror"]


### PR DESCRIPTION
Implement an influx client extenstion that allows for direct
serialization to a struct instead of needing to traverse the result and
build it by hand. Ex:

```rust
struct MgsFsTime {
    time: u64,
}

let xs: Vec<MgsFsTime> = client
        .query_into(
            format!(
                r#"
            SELECT mgs_fs,is_mgs_fs
            FROM target
            WHERE mgs_fs='{}' AND is_mgs_fs=true
            ORDER BY time ASC
            LIMIT 2"#,
                fs_names
            )
            .as_str(),
            Some(Precision::Nanoseconds),
        )
        .await?
        .unwrap_or_default();
```

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2262)
<!-- Reviewable:end -->
