### PR TITLE
Fix target table

### DIFF
--- a/iml-services/iml-device/src/lib.rs
+++ b/iml-services/iml-device/src/lib.rs
@@ -563,7 +563,7 @@ pub async fn get_mgs_filesystem_map(
 ) -> Result<TargetFsRecord, ImlDeviceError> {
     let query_result: Option<Vec<FsRecord>> = influx_client
         .query_into(
-            "select host,target,mgs_fs,is_mgs_fs from target order by time desc limit 1;",
+            "select host,target,mgs_fs,is_mgs_fs from target group by mgs_fs order by time desc limit 1;",
             Some(Precision::Nanoseconds),
         )
         .await?;


### PR DESCRIPTION
The targets table is not populating the filesystem for multiple mgs's
spanning across multiple nodes. For example, take these two zfs filesystems:

```
chroma=> select * from target;
  state  |      name      | active_host_id | host_ids | filesystems |         uuid         |      mount_path
---------+----------------+----------------+----------+-------------+----------------------+-----------------------
 mounted | zfsmo-MDT0001  |              2 | {2,1}    | {zfsmo}     | 8695343810740655893  | /lustre/zfsmo/mdt1
 mounted | zfsmo-MDT0000  |              1 | {1,2}    | {zfsmo}     | 4530718205682888275  | /lustre/zfsmo/mdt0
 mounted | zfsmo-OST0000  |              3 | {3,4}    | {zfsmo}     | 9462550654203081538  | /lustre/zfsmo/ost0
 mounted | zfsmo-OST0001  |              3 | {3,4}    | {zfsmo}     | 17341489608536510240 | /lustre/zfsmo/ost1
 mounted | zfsmo-OST0002  |              3 | {3,4}    | {zfsmo}     | 907585848540270792   | /lustre/zfsmo/ost2
 mounted | zfsmo-OST0003  |              3 | {3,4}    | {zfsmo}     | 1908792243855087943  | /lustre/zfsmo/ost3
 mounted | zfsmo-OST0004  |              3 | {3,4}    | {zfsmo}     | 9964840940169348808  | /lustre/zfsmo/ost4
 mounted | zfsmo-OST0005  |              4 | {4,3}    | {zfsmo}     | 1870318745999721585  | /lustre/zfsmo/ost5
 mounted | zfsmo-OST0008  |              4 | {4,3}    | {zfsmo}     | 5569133161292504856  | /lustre/zfsmo/ost8
 mounted | zfsmo-OST0009  |              4 | {4,3}    | {zfsmo}     | 2609160919963378077  | /lustre/zfsmo/ost9
 mounted | zfsmo2-MDT0000 |              3 | {3,4}    | {zfsmo2}    | 155006845089800165   | /lustre/zfsmo2/mdt2-0
 mounted | zfsmo2-MDT0001 |              4 | {4,3}    | {zfsmo2}    | 7226154305291075559  | /lustre/zfsmo2/mdt2-1
 mounted | zfsmo2-OST0000 |              3 | {3,4}    | {zfsmo2}    | 1227612915275685977  | /lustre/zfsmo2/ost2-0
 mounted | zfsmo2-OST0001 |              3 | {3,4}    | {zfsmo2}    | 11368925913638550022 | /lustre/zfsmo2/ost2-1
 mounted | zfsmo2-OST0002 |              4 | {4,3}    | {zfsmo2}    | 16569165094794320073 | /lustre/zfsmo2/ost2-2
 mounted | zfsmo2-OST0003 |              4 | {4,3}    | {zfsmo2}    | 3542588243068075595  | /lustre/zfsmo2/ost2-3
 mounted | MGS            |              1 | {1,2}    | {}          | 8587067722296475571  | /lustre/zfsmo/mgs
 mounted | MGS            |              3 | {3,4}    | {zfsmo2}    | 1320727904398126912  | /lustre/zfsmo2/mgs2
(18 rows)
```

With the change, the table is now displayed as follows:

```
chroma=> select * from target;
  state  |      name      | active_host_id | host_ids | filesystems |         uuid         |      mount_path
---------+----------------+----------------+----------+-------------+----------------------+-----------------------
 mounted | MGS            |              3 | {3,4}    | {zfsmo2}    | 1320727904398126912  | /lustre/zfsmo2/mgs2
 mounted | zfsmo-OST0000  |              3 | {3,4}    | {zfsmo}     | 9462550654203081538  | /lustre/zfsmo/ost0
 mounted | zfsmo-OST0001  |              3 | {3,4}    | {zfsmo}     | 17341489608536510240 | /lustre/zfsmo/ost1
 mounted | zfsmo-OST0002  |              3 | {3,4}    | {zfsmo}     | 907585848540270792   | /lustre/zfsmo/ost2
 mounted | zfsmo-OST0003  |              3 | {3,4}    | {zfsmo}     | 1908792243855087943  | /lustre/zfsmo/ost3
 mounted | zfsmo-OST0004  |              3 | {3,4}    | {zfsmo}     | 9964840940169348808  | /lustre/zfsmo/ost4
 mounted | zfsmo2-MDT0000 |              3 | {3,4}    | {zfsmo2}    | 155006845089800165   | /lustre/zfsmo2/mdt2-0
 mounted | zfsmo2-OST0000 |              3 | {3,4}    | {zfsmo2}    | 1227612915275685977  | /lustre/zfsmo2/ost2-0
 mounted | zfsmo2-OST0001 |              3 | {3,4}    | {zfsmo2}    | 11368925913638550022 | /lustre/zfsmo2/ost2-1
 mounted | zfsmo-OST0005  |              4 | {4,3}    | {zfsmo}     | 1870318745999721585  | /lustre/zfsmo/ost5
 mounted | zfsmo-OST0008  |              4 | {4,3}    | {zfsmo}     | 5569133161292504856  | /lustre/zfsmo/ost8
 mounted | zfsmo-OST0009  |              4 | {4,3}    | {zfsmo}     | 2609160919963378077  | /lustre/zfsmo/ost9
 mounted | zfsmo2-MDT0001 |              4 | {4,3}    | {zfsmo2}    | 7226154305291075559  | /lustre/zfsmo2/mdt2-1
 mounted | zfsmo2-OST0002 |              4 | {4,3}    | {zfsmo2}    | 16569165094794320073 | /lustre/zfsmo2/ost2-2
 mounted | zfsmo2-OST0003 |              4 | {4,3}    | {zfsmo2}    | 3542588243068075595  | /lustre/zfsmo2/ost2-3
 mounted | MGS            |              1 | {1,2}    | {zfsmo}     | 8587067722296475571  | /lustre/zfsmo/mgs
 mounted | zfsmo-MDT0000  |              1 | {1,2}    | {zfsmo}     | 4530718205682888275  | /lustre/zfsmo/mdt0
 mounted | zfsmo-MDT0001  |              2 | {2,1}    | {zfsmo}     | 8695343810740655893  | /lustre/zfsmo/mdt1
(18 rows)
```

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2312)
<!-- Reviewable:end -->
