### PR TITLE
Allow different names for IML CLI

### DIFF
--- a/iml-manager-cli/src/config-main.rs
+++ b/iml-manager-cli/src/config-main.rs
@@ -5,13 +5,13 @@
 use iml_manager_cli::{
     display_utils::display_error,
     nginx::{self, nginx_cli},
+    selfname,
 };
 use std::process::exit;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "iml-config", setting = structopt::clap::AppSettings::ColoredHelp)]
-/// The IML Config CLI
+#[structopt(setting = structopt::clap::AppSettings::ColoredHelp)]
 pub enum App {
     #[structopt(name = "nginx")]
     /// Nginx config file generator
@@ -25,7 +25,9 @@ pub enum App {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     iml_tracing::init();
 
-    let matches = App::from_args();
+    let name = selfname(Some("config")).unwrap_or_else(|| "iml-config".to_string());
+
+    let matches = App::from_clap(&App::clap().bin_name(&name).name(&name).get_matches());
 
     tracing::debug!("Matching args {:?}", matches);
 

--- a/iml-manager-cli/src/filesystem.rs
+++ b/iml-manager-cli/src/filesystem.rs
@@ -24,12 +24,7 @@ pub enum FilesystemCommand {
     /// List all configured filesystems
     #[structopt(name = "list")]
     List {
-        /// Set the display type
-        ///
-        /// The display type can be one of the following:
-        /// tabular: display content in a table format
-        /// json: return data in json format
-        /// yaml: return data in yaml format
+        /// Display type: json, yaml, tabular
         #[structopt(short = "d", long = "display", default_value = "tabular")]
         display_type: DisplayType,
     },

--- a/iml-manager-cli/src/lib.rs
+++ b/iml-manager-cli/src/lib.rs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+use std::{collections::BTreeSet, env};
 pub mod api;
 pub mod api_utils;
 pub mod display_utils;
@@ -14,3 +15,33 @@ pub mod server;
 pub mod snapshot;
 pub mod stratagem;
 pub mod update_repo_file;
+
+pub fn parse_hosts(hosts: &[String]) -> Result<BTreeSet<String>, error::ImlManagerCliError> {
+    let parsed: Vec<BTreeSet<String>> = hosts
+        .iter()
+        .map(|x| hostlist_parser::parse(x))
+        .collect::<Result<_, _>>()?;
+
+    let union = parsed
+        .into_iter()
+        .fold(BTreeSet::new(), |acc, h| acc.union(&h).cloned().collect());
+
+    Ok(union)
+}
+
+fn exe_name() -> Option<String> {
+    Some(
+        std::env::current_exe()
+            .ok()?
+            .file_stem()?
+            .to_str()?
+            .to_string(),
+    )
+}
+
+pub fn selfname(suffix: Option<&str>) -> Option<String> {
+    match env::var("CLI_NAME") {
+        Ok(n) => suffix.map(|s| format!("{}-{}", n, s)).or_else(|| Some(n)),
+        Err(_) => exe_name(),
+    }
+}

--- a/iml-manager-cli/src/main.rs
+++ b/iml-manager-cli/src/main.rs
@@ -6,6 +6,7 @@ use iml_manager_cli::{
     api::{self, api_cli, graphql_cli},
     display_utils::display_error,
     filesystem::{self, filesystem_cli},
+    selfname,
     server::{self, server_cli},
     snapshot::{self, snapshot_cli},
     stratagem::{self, stratagem_cli},
@@ -17,8 +18,7 @@ use structopt::clap::Shell;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "iml", setting = structopt::clap::AppSettings::ColoredHelp)]
-/// The Integrated Manager for Lustre CLI
+#[structopt(setting = structopt::clap::AppSettings::ColoredHelp)]
 pub enum App {
     #[structopt(name = "stratagem")]
     /// Work with Stratagem server
@@ -44,7 +44,7 @@ pub enum App {
         #[structopt(subcommand)]
         command: snapshot::SnapshotCommand,
     },
-    #[structopt(name = "update_repo")]
+    #[structopt(name = "update-repo")]
     /// Update Agent repo files
     UpdateRepoFile(update_repo_file::UpdateRepoFileHosts),
 
@@ -71,7 +71,9 @@ pub enum App {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     iml_tracing::init();
 
-    let matches = App::from_args();
+    let name = selfname(None).unwrap_or_else(|| "iml".to_string());
+
+    let matches = App::from_clap(&App::clap().bin_name(&name).name(&name).get_matches());
 
     tracing::debug!("Matching args {:?}", matches);
 

--- a/iml-manager-cli/src/ostpool.rs
+++ b/iml-manager-cli/src/ostpool.rs
@@ -33,12 +33,8 @@ pub enum OstPoolCommand {
     List {
         #[structopt(name = "FSNAME")]
         fsname: Option<String>,
-        /// Set the display type
-        ///
-        /// The display type can be one of the following:
-        /// tabular: display content in a table format
-        /// json: return data in json format
-        /// yaml: return data in yaml format
+
+        /// Display type: json, yaml, tabular
         #[structopt(short = "d", long = "display", default_value = "tabular")]
         display_type: DisplayType,
     },

--- a/iml-manager-cli/src/profile.rs
+++ b/iml-manager-cli/src/profile.rs
@@ -22,12 +22,7 @@ pub enum Cmd {
     /// List all profiles
     #[structopt(name = "list")]
     List {
-        /// Set the display type
-        ///
-        /// The display type can be one of the following:
-        /// tabular: display content in a table format
-        /// json: return data in json format
-        /// yaml: return data in yaml format
+        /// Display type: json, yaml, tabular
         #[structopt(short = "d", long = "display", default_value = "tabular")]
         display_type: DisplayType,
     },

--- a/iml-manager-cli/src/server.rs
+++ b/iml-manager-cli/src/server.rs
@@ -11,7 +11,7 @@ use crate::{
         DisplayType, IntoDisplayType as _,
     },
     error::ImlManagerCliError,
-    profile,
+    parse_hosts, profile,
 };
 use console::{style, Term};
 use dialoguer::Confirm;
@@ -59,34 +59,28 @@ pub enum ServerCommand {
     /// List all configured storage servers (default)
     #[structopt(name = "list")]
     List {
-        /// Set the display type
-        ///
-        /// The display type can be one of the following:
-        /// tabular: display content in a table format
-        /// json: return data in json format
-        /// yaml: return data in yaml format
+        /// Display type: json, yaml, tabular
         #[structopt(short = "d", long = "display", default_value = "tabular")]
         display_type: DisplayType,
     },
-    /// Add new servers to IML
+    /// Add new servers
     #[structopt(name = "add")]
     Add(AddHosts),
-    /// Remove servers from IML
+    /// Remove servers
     #[structopt(name = "remove")]
     Remove {
         /// Hostlist expressions, e. g. mds[1,2].local
         #[structopt(required = true, min_values = 1)]
         hosts: Vec<String>,
     },
-    /// Remove servers from IML DB, but leave agents in place.
-    /// Takes a hostlist expression of servers to remove.
+    /// Remove servers from DB, but leave agents in place.
     #[structopt(name = "force-remove")]
     ForceRemove {
         /// Hostlist expressions, e. g. mds[1,2].local
         #[structopt(required = true, min_values = 1)]
         hosts: Vec<String>,
     },
-    /// Work with Server Profiles
+    /// Work with server profiles
     #[structopt(name = "profile")]
     Profile {
         #[structopt(subcommand)]
@@ -185,19 +179,6 @@ pub struct Objects<T> {
     objects: Vec<T>,
 }
 
-fn parse_hosts(hosts: &[String]) -> Result<BTreeSet<String>, ImlManagerCliError> {
-    let parsed: Vec<BTreeSet<String>> = hosts
-        .iter()
-        .map(|x| hostlist_parser::parse(x))
-        .collect::<Result<_, _>>()?;
-
-    let union = parsed
-        .into_iter()
-        .fold(BTreeSet::new(), |acc, h| acc.union(&h).cloned().collect());
-
-    Ok(union)
-}
-
 /// Given an expanded hostlist and a list of API host objects
 /// returns a tuple of hosts that match a hostlist item, and the remaining hostlist items
 /// that did not match anything.
@@ -273,7 +254,10 @@ where
     I: IntoIterator<Item = &'a Host>,
 {
     for known_host in known_hosts {
-        display_cancelled(format!("Host {} already known to IML. Please remove first if attempting to complete deployment.", known_host.fqdn));
+        display_cancelled(format!(
+            "Host {} already known. Please remove first if attempting to complete deployment.",
+            known_host.fqdn
+        ));
     }
 }
 
@@ -631,7 +615,7 @@ async fn server(command: ServerCommand) -> Result<(), ImlManagerCliError> {
 
             for unknown_name in unknown_names {
                 display_cancelled(format!(
-                    "Host {} unknown to IML; it will not be removed.",
+                    "Host {} in unknown and cannot be removed.",
                     unknown_name
                 ));
             }

--- a/iml-manager-cli/src/snapshot.rs
+++ b/iml-manager-cli/src/snapshot.rs
@@ -17,12 +17,7 @@ use structopt::StructOpt;
 pub enum IntervalCommand {
     /// List snapshots intervals
     List {
-        /// Set the display type
-        ///
-        /// The display type can be one of the following:
-        /// tabular: display content in a table format
-        /// json: return data in json format
-        /// yaml: return data in yaml format
+        /// Display type: json, yaml, tabular
         #[structopt(short = "d", long = "display", default_value = "tabular")]
         display_type: DisplayType,
     },
@@ -49,12 +44,7 @@ pub enum IntervalCommand {
 pub enum RetentionCommand {
     /// List snapshots retention rules
     List {
-        /// Set the display type
-        ///
-        /// The display type can be one of the following:
-        /// tabular: display content in a table format
-        /// json: return data in json format
-        /// yaml: return data in yaml format
+        /// Display type: json, yaml, tabular
         #[structopt(short = "d", long = "display", default_value = "tabular")]
         display_type: DisplayType,
     },
@@ -89,12 +79,7 @@ pub enum SnapshotCommand {
     Unmount(snapshot::Unmount),
     /// List snapshots
     List {
-        /// Set the display type
-        ///
-        /// The display type can be one of the following:
-        /// tabular: display content in a table format
-        /// json: return data in json format
-        /// yaml: return data in yaml format
+        /// Display type: json, yaml, tabular
         #[structopt(short = "d", long = "display", default_value = "tabular")]
         display_type: DisplayType,
         /// The filesystem to list snapshots for


### PR DESCRIPTION
- Determine executable name.

- Remove "IML" where possbile.

![Screenshot_2020-10-06_15-21-03](https://user-images.githubusercontent.com/131844/95207136-d35f2580-07e7-11eb-96af-a22412d15d4d.png)

Separate packages would create a hard link for the executable and symlinks for shell completions.

Closes #2295.

Signed-off-by: Igor Pashev <pashev.igor@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2305)
<!-- Reviewable:end -->
