### PR TITLE
EX-1932 handle softlinks for llapi queries

### DIFF
--- a/liblustreapi/src/lib.rs
+++ b/liblustreapi/src/lib.rs
@@ -312,7 +312,7 @@ impl Llapi {
             path.pop();
         }
 
-        let fsc = CString::new(path.clone().into_os_string().as_bytes())?;
+        let fsc = CString::new(path.into_os_string().as_bytes())?;
         let mut fsname: Vec<u8> = vec![0; std::mem::size_of::<u8>() * MAXFSNAME + 1];
         let ptr = fsname.as_mut_ptr() as *mut libc::c_char;
 

--- a/liblustreapi/src/lib.rs
+++ b/liblustreapi/src/lib.rs
@@ -305,7 +305,19 @@ impl Llapi {
     }
 
     pub fn search_fsname(&self, pathname: &str) -> Result<String, LiblustreError> {
-        let fsc = CString::new(pathname.as_bytes())?;
+        let mut path = PathBuf::from(pathname);
+        let md = std::fs::symlink_metadata(&path)?;
+        if md.file_type().is_symlink() {
+            path.pop();
+        }
+
+        let fsc = CString::new(
+            path.clone()
+                .into_os_string()
+                .into_string()
+                .unwrap()
+                .as_bytes(),
+        )?;
         let mut fsname: Vec<u8> = vec![0; std::mem::size_of::<u8>() * MAXFSNAME + 1];
         let ptr = fsname.as_mut_ptr() as *mut libc::c_char;
 

--- a/liblustreapi/src/lib.rs
+++ b/liblustreapi/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
     ffi::{CStr, CString},
     fmt, io,
     num::ParseIntError,
+    os::unix::ffi::OsStrExt,
     path::PathBuf,
     str::FromStr,
     sync::Arc,
@@ -314,8 +315,6 @@ impl Llapi {
         let fsc = CString::new(
             path.clone()
                 .into_os_string()
-                .into_string()
-                .unwrap()
                 .as_bytes(),
         )?;
         let mut fsname: Vec<u8> = vec![0; std::mem::size_of::<u8>() * MAXFSNAME + 1];

--- a/liblustreapi/src/lib.rs
+++ b/liblustreapi/src/lib.rs
@@ -312,11 +312,7 @@ impl Llapi {
             path.pop();
         }
 
-        let fsc = CString::new(
-            path.clone()
-                .into_os_string()
-                .as_bytes(),
-        )?;
+        let fsc = CString::new(path.clone().into_os_string().as_bytes())?;
         let mut fsname: Vec<u8> = vec![0; std::mem::size_of::<u8>() * MAXFSNAME + 1];
         let ptr = fsname.as_mut_ptr() as *mut libc::c_char;
 


### PR DESCRIPTION
When constructing an llapi instance from a random path
liblustreapi first resolves that path fully, including
symbolic links.  This causes a failure when trying to
get an llapi instance from a symbolic link that lives on
a lustre filesystem (ex /mnt/lustre/symbolic_link)

If the path passed into search_fsname is a link, use
the parent dir instead.

Signed-off-by: Ben Evans <beevans@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2325)
<!-- Reviewable:end -->
