### PR TITLE
EX-1911 filesync: create options to specify openmpi

### DIFF
--- a/iml-agent/src/action_plugins/stratagem/action_filesync.rs
+++ b/iml-agent/src/action_plugins/stratagem/action_filesync.rs
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::{agent_error::ImlAgentError, lustre::search_rootpath};
+use crate::{agent_error::ImlAgentError, env, lustre::search_rootpath};
 use futures::{future::try_join_all, future::Future, stream, StreamExt, TryStreamExt};
 use iml_wire_types::{FidError, FidItem};
 use liblustreapi::LlapiFid;
@@ -57,6 +57,8 @@ async fn archive_fids(
     let mut result = vec![];
 
     let mut rsync_list: Vec<Work> = vec![];
+    let mpi_path = format!("{}/mpirun", env::get_openmpi_path());
+    let mpi_count = env::get_openmpi_count();
 
     for fid in fid_list {
         let fid_path = match llapi.fid2path(&fid.fid) {
@@ -81,10 +83,12 @@ async fn archive_fids(
          * and big files, otherwise just use rsync
          */
         if md.is_dir() || (md.len() > LARGEFILE) {
-            let output = Command::new("/usr/lib64/openmpi/bin/mpirun")
+            let output = Command::new(&mpi_path)
+                .arg("--allow-run-as-root")
+                .arg("-c")
+                .arg(format!("{}", mpi_count))
                 .arg("--hostfile")
                 .arg("/etc/iml/filesync-hostfile")
-                .arg("--allow-run-as-root")
                 .arg("dsync")
                 .arg("-S")
                 .arg(src_file)
@@ -136,6 +140,8 @@ async fn restore_fids(
     fid_list: Vec<FidItem>,
 ) -> Result<Vec<FidError>, ImlAgentError> {
     let mut result = vec![];
+    let mpi_path = format!("{}/mpirun", env::get_openmpi_path());
+    let mpi_count = env::get_openmpi_count();
 
     for fid in fid_list {
         let fid_path = llapi.fid2path(&fid.fid)?;
@@ -152,10 +158,12 @@ async fn restore_fids(
          */
         let output;
         if md.is_dir() || (md.len() > LARGEFILE) {
-            output = Command::new("mpirun")
+            output = Command::new(&mpi_path)
+                .arg("--allow-run-as-root")
+                .arg("-c")
+                .arg(format!("{}", mpi_count))
                 .arg("--hostfile")
                 .arg("/etc/iml/filesync-hostfile")
-                .arg("--allow-run-as-root")
                 .arg("dsync")
                 .arg("-S")
                 .arg(dest_file)

--- a/iml-agent/src/env.rs
+++ b/iml-agent/src/env.rs
@@ -51,6 +51,16 @@ pub fn mailbox_sock(mailbox: &str) -> String {
     format!("{}/postman-{}.sock", sock_dir(), mailbox)
 }
 
+pub fn get_openmpi_path() -> String {
+    get_var("OPENMPI_PATH")
+}
+
+pub fn get_openmpi_count() -> u32 {
+    get_var_else("OPENMPI_COUNT", "4")
+        .parse::<u32>()
+        .expect("Could not parse OPENMPI_COUNT")
+}
+
 lazy_static! {
     pub static ref PEM: Vec<u8> = {
         let mut result = Vec::new();

--- a/iml-agent/systemd-units/settings.conf
+++ b/iml-agent/systemd-units/settings.conf
@@ -13,3 +13,6 @@ LAMIGO_CONF_PATH=/etc/lamigo/{fs}-{mdt}.conf
 # ost is formatted OST{:04x}
 LPURGE_CONF_PATH=/etc/lpurge/{fs}/{ost}.conf
 LDEV_CONF_PATH=/etc/ldev.conf
+# Filesync openmpi parameters
+OPENMPI_PATH=/usr/mpi/gcc/openmpi-4.0.3rc4/bin
+OPENMPI_COUNT=4


### PR DESCRIPTION
Specify OPENMPI_PATH for the location of mpirun
Specify OPENMPI_COUNT for the number of threads to be used

defaults to /usr/mpi/gcc/openmpi-4.0.3rc4/bin
and 4

Since these are the default for 5.2 installs

Signed-off-by: Ben Evans <beevans@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2317)
<!-- Reviewable:end -->
