### PR TITLE
graphql: Return fqdn from get_fs_cluster_hosts()

### DIFF
--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -950,17 +950,15 @@ async fn get_fs_cluster_hosts(
 
         acc
     });
-    let xs = xs.into_iter().map(|idset| {
-        async move {
-            let fqdns = idset
-                .into_iter()
-                .map(|x| async move { fqdn_by_host_id(pool, x).await });
-            join_all(fqdns)
-                .await
-                .into_iter()
-                .filter_map(|x| x.ok())
-                .collect()
-        }
+    let xs = xs.into_iter().map(|idset| async move {
+        let fqdns = idset
+            .into_iter()
+            .map(|x| async move { fqdn_by_host_id(pool, x).await });
+        join_all(fqdns)
+            .await
+            .into_iter()
+            .filter_map(|x| x.ok())
+            .collect()
     });
 
     Ok(join_all(xs).await)

--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -8,7 +8,7 @@ use crate::{
     timer::{configure_snapshot_timer, remove_snapshot_timer},
 };
 use chrono::{DateTime, Utc};
-use futures::{TryFutureExt, TryStreamExt};
+use futures::{future::join_all, TryFutureExt, TryStreamExt};
 use iml_postgres::{sqlx, sqlx::postgres::types::PgInterval, PgPool};
 use iml_rabbit::Pool;
 use iml_wire_types::{
@@ -276,19 +276,8 @@ impl QueryRoot {
     async fn get_fs_cluster_hosts(
         context: &Context,
         fs_name: String,
-    ) -> juniper::FieldResult<Vec<Vec<i32>>> {
-        let xs = get_fs_target_resources(&context.pg_pool, Some(fs_name))
-            .await?
-            .into_iter()
-            .group_by(|x| x.cluster_id);
-
-        let xs = xs.into_iter().fold(vec![], |mut acc, (_, xs)| {
-            let xs: HashSet<i32> = xs.map(|x| x.cluster_hosts).flatten().collect();
-
-            acc.push(xs.into_iter().collect());
-
-            acc
-        });
+    ) -> juniper::FieldResult<Vec<Vec<String>>> {
+        let xs = get_fs_cluster_hosts(&context.pg_pool, fs_name).await?;
 
         Ok(xs)
     }
@@ -945,6 +934,38 @@ async fn get_fs_target_resources(
     Ok(xs)
 }
 
+async fn get_fs_cluster_hosts(
+    pool: &PgPool,
+    fs_name: String,
+) -> Result<Vec<Vec<String>>, ImlApiError> {
+    let xs = get_fs_target_resources(pool, Some(fs_name))
+        .await?
+        .into_iter()
+        .group_by(|x| x.cluster_id);
+
+    let xs: Vec<Vec<i32>> = xs.into_iter().fold(vec![], |mut acc, (_, xs)| {
+        let xs: HashSet<i32> = xs.map(|x| x.cluster_hosts).flatten().collect();
+
+        acc.push(xs.into_iter().collect());
+
+        acc
+    });
+    let xs = xs.into_iter().map(|idset| {
+        async move {
+            let fqdns = idset
+                .into_iter()
+                .map(|x| async move { fqdn_by_host_id(pool, x).await });
+            join_all(fqdns)
+                .await
+                .into_iter()
+                .filter_map(|x| x.ok())
+                .collect()
+        }
+    });
+
+    Ok(join_all(xs).await)
+}
+
 async fn get_banned_targets(pool: &PgPool) -> Result<Vec<BannedTargetResource>, ImlApiError> {
     let xs = sqlx::query!(r#"
             SELECT b.id, b.resource, b.node, b.cluster_id, nh.host_id, t.mount_point
@@ -1026,18 +1047,22 @@ async fn active_mgs_host_fqdn(
     tracing::trace!("Maybe active MGS host id: {:?}", maybe_active_mgs_host_id);
 
     if let Some(active_mgs_host_id) = maybe_active_mgs_host_id {
-        let active_mgs_host_fqdn = sqlx::query!(
-            r#"
-                SELECT fqdn FROM chroma_core_managedhost WHERE id=$1 and not_deleted = 't'
-            "#,
-            active_mgs_host_id
-        )
-        .fetch_one(pool)
-        .await?
-        .fqdn;
+        let active_mgs_host_fqdn = fqdn_by_host_id(pool, active_mgs_host_id).await?;
 
         Ok(Some(active_mgs_host_fqdn))
     } else {
         Ok(None)
     }
+}
+
+async fn fqdn_by_host_id(pool: &PgPool, id: i32) -> Result<String, iml_postgres::sqlx::Error> {
+    let fqdn = sqlx::query!(
+        r#"SELECT fqdn FROM chroma_core_managedhost WHERE id=$1 and not_deleted = 't'"#,
+        id
+    )
+    .fetch_one(pool)
+    .await?
+    .fqdn;
+
+    Ok(fqdn)
 }

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -3003,6 +3003,26 @@
       ]
     }
   },
+  "b35da5f6c785076d4e7b578ebce9678f7eae5d220145121b19661344ad4705f6": {
+    "query": "SELECT fqdn FROM chroma_core_managedhost WHERE id=$1 and not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "fqdn",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "b4865dbd455de729bbadd116bf6bf72108582704f5d559691c3821a54290bb0c": {
     "query": "\n        SELECT\n            index,\n            element_name,\n            health_state as \"health_state: _\",\n            health_state_reason,\n            child_health_state as \"child_health_state: _\",\n            model,\n            position,\n            enclosure_type as \"enclosure_type: _\",\n            canister_location,\n            storage_system\n        FROM chroma_core_sfaenclosure",
     "describe": {
@@ -4025,26 +4045,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "f7cb59fe7a6bc5dde5fe7f15025161aa8d6e7ba933bb963fcfe8d9afeee26945": {
-    "query": "\n                SELECT fqdn FROM chroma_core_managedhost WHERE id=$1 and not_deleted = 't'\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "fqdn",
-          "type_info": "Varchar"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int4"
-        ]
-      },
-      "nullable": [
-        false
-      ]
     }
   },
   "f8cd2baf66e0d74fea5babd851be21a3badca94a53aee6bac038141cece53646": {


### PR DESCRIPTION
Return FQDNs instead of host IDs so that it can be used by
hotpools.

Related #2241 #1464  

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2287)
<!-- Reviewable:end -->
