### PR TITLE
Fix Vbox fencing

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -262,7 +262,7 @@ Vagrant.configure('2') do |config|
   #
   (1..2).each do |i|
     config.vm.define "mds#{i}" do |mds|
-      mds.vm.hostname = "mds#{i}.local"
+      mds.vm.hostname = "mds#{i}"
 
       mds.vm.provider 'virtualbox' do |vbx|
         vbx.name = "mds#{i}"
@@ -506,7 +506,7 @@ Vagrant.configure('2') do |config|
     config.vm.define "oss#{i}",
                      autostart: i <= 2 do |oss|
 
-      oss.vm.hostname = "oss#{i}.local"
+      oss.vm.hostname = "oss#{i}"
 
       oss.vm.provider 'virtualbox' do |vbx|
         vbx.name = "oss#{i}"

--- a/vagrant/scripts/create_ldiskfs_lvm_mds_ha_setup.sh
+++ b/vagrant/scripts/create_ldiskfs_lvm_mds_ha_setup.sh
@@ -6,8 +6,8 @@ USER=$1
 PASSWD=$2
 SSHKEY=$3
 
-pcs cluster auth mds1.local mds2.local -u hacluster -p lustre
-pcs cluster setup --start --name mds-cluster mds1.local mds2.local --enable --token 17000
+pcs cluster auth mds1 mds2 -u hacluster -p lustre
+pcs cluster setup --start --name mds-cluster mds1 mds2 --enable --token 17000
 pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 login=${USER} ${PASSWD:+passwd=${PASSWD}} ${SSHKEY:+identity_file=${SSHKEY}}
 pcs resource create mgs-vg ocf:heartbeat:LVM volgrpname=mgt_vg exclusive=true op start timeout=120 op stop timeout=120 --group mgs-grp
 pcs resource create mgs ocf:lustre:Lustre target=/dev/mapper/mgt_vg-mgt mountpoint=/mnt/mgs op start timeout=900 op stop timeout=120 --group mgs-grp

--- a/vagrant/scripts/create_ldiskfs_lvm_oss_ha_setup.sh
+++ b/vagrant/scripts/create_ldiskfs_lvm_oss_ha_setup.sh
@@ -9,8 +9,8 @@ USER=$3
 PASSWD=$4
 SSHKEY=$5
 
-pcs cluster auth oss1.local oss2.local -u hacluster -p lustre
-pcs cluster setup --start --name oss-cluster oss1.local oss2.local --enable --token 17000
+pcs cluster auth oss1 oss2 -u hacluster -p lustre
+pcs cluster setup --start --name oss-cluster oss1 oss2 --enable --token 17000
 pcs stonith create vboxfence fence_vbox ipaddr=10.0.2.2 login=${USER} ${PASSWD:+passwd=${PASSWD}} ${SSHKEY:+identity_file=${SSHKEY}}
 
 for x in $(eval "echo $LIST"); do


### PR DESCRIPTION
Fencing is currently broken for vagrant installs.

This appears to be because the fence agent tries to use node.local as
the node to fence, but this does not coorespond to any vm name.

Instead it should use just node.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2342)
<!-- Reviewable:end -->
