### PR TITLE
Create graphql_map scalar type

### DIFF
--- a/iml-wire-types/src/graphql_map.rs
+++ b/iml-wire-types/src/graphql_map.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use std::collections::HashMap;
+
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+pub struct GraphQLMap(pub HashMap<String, serde_json::Value>);
+
+#[cfg(feature = "graphql")]
+#[juniper::graphql_scalar(
+    name = "Map",
+    description = "A Map type"
+)]
+impl<S> GraphQLScalar for GraphQLMap
+where
+    S: juniper::ScalarValue,
+{
+    fn resolve(&self) -> juniper::Value {
+        juniper::Value::scalar(serde_json::to_string(&self.0).expect("convert map to string"))
+    }
+
+    fn from_input_value(value: &juniper::InputValue) -> Option<GraphQLMap> {
+        let v = value.as_string_value()?;
+        serde_json::from_str(v).map(|x| GraphQLMap(x)).ok()
+    }
+
+    fn from_str<'a>(value: juniper::ScalarToken<'a>) -> juniper::ParseScalarResult<'a, S> {
+        <String as juniper::ParseScalarValue<S>>::from_str(value)
+    }
+}

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod client;
 pub mod db;
 pub mod graphql_duration;
+pub mod graphql_map;
 pub mod high_availability;
 pub mod sfa;
 pub mod snapshot;


### PR DESCRIPTION
Since graphql doesn't support a map type, we can create a scalar that
will use serde to serialize and deserialze map data.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2291)
<!-- Reviewable:end -->
