### PR TITLE
Hide snapshot table if there are no rows to display.

### DIFF
--- a/iml-gui/crate/src/page/snapshot/list.rs
+++ b/iml-gui/crate/src/page/snapshot/list.rs
@@ -100,7 +100,7 @@ pub fn view(model: &Model, cache: &ArcCache) -> Node<Msg> {
     if model.rows.is_empty() {
         return empty!();
     }
-    
+
     panel::view(
         h3![class![C.py_4, C.font_normal, C.text_lg], "Snapshots"],
         div![

--- a/iml-gui/crate/src/page/snapshot/list.rs
+++ b/iml-gui/crate/src/page/snapshot/list.rs
@@ -97,6 +97,10 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
 }
 
 pub fn view(model: &Model, cache: &ArcCache) -> Node<Msg> {
+    if model.rows.is_empty() {
+        return empty!();
+    }
+    
     panel::view(
         h3![class![C.py_4, C.font_normal, C.text_lg], "Snapshots"],
         div![


### PR DESCRIPTION
The snapshot table should not display if there are no rows.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2286)
<!-- Reviewable:end -->
