### PR TITLE
Implement fetching commands by ids

### DIFF
--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -333,7 +333,7 @@ impl QueryRoot {
         limit(description = "paging limit, defaults to 20"),
         offset(description = "Offset into items, defaults to 0"),
         dir(description = "Sort direction, defaults to ASC"),
-        is_active(description = "Command status, active means not completed, can be omitted"),
+        is_active(description = "Command status, active means not completed, default is true"),
         msg(description = "Substring of the command's message, null or empty matches all"),
     ))]
     async fn commands(
@@ -345,7 +345,7 @@ impl QueryRoot {
         msg: Option<String>,
     ) -> juniper::FieldResult<Vec<Command>> {
         let dir = dir.unwrap_or_default();
-        let is_completed = is_active.map(|active| !active);
+        let is_completed = !is_active.unwrap_or(true);
         let commands: Vec<Command> = sqlx::query_as!(
             CommandTmpRecord,
             r#"

--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -459,21 +459,15 @@ impl QueryRoot {
                 .collect::<Vec<_>>()
         })
         .await?;
-        // convert the commands into the hashmap id -> command
         let mut hm = unordered_cmds
             .into_iter()
             .map(|c| (c.id, c))
             .collect::<HashMap<i32, Command>>();
         let commands = ids
             .iter()
-            .map(|id| {
-                if let Some(c) = hm.remove(id) {
-                    Some(c)
-                } else {
-                    None
-                }
-            })
-            .collect();
+            .map(|id| hm.remove(id))
+            .collect::<Vec<Option<Command>>>();
+
         Ok(commands)
     }
 

--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -399,13 +399,13 @@ impl QueryRoot {
         Ok(commands)
     }
 
-    /// Fetch the list of commands by ids
+    /// Fetch the list of commands by ids, the returned
+    /// collection is guaranteed to match the input, if a command not found,
+    /// None is returned for that index.
     #[graphql(arguments(
         limit(description = "paging limit, defaults to 20"),
         offset(description = "Offset into items, defaults to 0"),
-        ids(
-            description = "The list of command ids to fetch, empty ids make no commands to return"
-        ),
+        ids(description = "The list of command ids to fetch, ids may be empty"),
     ))]
     async fn commands_by_ids(
         context: &Context,

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -823,6 +823,64 @@
       ]
     }
   },
+  "3b1ddcee3dee96365325874c4ea32c832ffd74ab137399443052a0918d69f2ed": {
+    "query": "\n                SELECT\n                    c.id AS id,\n                    cancelled,\n                    complete,\n                    errored,\n                    created_at,\n                    array_agg(cj.job_id)::INT[] AS job_ids,\n                    message\n                FROM chroma_core_command c\n                JOIN chroma_core_command_jobs cj ON c.id = cj.command_id\n                WHERE (c.id = ANY ($3::INT[]))\n                GROUP BY c.id\n                OFFSET $1 LIMIT $2\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "cancelled",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 2,
+          "name": "complete",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 3,
+          "name": "errored",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "created_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 5,
+          "name": "job_ids",
+          "type_info": "Int4Array"
+        },
+        {
+          "ordinal": 6,
+          "name": "message",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8",
+          "Int4Array"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        null,
+        false
+      ]
+    }
+  },
   "3bded6ce17eeea786bb32a1c8b5fe37b40b25391f24e9bd6dd25652381f84bc8": {
     "query": "select * from chroma_core_stratagemconfiguration where not_deleted = 't'",
     "describe": {
@@ -1407,6 +1465,66 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "67823b0937ae10ec17b2f0bb4f82ca85be68e46e999129786957970af1fcf7e2": {
+    "query": "\n                SELECT\n                    c.id AS id,\n                    cancelled,\n                    complete,\n                    errored,\n                    created_at,\n                    array_agg(cj.job_id)::INT[] AS job_ids,\n                    message\n                FROM chroma_core_command c\n                JOIN chroma_core_command_jobs cj ON c.id = cj.command_id\n                WHERE ($4::BOOL IS NULL OR complete = $4)\n                  AND ($5::TEXT IS NULL OR c.message ILIKE '%' || $5 || '%')\n                GROUP BY c.id\n                ORDER BY\n                    CASE WHEN $3 = 'asc' THEN c.id END ASC,\n                    CASE WHEN $3 = 'desc' THEN c.id END DESC\n                OFFSET $1 LIMIT $2\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "cancelled",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 2,
+          "name": "complete",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 3,
+          "name": "errored",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "created_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 5,
+          "name": "job_ids",
+          "type_info": "Int4Array"
+        },
+        {
+          "ordinal": 6,
+          "name": "message",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8",
+          "Text",
+          "Bool",
+          "Text"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        null,
+        false
+      ]
     }
   },
   "681d997bb965a228c0aa75d93d09faefe5412daaf3e7bda3630df319fb9edabb": {
@@ -2388,67 +2506,6 @@
         false,
         true,
         false,
-        false
-      ]
-    }
-  },
-  "a6eb7bd9f10ddb23a075d59ed2fd5c39cecc56b7bba479f2d6be3dcaf72b05ad": {
-    "query": "\n                SELECT\n                    c.id AS id,\n                    cancelled,\n                    complete,\n                    errored,\n                    created_at,\n                    array_agg(cj.job_id)::INT[] AS job_ids,\n                    message\n                FROM chroma_core_command c\n                JOIN chroma_core_command_jobs cj ON c.id = cj.command_id\n                WHERE complete = $4\n                  AND ($5::TEXT IS NULL OR c.message ILIKE '%' || $5 || '%')\n                  AND ($6::INT[] IS NULL OR c.id = ANY ($6::INT[]))\n                GROUP BY c.id\n                ORDER BY\n                    CASE WHEN $3 = 'asc' THEN c.id END ASC,\n                    CASE WHEN $3 = 'desc' THEN c.id END DESC\n                OFFSET $1 LIMIT $2\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 1,
-          "name": "cancelled",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 2,
-          "name": "complete",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 3,
-          "name": "errored",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 4,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 5,
-          "name": "job_ids",
-          "type_info": "Int4Array"
-        },
-        {
-          "ordinal": 6,
-          "name": "message",
-          "type_info": "Varchar"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Int8",
-          "Text",
-          "Bool",
-          "Text",
-          "Int4Array"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        null,
         false
       ]
     }

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -2174,66 +2174,6 @@
       ]
     }
   },
-  "96578c531d3344f51586bd7f502d258fe105acafebd361a5458d14fa4c26af8d": {
-    "query": "\n                SELECT\n                    c.id AS id,\n                    cancelled,\n                    complete,\n                    errored,\n                    created_at,\n                    array_agg(cj.job_id)::INT[] AS job_ids,\n                    message\n                FROM chroma_core_command c\n                JOIN chroma_core_command_jobs cj ON c.id = cj.command_id\n                WHERE complete = $4\n                  AND ($5::TEXT IS NULL OR c.message ILIKE '%' || $5 || '%')\n                GROUP BY c.id\n                ORDER BY\n                    CASE WHEN $3 = 'asc' THEN c.id END ASC,\n                    CASE WHEN $3 = 'desc' THEN c.id END DESC\n                OFFSET $1 LIMIT $2 ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 1,
-          "name": "cancelled",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 2,
-          "name": "complete",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 3,
-          "name": "errored",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 4,
-          "name": "created_at",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 5,
-          "name": "job_ids",
-          "type_info": "Int4Array"
-        },
-        {
-          "ordinal": 6,
-          "name": "message",
-          "type_info": "Varchar"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Int8",
-          "Text",
-          "Bool",
-          "Text"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        null,
-        false
-      ]
-    }
-  },
   "9a4c05da9d9233e6b3fa63ca2f50cf90feb0c305b1cc05e0eb2edcf2572db4ba": {
     "query": "select * from chroma_core_volume where not_deleted = 't'",
     "describe": {
@@ -2448,6 +2388,67 @@
         false,
         true,
         false,
+        false
+      ]
+    }
+  },
+  "a6eb7bd9f10ddb23a075d59ed2fd5c39cecc56b7bba479f2d6be3dcaf72b05ad": {
+    "query": "\n                SELECT\n                    c.id AS id,\n                    cancelled,\n                    complete,\n                    errored,\n                    created_at,\n                    array_agg(cj.job_id)::INT[] AS job_ids,\n                    message\n                FROM chroma_core_command c\n                JOIN chroma_core_command_jobs cj ON c.id = cj.command_id\n                WHERE complete = $4\n                  AND ($5::TEXT IS NULL OR c.message ILIKE '%' || $5 || '%')\n                  AND ($6::INT[] IS NULL OR c.id = ANY ($6::INT[]))\n                GROUP BY c.id\n                ORDER BY\n                    CASE WHEN $3 = 'asc' THEN c.id END ASC,\n                    CASE WHEN $3 = 'desc' THEN c.id END DESC\n                OFFSET $1 LIMIT $2\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "cancelled",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 2,
+          "name": "complete",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 3,
+          "name": "errored",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 4,
+          "name": "created_at",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 5,
+          "name": "job_ids",
+          "type_info": "Int4Array"
+        },
+        {
+          "ordinal": 6,
+          "name": "message",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8",
+          "Text",
+          "Bool",
+          "Text",
+          "Int4Array"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        null,
         false
       ]
     }


### PR DESCRIPTION
For the ids supplied return the commands, the order is guaranteed to be preserved.
![Screenshot 2020-09-22 at 23 45 25](https://user-images.githubusercontent.com/940363/93919390-6bacd300-fd2f-11ea-847f-71ce4fe4c0dc.png)
![Screenshot 2020-09-22 at 23 47 36](https://user-images.githubusercontent.com/940363/93919394-6d769680-fd2f-11ea-8c2f-5524fa759d54.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2265)
<!-- Reviewable:end -->
