### PR TITLE
Remove CLI indirection

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -366,7 +366,6 @@ services:
     volumes:
       - "manager-config:/var/lib/chroma"
     environment:
-      - SERVER_HTTP_URL=gunicorn
       - RUST_LOG=info
   iml-ostpool:
     image: "imlteam/iml-ostpool:6.2.0-dev"

--- a/docker/iml-manager-cli.dockerfile
+++ b/docker/iml-manager-cli.dockerfile
@@ -4,8 +4,4 @@ FROM imlteam/rust-service-base:6.2.0-dev
 COPY --from=builder /build/target/release/iml /usr/bin
 COPY docker/wait-for-dependencies.sh /usr/local/bin
 
-RUN echo -e "#! /usr/bin/env bash\n\
-  source /root/.profile && /usr/bin/iml \${@:1}\n\
-  " > /usr/local/bin/iml && chmod +x /usr/local/bin/iml
-
-ENTRYPOINT wait-for-dependencies.sh && cat /var/lib/chroma/iml-settings.conf > ~/.profile && /bin/bash
+ENTRYPOINT wait-for-dependencies.sh && /bin/bash


### PR DESCRIPTION
The docker iml cli had an extra layer of indirection where it would
source a profile before invoking the iml binary.

This may have been done prior to using .dotenv in the cli binary, but
it's no longer needed so we can remove all of it.

![Screen Shot 2020-10-01 at 12 36 02 PM](https://user-images.githubusercontent.com/458717/94837802-b8a14100-03e2-11eb-9386-b7a6bf183cc6.png)


Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2294)
<!-- Reviewable:end -->
