### PR TITLE
Update text color for available space on the chart

### DIFF
--- a/iml-gui/crate/src/components/dashboard/dashboard_fs_usage.rs
+++ b/iml-gui/crate/src/components/dashboard/dashboard_fs_usage.rs
@@ -27,7 +27,10 @@ pub fn view<T>(model: &fs_usage::Model) -> Node<T> {
             ]),
             div![
                 class![C.p_2],
-                p![number_formatter::format_bytes(metrics.bytes_avail, 1)],
+                p![
+                    class![C.text_gray_600],
+                    number_formatter::format_bytes(metrics.bytes_avail, 1)
+                ],
                 p![class![C.text_gray_500, C.text_xs], "(Available)"]
             ]
         ];


### PR DESCRIPTION
The text color for available space on the chart is currently black. This
leads to confusion whereas one might think that this value represents
the total space. This color should be closer to the gray value used in
the circle of the graph.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2297)
<!-- Reviewable:end -->
