### PR TITLE
Do not require chronyd to be installed on storage servers

### DIFF
--- a/chroma_core/models/ntp.py
+++ b/chroma_core/models/ntp.py
@@ -19,6 +19,7 @@ from chroma_core.lib.job import DependOn, DependAll, Step
 from chroma_help.help import help_text
 
 import settings
+import sys
 
 
 class NTPConfiguration(DeletableStatefulObject):
@@ -56,14 +57,34 @@ class StopChronyStep(Step):
     idempotent = True
 
     def run(self, kwargs):
-        return self.invoke_rust_agent_expect_result(kwargs["fqdn"], "stop_unit", "chronyd.service")
+        from chroma_core.services.job_scheduler.agent_rpc import AgentException
+
+        try:
+            return self.invoke_rust_agent_expect_result(kwargs["fqdn"], "stop_unit", "chronyd.service")
+        except AgentException as e:
+            t, v, tb = sys.exc_info()
+
+            if "Unknown busctl" in str(e):
+                return ""
+            else:
+                raise t, v, tb
 
 
 class DisableChronyStep(Step):
     idempotent = True
 
     def run(self, kwargs):
-        return self.invoke_rust_agent_expect_result(kwargs["fqdn"], "disable_unit", "chronyd.service")
+        from chroma_core.services.job_scheduler.agent_rpc import AgentException
+
+        try:
+            return self.invoke_rust_agent_expect_result(kwargs["fqdn"], "disable_unit", "chronyd.service")
+        except AgentException as e:
+            t, v, tb = sys.exc_info()
+
+            if "Unknown busctl" in str(e):
+                return ""
+            else:
+                raise t, v, tb
 
 
 class EnableNtpStep(Step):


### PR DESCRIPTION
When installing a minimum build of centos it will not include chronyd in
the installation. This currently prevents users from being able to add
storage servers. Update the disable chronyd step to be smarter such that
the command does not error if it is not installed.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>