### PR TITLE
GH-2268 Update the limit param in graphql api's

### DIFF
--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -136,7 +136,7 @@ pub(crate) struct QueryRoot;
 #[juniper::graphql_object(Context = Context)]
 impl QueryRoot {
     #[graphql(arguments(
-        limit(description = "paging limit, defaults to 20"),
+        limit(description = "paging limit, defaults to All"),
         offset(description = "Offset into items, defaults to 0"),
         dir(description = "Sort direction, defaults to asc")
     ))]
@@ -184,7 +184,7 @@ impl QueryRoot {
     }
 
     #[graphql(arguments(
-        limit(description = "paging limit, defaults to 20"),
+        limit(description = "paging limit, defaults to All"),
         offset(description = "Offset into items, defaults to 0"),
         dir(description = "Sort direction, defaults to asc"),
         fs_name(description = "Targets associated with the specified filesystem"),
@@ -293,7 +293,7 @@ impl QueryRoot {
     }
 
     #[graphql(arguments(
-        limit(description = "paging limit, defaults to 20"),
+        limit(description = "paging limit, defaults to All"),
         offset(description = "Offset into items, defaults to 0"),
         dir(description = "Sort direction, defaults to ASC"),
         fsname(description = "Filesystem the snapshot was taken from"),
@@ -333,7 +333,7 @@ impl QueryRoot {
 
     /// Fetch the list of commands
     #[graphql(arguments(
-        limit(description = "paging limit, defaults to 20"),
+        limit(description = "paging limit, defaults to All"),
         offset(description = "Offset into items, defaults to 0"),
         dir(description = "Sort direction, defaults to ASC"),
         is_active(description = "Command status, active means not completed, default is false"),

--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -173,7 +173,7 @@ impl QueryRoot {
                 OFFSET $2 LIMIT $3"#,
             dir.deref(),
             offset.unwrap_or(0) as i64,
-            limit.unwrap_or(20) as i64
+            limit.map(|x| x.to_string()).unwrap_or("ALL".to_string()) as String
         )
         .fetch_all(&context.pg_pool)
         .await?;
@@ -208,7 +208,7 @@ impl QueryRoot {
                     CASE WHEN $3 = 'desc' THEN t.name END DESC
                 OFFSET $1 LIMIT $2"#,
             offset.unwrap_or(0) as i64,
-            limit.unwrap_or(20) as i64,
+            limit.map(|x| x.to_string()).unwrap_or("ALL".to_string()) as String,
             dir.deref()
         )
         .fetch_all(&context.pg_pool)
@@ -316,7 +316,7 @@ impl QueryRoot {
                         CASE WHEN $3 = 'desc' THEN s.create_time END DESC
                     OFFSET $1 LIMIT $2"#,
                 offset.unwrap_or(0) as i64,
-                limit.unwrap_or(20) as i64,
+                limit.map(|x| x.to_string()).unwrap_or("ALL".to_string()) as String,
                 dir.deref(),
                 fsname,
                 name,
@@ -365,7 +365,7 @@ impl QueryRoot {
                     CASE WHEN $3 = 'desc' THEN c.id END DESC
                 OFFSET $1 LIMIT $2 "#,
             offset.unwrap_or(0) as i64,
-            limit.unwrap_or(20) as i64,
+            limit.map(|x| x.to_string()).unwrap_or("ALL".to_string()) as String,
             dir.deref(),
             is_completed,
             msg,

--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -173,7 +173,7 @@ impl QueryRoot {
                 OFFSET $2 LIMIT $3"#,
             dir.deref(),
             offset.unwrap_or(0) as i64,
-            limit.map(|x| x.to_string()).unwrap_or("ALL".to_string()) as String
+            limit.map(|x| x.to_string()).unwrap_or_else(|| "ALL".to_string()) as String
         )
         .fetch_all(&context.pg_pool)
         .await?;
@@ -208,7 +208,7 @@ impl QueryRoot {
                     CASE WHEN $3 = 'desc' THEN t.name END DESC
                 OFFSET $1 LIMIT $2"#,
             offset.unwrap_or(0) as i64,
-            limit.map(|x| x.to_string()).unwrap_or("ALL".to_string()) as String,
+            limit.map(|x| x.to_string()).unwrap_or_else(|| "ALL".to_string()) as String,
             dir.deref()
         )
         .fetch_all(&context.pg_pool)
@@ -316,7 +316,7 @@ impl QueryRoot {
                         CASE WHEN $3 = 'desc' THEN s.create_time END DESC
                     OFFSET $1 LIMIT $2"#,
                 offset.unwrap_or(0) as i64,
-                limit.map(|x| x.to_string()).unwrap_or("ALL".to_string()) as String,
+                limit.map(|x| x.to_string()).unwrap_or_else(|| "ALL".to_string()) as String,
                 dir.deref(),
                 fsname,
                 name,
@@ -365,7 +365,7 @@ impl QueryRoot {
                     CASE WHEN $3 = 'desc' THEN c.id END DESC
                 OFFSET $1 LIMIT $2 "#,
             offset.unwrap_or(0) as i64,
-            limit.map(|x| x.to_string()).unwrap_or("ALL".to_string()) as String,
+            limit.map(|x| x.to_string()).unwrap_or_else(|| "ALL".to_string()) as String,
             dir.deref(),
             is_completed,
             msg,

--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -136,7 +136,7 @@ pub(crate) struct QueryRoot;
 #[juniper::graphql_object(Context = Context)]
 impl QueryRoot {
     #[graphql(arguments(
-        limit(description = "paging limit, defaults to All"),
+        limit(description = "optional paging limit, defaults to all rows"),
         offset(description = "Offset into items, defaults to 0"),
         dir(description = "Sort direction, defaults to asc")
     ))]
@@ -184,7 +184,7 @@ impl QueryRoot {
     }
 
     #[graphql(arguments(
-        limit(description = "paging limit, defaults to All"),
+        limit(description = "optional paging limit, defaults to all rows"),
         offset(description = "Offset into items, defaults to 0"),
         dir(description = "Sort direction, defaults to asc"),
         fs_name(description = "Targets associated with the specified filesystem"),
@@ -293,7 +293,7 @@ impl QueryRoot {
     }
 
     #[graphql(arguments(
-        limit(description = "paging limit, defaults to All"),
+        limit(description = "optional paging limit, defaults to all rows"),
         offset(description = "Offset into items, defaults to 0"),
         dir(description = "Sort direction, defaults to ASC"),
         fsname(description = "Filesystem the snapshot was taken from"),
@@ -333,7 +333,7 @@ impl QueryRoot {
 
     /// Fetch the list of commands
     #[graphql(arguments(
-        limit(description = "paging limit, defaults to All"),
+        limit(description = "optional paging limit, defaults to all rows"),
         offset(description = "Offset into items, defaults to 0"),
         dir(description = "Sort direction, defaults to ASC"),
         is_active(description = "Command status, active means not completed, default is false"),

--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -173,7 +173,9 @@ impl QueryRoot {
                 OFFSET $2 LIMIT $3"#,
             dir.deref(),
             offset.unwrap_or(0) as i64,
-            limit.map(|x| x.to_string()).unwrap_or_else(|| "ALL".to_string()) as String
+            limit
+                .map(|x| x.to_string())
+                .unwrap_or_else(|| "ALL".to_string()) as String
         )
         .fetch_all(&context.pg_pool)
         .await?;
@@ -208,7 +210,9 @@ impl QueryRoot {
                     CASE WHEN $3 = 'desc' THEN t.name END DESC
                 OFFSET $1 LIMIT $2"#,
             offset.unwrap_or(0) as i64,
-            limit.map(|x| x.to_string()).unwrap_or_else(|| "ALL".to_string()) as String,
+            limit
+                .map(|x| x.to_string())
+                .unwrap_or_else(|| "ALL".to_string()) as String,
             dir.deref()
         )
         .fetch_all(&context.pg_pool)
@@ -365,7 +369,9 @@ impl QueryRoot {
                     CASE WHEN $3 = 'desc' THEN c.id END DESC
                 OFFSET $1 LIMIT $2 "#,
             offset.unwrap_or(0) as i64,
-            limit.map(|x| x.to_string()).unwrap_or_else(|| "ALL".to_string()) as String,
+            limit
+                .map(|x| x.to_string())
+                .unwrap_or_else(|| "ALL".to_string()) as String,
             dir.deref(),
             is_completed,
             msg,


### PR DESCRIPTION
Fixes #2268.

Currently, the limit param allows you to specify a limit when retrieving items back from an API call. This is a numeric value that can be passed in but in some cases, we may want all results. To address this, postress allows us to pass in ALL instead of a numeric value, which is effectively the same as not passing a limit at all. Update all of the graphql API endpoints such that if None is passed in it will pass ALL to the LIMIT clause in the query. This will allow us to get all entries without modifying the existing api.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2269)
<!-- Reviewable:end -->
