### PR TITLE
Pass RUST_LOG to cli

### DIFF
--- a/docker/iml-cli-proxy.sh
+++ b/docker/iml-cli-proxy.sh
@@ -7,4 +7,4 @@ if [ -n "$RUST_LOG" ]; then
 	ENVOPT="-e RUST_LOG=$RUST_LOG"
 fi
 
-docker exec -i $TTYOPT $ENVOPT iml_iml-manager-cli.1.$trailer /usr/bin/iml "${@:1}"
+docker exec -i $TTYOPT $ENVOPT iml_iml-manager-cli.1.$trailer iml "${@:1}"

--- a/docker/iml-cli-proxy.sh
+++ b/docker/iml-cli-proxy.sh
@@ -7,4 +7,4 @@ if [ -n "$RUST_LOG" ]; then
 	ENVOPT="-e RUST_LOG=$RUST_LOG"
 fi
 
-docker exec -i $TTYOPT $ENVOPT iml_iml-manager-cli.1.$trailer /usr/local/bin/iml "${@:1}"
+docker exec -i $TTYOPT $ENVOPT iml_iml-manager-cli.1.$trailer /usr/bin/iml "${@:1}"

--- a/docker/iml-cli-proxy.sh
+++ b/docker/iml-cli-proxy.sh
@@ -2,5 +2,9 @@
 
 trailer=$(docker service ps -f 'name=iml_iml-manager-cli.1' iml_iml-manager-cli -q --no-trunc | head -n1)
 TTYOPT=$(tty -s && echo "-t")
+ENVOPT=""
+if [ -n "$RUST_LOG" ]; then
+	ENVOPT="-e RUST_LOG=$RUST_LOG"
+fi
 
-docker exec -i $TTYOPT iml_iml-manager-cli.1.$trailer iml "${@:1}"
+docker exec -i $TTYOPT $ENVOPT iml_iml-manager-cli.1.$trailer /usr/local/bin/iml "${@:1}"

--- a/docker/iml-manager-cli.dockerfile
+++ b/docker/iml-manager-cli.dockerfile
@@ -5,7 +5,7 @@ COPY --from=builder /build/target/release/iml /usr/bin
 COPY docker/wait-for-dependencies.sh /usr/local/bin
 
 RUN echo -e "#! /usr/bin/env bash\n\
-  source /root/.profile && /usr/bin/iml \${@:1}\n\
+  source /root/.profile && /usr/bin/iml \"\${@:1}\"\n\
   " > /usr/local/bin/iml && chmod +x /usr/local/bin/iml
 
 ENTRYPOINT wait-for-dependencies.sh && cat /var/lib/chroma/iml-settings.conf > ~/.profile && /bin/bash

--- a/docker/iml-manager-cli.dockerfile
+++ b/docker/iml-manager-cli.dockerfile
@@ -5,7 +5,7 @@ COPY --from=builder /build/target/release/iml /usr/bin
 COPY docker/wait-for-dependencies.sh /usr/local/bin
 
 RUN echo -e "#! /usr/bin/env bash\n\
-  source /root/.profile && /usr/bin/iml \"\${@:1}\"\n\
+  source /root/.profile && /usr/bin/iml \${@:1}\n\
   " > /usr/local/bin/iml && chmod +x /usr/local/bin/iml
 
 ENTRYPOINT wait-for-dependencies.sh && cat /var/lib/chroma/iml-settings.conf > ~/.profile && /bin/bash


### PR DESCRIPTION
iml-cli-proxy: calling direct prevents argument expansion
This also adds pathrough for RUST_LOG variable

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2293)
<!-- Reviewable:end -->
