### PR TITLE
Remove spinners lib from manager cli.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,7 +1772,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "spinners",
  "structopt",
  "thiserror",
  "tokio",
@@ -2251,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "juniper"
 version = "0.14.2"
-source = "git+https://github.com/graphql-rust/juniper#b1a03661122c0fa5c8a4fc41418dee7f9ede6308"
+source = "git+https://github.com/graphql-rust/juniper#f914322ef44eab706fb3d5d4a4b3e7022f47ab86"
 dependencies = [
  "async-trait",
  "bson",
@@ -2271,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "juniper_codegen"
 version = "0.14.2"
-source = "git+https://github.com/graphql-rust/juniper#b1a03661122c0fa5c8a4fc41418dee7f9ede6308"
+source = "git+https://github.com/graphql-rust/juniper#f914322ef44eab706fb3d5d4a4b3e7022f47ab86"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
@@ -2291,16 +2290,16 @@ dependencies = [
 
 [[package]]
 name = "lapin"
-version = "1.4.1"
+version = "1.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e54e5cfd9393c574159e44c9049fb621325e6c7560f4a506a44e2139a8cf1a8"
+checksum = "0047ccf3b150ff99158931f7e38d476c1e0251178cee776b096e6b0697d888b0"
 dependencies = [
  "amq-protocol",
  "async-task",
  "crossbeam-channel",
  "futures-core",
  "log",
- "mio 0.7.2",
+ "mio 0.7.3",
  "parking_lot",
  "pinky-swear",
 ]
@@ -2494,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
+checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
  "autocfg 1.0.1",
@@ -2523,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5fc35678fa91ff960494e4bd72a0e1f8e72e035460887a2005de51915993cd"
+checksum = "e53a6ea5f38c0a48ca42159868c6d8e1bd56c0451238856cc08d58563643bdc3"
 dependencies = [
  "libc",
  "log",
@@ -4095,7 +4094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d147f992a9942eb288eb52f58ba1868eee976d4983f2013867fde3736c52d0c"
 dependencies = [
  "cfg-if",
- "mio 0.7.2",
+ "mio 0.7.3",
  "p12",
  "rustls-connector",
 ]

--- a/iml-manager-cli/Cargo.toml
+++ b/iml-manager-cli/Cargo.toml
@@ -29,7 +29,6 @@ reqwest = {version = "0.10", default-features = false, features = ["rustls-tls",
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 serde_yaml = "0.8"
-spinners = "1.2.0"
 structopt = "0.3"
 thiserror = "1.0"
 tokio = {version = "0.2", features = ["macros", "io-std", "io-util", "fs", "rt-threaded"]}

--- a/iml-manager-cli/src/api_utils.rs
+++ b/iml-manager-cli/src/api_utils.rs
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::{display_utils, error::ImlManagerCliError};
+use crate::{
+    display_utils::{self, display_cmd_state, wrap_fut},
+    error::ImlManagerCliError,
+};
 use futures::{channel::mpsc, future, FutureExt, StreamExt, TryFutureExt};
 use iml_command_utils::{wait_for_cmds_progress, Progress};
 use iml_wire_types::{ApiList, AvailableAction, Command, EndpointName, FlatQuery, Host};
@@ -61,6 +64,16 @@ pub async fn wait_for_cmd(cmd: Command) -> Result<Command, ImlManagerCliError> {
             return Ok(cmd);
         }
     }
+}
+
+/// Waits for command completion and prints a spinner during progression.
+/// When completed, prints the final command state
+pub async fn wait_for_cmd_display(cmd: Command) -> Result<Command, ImlManagerCliError> {
+    let cmd = wrap_fut(&cmd.message.to_string(), wait_for_cmd(cmd)).await?;
+
+    display_cmd_state(&cmd);
+
+    Ok(cmd)
 }
 
 /// Waits for command completion and prints progress messages

--- a/iml-manager-cli/src/display_utils.rs
+++ b/iml-manager-cli/src/display_utils.rs
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 use chrono_humanize::{Accuracy, HumanTime, Tense};
-use console::{style, Term};
+use console::style;
 use futures::{Future, FutureExt};
 use iml_wire_types::{
     snapshot::{ReserveUnit, Snapshot, SnapshotInterval, SnapshotRetention},
@@ -12,7 +12,6 @@ use iml_wire_types::{
 use indicatif::ProgressBar;
 use number_formatter::{format_bytes, format_number};
 use prettytable::{Row, Table};
-use spinners::{Spinner, Spinners};
 use std::{fmt::Display, io, str::FromStr};
 use structopt::StructOpt;
 
@@ -22,22 +21,6 @@ pub fn wrap_fut<T>(msg: &str, fut: impl Future<Output = T>) -> impl Future<Outpu
     pb.set_message(msg);
 
     fut.inspect(move |_| pb.finish_and_clear())
-}
-
-pub fn start_spinner(msg: &str) -> impl FnOnce(Option<String>) {
-    let sp = Spinner::new(Spinners::Dots9, style(msg).dim().to_string());
-
-    move |msg_opt| match msg_opt {
-        Some(msg) => {
-            sp.message(msg);
-        }
-        None => {
-            sp.stop();
-            if let Err(e) = Term::stdout().clear_line() {
-                tracing::debug!("Could not clear current line {}", e);
-            };
-        }
-    }
 }
 
 pub fn format_cmd_state(cmd: &Command) -> String {

--- a/iml-rabbit/Cargo.toml
+++ b/iml-rabbit/Cargo.toml
@@ -9,7 +9,7 @@ deadpool-lapin = {version = "0.6", default-features = false}
 futures = "0.3"
 iml-manager-env = {path = "../iml-manager-env", version = "0.4"}
 iml-wire-types = {path = "../iml-wire-types", version = "0.4"}
-lapin = {version = "1.2", default-features = false, features = ["rustls"]}
+lapin = {version = "=1.2.8", default-features = false, features = ["rustls"]}
 serde_json = "1"
 thiserror = "1.0"
 tokio-amqp = {version = "0.1", default-features = false}


### PR DESCRIPTION
The spinner lib unwraps term::stdout without checking if it's available.
In the case of running systemd within docker it is not available.

Switch to using the indicatif spinner, which seems to behave a bit
better in this scenario.

Fixes #2314.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2315)
<!-- Reviewable:end -->
