### PR TITLE
Write timer service to non volume mounted area

### DIFF
--- a/docker/iml-timer.dockerfile
+++ b/docker/iml-timer.dockerfile
@@ -3,7 +3,7 @@ FROM rust-iml-base as builder
 FROM imlteam/systemd-base:6.2.0-dev
 COPY --from=builder /build/target/release/iml-timer /bin/
 COPY --from=builder /build/target/release/iml /usr/bin
-COPY docker/iml-timer/iml-timer.service /etc/systemd/system/
+COPY docker/iml-timer/iml-timer.service /usr/lib/systemd/system/
 COPY docker/wait-for-settings.sh /usr/local/bin/
 
 RUN systemctl enable iml-timer


### PR DESCRIPTION
The `iml-timer.service` is moved to a directory that has a volume
mounted over it.

Because of this, any changes to the service file from the image are
overwritten.

Move the service file to a dir that does not have a volume mounted.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2284)
<!-- Reviewable:end -->
