### PR TITLE
Lower snapshot listing interval

### DIFF
--- a/iml-agent/src/daemon_plugins/snapshot.rs
+++ b/iml-agent/src/daemon_plugins/snapshot.rs
@@ -121,7 +121,7 @@ impl DaemonPlugin for SnapshotList {
                                 lock.updated = true;
                             }
                         }
-                        delay_for(Duration::from_secs(60)).await;
+                        delay_for(Duration::from_secs(30)).await;
                     }
                 },
                 reader_reg,

--- a/iml-agent/src/daemon_plugins/snapshot.rs
+++ b/iml-agent/src/daemon_plugins/snapshot.rs
@@ -121,7 +121,7 @@ impl DaemonPlugin for SnapshotList {
                                 lock.updated = true;
                             }
                         }
-                        delay_for(Duration::from_secs(30)).await;
+                        delay_for(Duration::from_secs(10)).await;
                     }
                 },
                 reader_reg,


### PR DESCRIPTION
Listing times on the agent. With 10 snapshots:
```
[root@mds1 vagrant]# time iml-agent snapshot list fs
{{[Snapshot
{ filesystem_name: "fs", snapshot_name: "test2", snapshot_fsname: "7941fd0f", modify_time: 2020-09-25T09:53:04Z, create_time: 2020-09-25T09:53:04Z, mounted: Some(false), comment: Some("") }
...
real 0m4.728s
user 0m0.610s
sys 0m0.408s
```
With 20 snapshots:
```
[root@mds1 vagrant]# time iml-agent snapshot list fs
[Snapshot
{ filesystem_name: "fs", snapshot_name: "test2", snapshot_fsname: "7941fd0f", modify_time: 2020-09-25T09:53:04Z, create_time: 2020-09-25T09:53:04Z, mounted: Some(false), comment: Some("") }
...
real 0m11.720s
user 0m1.571s
sys 0m0.905s
```

There's also some variance. For 20 snapshots, these are 5 times: 0m11.720s, 0m10.119s, 0m9.724s, 0m10.353s, 0m8.728s.

Signed-off-by: Michael Pankov <work@michaelpankov.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2276)
<!-- Reviewable:end -->
