### PR TITLE
Add devpath to targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -186,9 +186,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
+checksum = "f813291114c186a042350e787af10c26534601062603d888be110f59f85ef8fa"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 
 [[package]]
 name = "cexpr"
@@ -730,7 +730,7 @@ checksum = "3df5480412da86cdf5d6b7f3b682422c84359ff7399aa658df1d15ee83244b1d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -1062,7 +1062,7 @@ dependencies = [
  "derive_utils",
  "find-crate",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -1091,7 +1091,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "juniper"
 version = "0.14.2"
-source = "git+https://github.com/graphql-rust/juniper#f914322ef44eab706fb3d5d4a4b3e7022f47ab86"
+source = "git+https://github.com/graphql-rust/juniper#746aff34a57e5b846a21cdf981d066c0dddde13b"
 dependencies = [
  "async-trait",
  "bson",
@@ -2270,12 +2270,12 @@ dependencies = [
 [[package]]
 name = "juniper_codegen"
 version = "0.14.2"
-source = "git+https://github.com/graphql-rust/juniper#f914322ef44eab706fb3d5d4a4b3e7022f47ab86"
+source = "git+https://github.com/graphql-rust/juniper#746aff34a57e5b846a21cdf981d066c0dddde13b"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -2857,7 +2857,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -2916,7 +2916,7 @@ checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -3012,7 +3012,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
  "version_check 0.9.2",
 ]
 
@@ -3427,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
 
 [[package]]
 name = "rustc_version"
@@ -3600,7 +3600,7 @@ checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -3623,7 +3623,7 @@ checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -3872,7 +3872,7 @@ dependencies = [
  "sha2",
  "sqlx-core",
  "sqlx-rt",
- "syn 1.0.42",
+ "syn 1.0.43",
  "url",
 ]
 
@@ -3889,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "standback"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a71ea1ea5f8747d1af1979bfb7e65c3a025a70609f04ceb78425bc5adad8e6"
+checksum = "f4e0831040d2cf2bdfd51b844be71885783d489898a192f254ae25d57cce725c"
 dependencies = [
  "version_check 0.9.2",
 ]
@@ -3926,7 +3926,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -3942,7 +3942,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -4012,9 +4012,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
+checksum = "a7a7159e7d0dbcab6f9c980d7971ef50f3ff5753081461eeda120d5974a4ee95"
 dependencies = [
  "clap",
  "lazy_static",
@@ -4023,15 +4023,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
+checksum = "8fc47de4dfba76248d1e9169ccff240eea2a4dc1e34e309b95b2393109b4b383"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -4069,9 +4069,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "1e2e59c50ed8f6b050b071aa7b6865293957a9af6b58b94f97c1c9434ad440ea"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4198,7 +4198,7 @@ checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -4257,7 +4257,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "standback",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -4308,7 +4308,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -4449,7 +4449,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -4494,9 +4494,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
+checksum = "4ef0a5e15477aa303afbfac3a44cba9b6430fdaad52423b1e6c0dbbe28c3eedd"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -4508,6 +4508,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -4639,7 +4640,7 @@ checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -4791,7 +4792,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -4825,7 +4826,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/iml-api/src/graphql.rs
+++ b/iml-api/src/graphql.rs
@@ -63,6 +63,8 @@ struct Target {
     state: String,
     /// The target name
     name: String,
+    /// The device path used to create the target mount
+    dev_path: Option<String>,
     /// The `host.id` of the host running this target
     active_host_id: Option<i32>,
     /// The list of `hosts.id`s the target can be mounted on.

--- a/iml-services/iml-device/src/lib.rs
+++ b/iml-services/iml-device/src/lib.rs
@@ -384,13 +384,13 @@ pub fn find_targets<'a>(
 
             let fs_uuid = device.get_fs_uuid()?;
 
-            Some((fqdn, mntpnt, dev_id, fs_uuid, target))
+            Some((fqdn, mntpnt, dev_id, dev, fs_uuid, target))
         })
         .collect();
 
     let xs: Vec<_> = xs
         .into_iter()
-        .filter_map(|(fqdn, mntpnt, dev_id, fs_uuid, target)| {
+        .filter_map(|(fqdn, mntpnt, dev_id, dev_path, fs_uuid, target)| {
             let ys: Vec<_> = device_index
                 .0
                 .iter()
@@ -416,16 +416,18 @@ pub fn find_targets<'a>(
                 [vec![*host_id], ys].concat(),
                 mntpnt,
                 fs_uuid,
+                dev_path,
                 target,
             ))
         })
         .collect();
 
     xs.into_iter()
-        .map(|(fqdn, ids, mntpnt, fs_uuid, target)| Target {
+        .map(|(fqdn, ids, mntpnt, fs_uuid, dev_path, target)| Target {
             state: "mounted".into(),
             active_host_id: Some(*fqdn),
             host_ids: ids,
+            dev_path: Some(dev_path.0.to_string_lossy().to_string()),
             filesystems: target_to_fs_map
                 .get(target)
                 .map(|xs| {
@@ -451,6 +453,7 @@ pub fn find_targets<'a>(
 pub struct Target {
     pub state: String,
     pub name: String,
+    pub dev_path: Option<String>,
     pub active_host_id: Option<i32>,
     pub host_ids: Vec<i32>,
     pub filesystems: Vec<String>,
@@ -623,6 +626,7 @@ mod tests {
             Target {
                 state: "mounted".into(),
                 name: "mdt1".into(),
+                dev_path: None,
                 active_host_id: Some(1),
                 host_ids: vec![2],
                 filesystems: vec!["fs1".to_string()],
@@ -632,6 +636,7 @@ mod tests {
             Target {
                 state: "mounted".into(),
                 name: "ost1".into(),
+                dev_path: Some("/dev/mapper/mpathz".to_string()),
                 active_host_id: Some(3),
                 host_ids: vec![4],
                 filesystems: vec!["fs1".to_string()],
@@ -652,6 +657,7 @@ mod tests {
         let t = Target {
             state: "mounted".into(),
             name: "mdt1".into(),
+            dev_path: None,
             active_host_id: Some(1),
             host_ids: vec![2],
             filesystems: vec!["fs1".to_string()],
@@ -665,6 +671,7 @@ mod tests {
             Target {
                 state: "mounted".into(),
                 name: "mdt2".into(),
+                dev_path: None,
                 active_host_id: Some(2),
                 host_ids: vec![1],
                 filesystems: vec!["fs1".to_string()],
@@ -674,6 +681,7 @@ mod tests {
             Target {
                 state: "mounted".into(),
                 name: "ost1".into(),
+                dev_path: None,
                 active_host_id: Some(3),
                 host_ids: vec![4],
                 filesystems: vec!["fs1".to_string()],
@@ -694,6 +702,7 @@ mod tests {
         let t = Target {
             state: "mounted".into(),
             name: "mdt1".into(),
+            dev_path: None,
             active_host_id: Some(1),
             host_ids: vec![2],
             filesystems: vec!["fs1".into()],

--- a/iml-services/iml-device/src/main.rs
+++ b/iml-services/iml-device/src/main.rs
@@ -153,7 +153,16 @@ async fn main() -> Result<(), ImlDeviceError> {
         let xs = iml_device::build_updates(x);
 
         let x = xs.into_iter().fold(
-            (vec![], vec![], vec![], vec![], vec![], vec![], vec![]),
+            (
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+                vec![],
+            ),
             |mut acc, x| {
                 acc.0.push(x.state);
                 acc.1.push(x.name);
@@ -168,7 +177,7 @@ async fn main() -> Result<(), ImlDeviceError> {
                 acc.4.push(x.filesystems.join(","));
                 acc.5.push(x.uuid);
                 acc.6.push(x.mount_path);
-
+                acc.7.push(x.dev_path);
                 acc
             },
         );
@@ -176,10 +185,10 @@ async fn main() -> Result<(), ImlDeviceError> {
         tracing::debug!("x: {:?}", x);
 
         sqlx::query!(r#"INSERT INTO target
-                        (state, name, active_host_id, host_ids, filesystems, uuid, mount_path) 
-                        SELECT state, name, active_host_id, string_to_array(host_ids, ',')::int[], string_to_array(filesystems, ',')::text[], uuid, mount_path
-                        FROM UNNEST($1::text[], $2::text[], $3::int[], $4::text[], $5::text[], $6::text[], $7::text[])
-                        AS t(state, name, active_host_id, host_ids, filesystems, uuid, mount_path)
+                        (state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path)
+                        SELECT state, name, active_host_id, string_to_array(host_ids, ',')::int[], string_to_array(filesystems, ',')::text[], uuid, mount_path, dev_path
+                        FROM UNNEST($1::text[], $2::text[], $3::int[], $4::text[], $5::text[], $6::text[], $7::text[], $8::text[])
+                        AS t(state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path)
                         ON CONFLICT (uuid)
                             DO
                             UPDATE SET  state          = EXCLUDED.state,
@@ -187,7 +196,8 @@ async fn main() -> Result<(), ImlDeviceError> {
                                         active_host_id = EXCLUDED.active_host_id,
                                         host_ids       = EXCLUDED.host_ids,
                                         filesystems    = EXCLUDED.filesystems,
-                                        mount_path     = EXCLUDED.mount_path"#,
+                                        mount_path     = EXCLUDED.mount_path,
+                                        dev_path       = EXCLUDED.dev_path"#,
             &x.0,
             &x.1,
             &x.2 as &[Option<i32>],
@@ -195,6 +205,7 @@ async fn main() -> Result<(), ImlDeviceError> {
             &x.4,
             &x.5,
             &x.6 as &[Option<String>],
+            &x.7 as &[Option<String>],
         )
         .execute(&pool)
         .await?;

--- a/iml-services/iml-device/src/snapshots/iml_device__tests__deletions_only.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__tests__deletions_only.snap
@@ -6,6 +6,7 @@ expression: xs
     Target {
         state: "unmounted",
         name: "mdt1",
+        dev_path: None,
         active_host_id: None,
         host_ids: [
             2,

--- a/iml-services/iml-device/src/snapshots/iml_device__tests__upserts_and_deletions.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__tests__upserts_and_deletions.snap
@@ -6,6 +6,7 @@ expression: xs
     Target {
         state: "unmounted",
         name: "mdt1",
+        dev_path: None,
         active_host_id: None,
         host_ids: [
             2,
@@ -21,6 +22,7 @@ expression: xs
     Target {
         state: "mounted",
         name: "mdt2",
+        dev_path: None,
         active_host_id: Some(
             2,
         ),
@@ -38,6 +40,7 @@ expression: xs
     Target {
         state: "mounted",
         name: "ost1",
+        dev_path: None,
         active_host_id: Some(
             3,
         ),

--- a/iml-services/iml-device/src/snapshots/iml_device__tests__upserts_only.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__tests__upserts_only.snap
@@ -6,6 +6,7 @@ expression: xs
     Target {
         state: "mounted",
         name: "mdt1",
+        dev_path: None,
         active_host_id: Some(
             1,
         ),
@@ -23,6 +24,9 @@ expression: xs
     Target {
         state: "mounted",
         name: "ost1",
+        dev_path: Some(
+            "/dev/mapper/mpathz",
+        ),
         active_host_id: Some(
             3,
         ),

--- a/migrations/20201008184126_target_devpath_column.sql
+++ b/migrations/20201008184126_target_devpath_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS target ADD COLUMN dev_path TEXT;

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1915,6 +1915,11 @@
           "ordinal": 6,
           "name": "mount_path",
           "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "dev_path",
+          "type_info": "Text"
         }
       ],
       "parameters": {
@@ -1927,6 +1932,7 @@
         false,
         false,
         false,
+        true,
         true
       ]
     }
@@ -3395,24 +3401,6 @@
       "nullable": []
     }
   },
-  "d52cd10b41279ed650bcf206d2da47bb545009a72d513c9add43b72b77637b82": {
-    "query": "INSERT INTO target\n                        (state, name, active_host_id, host_ids, filesystems, uuid, mount_path) \n                        SELECT state, name, active_host_id, string_to_array(host_ids, ',')::int[], string_to_array(filesystems, ',')::text[], uuid, mount_path\n                        FROM UNNEST($1::text[], $2::text[], $3::int[], $4::text[], $5::text[], $6::text[], $7::text[])\n                        AS t(state, name, active_host_id, host_ids, filesystems, uuid, mount_path)\n                        ON CONFLICT (uuid)\n                            DO\n                            UPDATE SET  state          = EXCLUDED.state,\n                                        name           = EXCLUDED.name,\n                                        active_host_id = EXCLUDED.active_host_id,\n                                        host_ids       = EXCLUDED.host_ids,\n                                        filesystems    = EXCLUDED.filesystems,\n                                        mount_path     = EXCLUDED.mount_path",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "TextArray",
-          "TextArray",
-          "Int4Array",
-          "TextArray",
-          "TextArray",
-          "TextArray",
-          "TextArray"
-        ]
-      },
-      "nullable": []
-    }
-  },
   "d6b4367df2c3c035c560763054e4658c5e043c28393decb96ab76f7383f9fd37": {
     "query": "\n            INSERT INTO corosync_resource_bans (id, cluster_id, resource, node, weight, master_only)\n            SELECT\n                id,\n                $6,\n                resource,\n                node,\n                weight,\n                master_only\n            FROM UNNEST(\n                $1::text[],\n                $2::text[],\n                $3::text[],\n                $4::int[],\n                $5::bool[]\n            )\n            AS t(\n                id,\n                resource,\n                node,\n                weight,\n                master_only\n            )\n            ON CONFLICT (id, cluster_id, resource, node) DO UPDATE\n            SET\n                weight = excluded.weight,\n                master_only = excluded.master_only\n        ",
     "describe": {
@@ -3932,6 +3920,25 @@
       "nullable": []
     }
   },
+  "f4165ef6b0015f9503e88fafa27d7e5dc1e6c7150254dbdb9e67c5d10cbef4be": {
+    "query": "INSERT INTO target\n                        (state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path)\n                        SELECT state, name, active_host_id, string_to_array(host_ids, ',')::int[], string_to_array(filesystems, ',')::text[], uuid, mount_path, dev_path\n                        FROM UNNEST($1::text[], $2::text[], $3::int[], $4::text[], $5::text[], $6::text[], $7::text[], $8::text[])\n                        AS t(state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path)\n                        ON CONFLICT (uuid)\n                            DO\n                            UPDATE SET  state          = EXCLUDED.state,\n                                        name           = EXCLUDED.name,\n                                        active_host_id = EXCLUDED.active_host_id,\n                                        host_ids       = EXCLUDED.host_ids,\n                                        filesystems    = EXCLUDED.filesystems,\n                                        mount_path     = EXCLUDED.mount_path,\n                                        dev_path       = EXCLUDED.dev_path",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "TextArray",
+          "TextArray",
+          "Int4Array",
+          "TextArray",
+          "TextArray",
+          "TextArray",
+          "TextArray",
+          "TextArray"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "f41f8df43f7062267e95bb90cabcb67d07d4978f9f27e834c7ca21ab91ce99c6": {
     "query": "SELECT * FROM chroma_core_task",
     "describe": {
@@ -4205,6 +4212,11 @@
           "ordinal": 6,
           "name": "mount_path",
           "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "dev_path",
+          "type_info": "Text"
         }
       ],
       "parameters": {
@@ -4221,6 +4233,7 @@
         false,
         false,
         false,
+        true,
         true
       ]
     }


### PR DESCRIPTION
Add the devpath used to mount a target to the targets table.
This is useful for tasks where we need to know the underlying device for
a target.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

![Screen Shot 2020-10-13 at 1 37 47 PM](https://user-images.githubusercontent.com/458717/95895894-656fac80-0d59-11eb-8b39-1fe79598bff5.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2319)
<!-- Reviewable:end -->
