### PR TITLE
EX-1934 cloudsync: remove unused option from command line

### DIFF
--- a/iml-manager-cli/src/stratagem.rs
+++ b/iml-manager-cli/src/stratagem.rs
@@ -155,7 +155,6 @@ pub struct StratagemCloudsyncData {
     /// Match expression
     #[structopt(short = "e", long = "expression")]
     expression: String,
-    policy: String,
     #[structopt(skip = true)]
     cloudsync: bool,
 }


### PR DESCRIPTION
Signed-off-by: Ben Evans <beevans@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2327)
<!-- Reviewable:end -->
