### PR TITLE
EX-1872 stratagem: require at least one file

### DIFF
--- a/iml-agent/src/cli.rs
+++ b/iml-agent/src/cli.rs
@@ -246,7 +246,7 @@ pub enum StratagemClientCommand {
         /// remote fs path
         target_fs: String,
 
-        #[structopt(parse(from_os_str))]
+        #[structopt(parse(from_os_str), min_values = 1, required = true)]
         files: Vec<PathBuf>,
     },
 
@@ -261,7 +261,7 @@ pub enum StratagemClientCommand {
         /// destination s3 bucket
         target: String,
 
-        #[structopt(parse(from_os_str))]
+        #[structopt(parse(from_os_str), min_values = 1, required = true)]
         files: Vec<PathBuf>,
     },
 }


### PR DESCRIPTION
filesync and cloudsync need at least one file specified
on iml-agent command line.  Enforce it.

Signed-off-by: Ben Evans <beevans@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2308)
<!-- Reviewable:end -->
