### PR TITLE
Add fs_type field to targets table

### DIFF
--- a/iml-agent/src/action_plugins/ldev.rs
+++ b/iml-agent/src/action_plugins/ldev.rs
@@ -60,148 +60,171 @@ pub async fn create(entries: Vec<LdevEntry>) -> Result<(), ImlAgentError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use iml_wire_types::FsType;
 
     #[test]
     fn test_create() -> Result<(), ImlAgentError> {
-        // oss2 oss1 zfsmo-OST0013 zfs:ost19/ost19
         let entries = vec![
             LdevEntry {
                 primary: "mds1".into(),
                 failover: Some("mds2".into()),
                 label: "MGS".into(),
                 device: "zfs:mdt0/mdt0".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "mds1".into(),
                 failover: Some("mds2".into()),
                 label: "zfsmo-MDT0000".into(),
                 device: "zfs:mdt0/mdt0".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "mds2".into(),
                 failover: Some("mds1".into()),
                 label: "zfsmo-MDT0001".into(),
                 device: "zfs:mdt1/mdt1".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss1".into(),
                 failover: Some("oss2".into()),
                 label: "zfsmo-OST0000".into(),
                 device: "zfs:ost0/ost0".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss1".into(),
                 failover: Some("oss2".into()),
                 label: "zfsmo-OST0001".into(),
                 device: "zfs:ost1/ost1".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss1".into(),
                 failover: Some("oss2".into()),
                 label: "zfsmo-OST0002".into(),
                 device: "zfs:ost2/ost2".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss1".into(),
                 failover: Some("oss2".into()),
                 label: "zfsmo-OST0003".into(),
                 device: "zfs:ost3/ost3".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss1".into(),
                 failover: Some("oss2".into()),
                 label: "zfsmo-OST0004".into(),
                 device: "zfs:ost4/ost4".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss1".into(),
                 failover: Some("oss2".into()),
                 label: "zfsmo-OST0005".into(),
                 device: "zfs:ost5/ost5".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss1".into(),
                 failover: Some("oss2".into()),
                 label: "zfsmo-OST0006".into(),
                 device: "zfs:ost6/ost6".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss1".into(),
                 failover: Some("oss2".into()),
                 label: "zfsmo-OST0007".into(),
                 device: "zfs:ost7/ost7".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss1".into(),
                 failover: Some("oss2".into()),
                 label: "zfsmo-OST0008".into(),
                 device: "zfs:ost8/ost8".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss1".into(),
                 failover: Some("oss2".into()),
                 label: "zfsmo-OST0009".into(),
                 device: "zfs:ost9/ost9".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss2".into(),
                 failover: Some("oss1".into()),
                 label: "zfsmo-OST000a".into(),
                 device: "zfs:ost10/ost10".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss2".into(),
                 failover: Some("oss1".into()),
                 label: "zfsmo-OST000b".into(),
                 device: "zfs:ost11/ost11".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss2".into(),
                 failover: Some("oss1".into()),
                 label: "zfsmo-OST000c".into(),
                 device: "zfs:ost12/ost12".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss2".into(),
                 failover: Some("oss1".into()),
                 label: "zfsmo-OST000d".into(),
                 device: "zfs:ost13/ost13".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss2".into(),
                 failover: Some("oss1".into()),
                 label: "zfsmo-OST000e".into(),
                 device: "zfs:ost14/ost14".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss2".into(),
                 failover: Some("oss1".into()),
                 label: "zfsmo-OST000f".into(),
                 device: "zfs:ost15/ost15".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss2".into(),
                 failover: Some("oss1".into()),
                 label: "zfsmo-OST0010".into(),
                 device: "zfs:ost16/ost16".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss2".into(),
                 failover: Some("oss1".into()),
                 label: "zfsmo-OST00011".into(),
                 device: "zfs:ost17/ost17".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss2".into(),
                 failover: Some("oss1".into()),
                 label: "zfsmo-OST00012".into(),
                 device: "zfs:ost18/ost18".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "oss2".into(),
                 failover: Some("oss1".into()),
                 label: "zfsmo-OST00013".into(),
                 device: "zfs:ost19/ost19".into(),
+                fs_type: Some(FsType::Zfs),
             },
         ]
         .into_iter()
@@ -221,12 +244,14 @@ mod tests {
                 failover: None,
                 label: "MGS".into(),
                 device: "zfs:mdt0/mdt0".into(),
+                fs_type: Some(FsType::Zfs),
             },
             LdevEntry {
                 primary: "mds1".into(),
                 failover: Some("mds2".into()),
                 label: "zfsmo-MDT0000".into(),
                 device: "zfs:mdt0/mdt0".into(),
+                fs_type: Some(FsType::Zfs),
             },
         ]
         .into_iter()

--- a/iml-api/src/graphql/mod.rs
+++ b/iml-api/src/graphql/mod.rs
@@ -23,7 +23,7 @@ use iml_wire_types::{
     logs::{LogResponse, Meta},
     snapshot::{ReserveUnit, Snapshot, SnapshotInterval, SnapshotRetention},
     task::Task,
-    Command, EndpointName, Job, LogMessage, LogSeverity, MessageClass, SortDir,
+    Command, EndpointName, FsType, Job, LogMessage, LogSeverity, MessageClass, SortDir,
 };
 use itertools::Itertools;
 use juniper::{
@@ -186,7 +186,7 @@ impl QueryRoot {
         let xs: Vec<TargetRecord> = sqlx::query_as!(
             TargetRecord,
             r#"
-                SELECT * from target t
+                SELECT id, state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path, fs_type as "fs_type: FsType" from target t
                 ORDER BY
                     CASE WHEN $3 = 'ASC' THEN t.name END ASC,
                     CASE WHEN $3 = 'DESC' THEN t.name END DESC

--- a/iml-graphql-queries/src/target.rs
+++ b/iml-graphql-queries/src/target.rs
@@ -18,6 +18,7 @@ pub mod list {
                 filesystems
                 uuid
                 mount_path: mountPath
+                fs_type: fsType
               }
             }
         "#;

--- a/iml-manager-cli/src/display_utils.rs
+++ b/iml-manager-cli/src/display_utils.rs
@@ -283,7 +283,7 @@ impl IntoTable for (Vec<Host>, Vec<TargetRecord>) {
         let (hosts, targets) = self;
 
         generate_table(
-            &["Name", "State", "Active Host", "Filesystems", "UUID"],
+            &["Name", "State", "Active Host", "Filesystems", "UUID", "fs_type"],
             targets.into_iter().map(|x| {
                 let active_host = x
                     .active_host_id
@@ -298,6 +298,7 @@ impl IntoTable for (Vec<Host>, Vec<TargetRecord>) {
                     active_host,
                     x.filesystems.join(" "),
                     x.uuid,
+                    x.fs_type.map(|x| x.to_string().to_lowercase()).unwrap_or_else(|| "".into()),
                 ]
             }),
         )

--- a/iml-manager-cli/src/display_utils.rs
+++ b/iml-manager-cli/src/display_utils.rs
@@ -283,7 +283,14 @@ impl IntoTable for (Vec<Host>, Vec<TargetRecord>) {
         let (hosts, targets) = self;
 
         generate_table(
-            &["Name", "State", "Active Host", "Filesystems", "UUID", "fs_type"],
+            &[
+                "Name",
+                "State",
+                "Active Host",
+                "Filesystems",
+                "UUID",
+                "fs_type",
+            ],
             targets.into_iter().map(|x| {
                 let active_host = x
                     .active_host_id
@@ -298,7 +305,9 @@ impl IntoTable for (Vec<Host>, Vec<TargetRecord>) {
                     active_host,
                     x.filesystems.join(" "),
                     x.uuid,
-                    x.fs_type.map(|x| x.to_string().to_lowercase()).unwrap_or_else(|| "".into()),
+                    x.fs_type
+                        .map(|x| x.to_string())
+                        .unwrap_or_else(|| "".into()),
                 ]
             }),
         )

--- a/iml-services/iml-device/src/lib.rs
+++ b/iml-services/iml-device/src/lib.rs
@@ -440,8 +440,7 @@ pub fn find_targets<'a>(
         })
         .collect();
 
-    xs
-        .into_iter()
+    xs.into_iter()
         .map(
             |(fqdn, ids, mntpnt, fs_uuid, dev_path, target, osd)| Target {
                 state: "mounted".into(),

--- a/iml-services/iml-device/src/lib.rs
+++ b/iml-services/iml-device/src/lib.rs
@@ -16,7 +16,7 @@ use iml_change::*;
 use iml_influx::{Client, InfluxClientExt as _, Precision};
 use iml_postgres::sqlx::{self, PgPool};
 use iml_tracing::tracing;
-use iml_wire_types::Fqdn;
+use iml_wire_types::{Fqdn, FsType};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
@@ -63,17 +63,20 @@ pub async fn create_cache(pool: &PgPool) -> Result<Cache, ImlDeviceError> {
 }
 
 pub async fn create_target_cache(pool: &PgPool) -> Result<Vec<Target>, ImlDeviceError> {
-    let xs: Vec<Target> = sqlx::query!("select * from target")
+    let xs: Vec<Target> = sqlx::query!(r#"SELECT state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path, fs_type AS "fs_type: FsType" FROM target"#)
         .fetch(pool)
-        .map_ok(|x| Target {
-            state: x.state,
-            name: x.name,
-            dev_path: x.dev_path,
-            active_host_id: x.active_host_id,
-            host_ids: x.host_ids,
-            filesystems: x.filesystems,
-            uuid: x.uuid,
-            mount_path: x.mount_path,
+        .map_ok(|x| {
+            Target {
+                state: x.state,
+                name: x.name,
+                active_host_id: x.active_host_id,
+                host_ids: x.host_ids,
+                filesystems: x.filesystems,
+                uuid: x.uuid,
+                mount_path: x.mount_path,
+                dev_path: x.dev_path,
+                fs_type: x.fs_type,
+            }
         })
         .try_collect()
         .await?;
@@ -380,13 +383,16 @@ pub fn find_targets<'a>(
 
             let s = s.split('=').nth(1)?;
 
-            Some((fqdn, &x.target, &x.source, s))
+            let osd = x.opts.0.split(',').find(|x| x.starts_with("osd="))?;
+            let osd = osd.split('=').nth(1)?;
+
+            Some((fqdn, &x.target, &x.source, s, osd))
         })
         .collect();
 
     let xs: Vec<_> = xs
         .into_iter()
-        .filter_map(|(fqdn, mntpnt, dev, target)| {
+        .filter_map(|(fqdn, mntpnt, dev, target, osd)| {
             let dev_tree = x.get(&fqdn)?;
 
             let device = dev_tree.find_device_by_devpath(dev)?;
@@ -395,13 +401,13 @@ pub fn find_targets<'a>(
 
             let fs_uuid = device.get_fs_uuid()?;
 
-            Some((fqdn, mntpnt, dev_id, dev, fs_uuid, target))
+            Some((fqdn, mntpnt, dev_id, dev, fs_uuid, target, osd))
         })
         .collect();
 
     let xs: Vec<_> = xs
         .into_iter()
-        .filter_map(|(fqdn, mntpnt, dev_id, dev_path, fs_uuid, target)| {
+        .filter_map(|(fqdn, mntpnt, dev_id, dev_path, fs_uuid, target, osd)| {
             let ys: Vec<_> = device_index
                 .0
                 .iter()
@@ -429,38 +435,43 @@ pub fn find_targets<'a>(
                 fs_uuid,
                 dev_path,
                 target,
+                osd,
             ))
         })
         .collect();
 
-    let xs: Vec<_> = xs
+    xs
         .into_iter()
-        .map(|(fqdn, ids, mntpnt, fs_uuid, dev_path, target)| Target {
-            state: "mounted".into(),
-            active_host_id: Some(*fqdn),
-            host_ids: ids,
-            dev_path: Some(dev_path.0.to_string_lossy().to_string()),
-            filesystems: target_to_fs_map
-                .get(target)
-                .map(|xs| {
-                    xs.iter()
-                        .filter(|(host, _)| {
-                            host_map
-                                .get(host)
-                                .unwrap_or_else(|| panic!("Couldn't get host {}", host.0))
-                                == fqdn
-                        })
-                        .map(|(_, fs)| fs.clone())
-                        .collect::<Vec<String>>()
-                })
-                .unwrap_or_default(),
-            name: target.into(),
-            uuid: fs_uuid.into(),
-            mount_path: Some(mntpnt.0.to_string_lossy().to_string()),
-        })
-        .collect();
-
-    xs.into_iter()
+        .map(
+            |(fqdn, ids, mntpnt, fs_uuid, dev_path, target, osd)| Target {
+                state: "mounted".into(),
+                active_host_id: Some(*fqdn),
+                host_ids: ids,
+                dev_path: Some(dev_path.0.to_string_lossy().to_string()),
+                filesystems: target_to_fs_map
+                    .get(target)
+                    .map(|xs| {
+                        xs.iter()
+                            .filter(|(host, _)| {
+                                host_map
+                                    .get(host)
+                                    .unwrap_or_else(|| panic!("Couldn't get host {}", host.0))
+                                    == fqdn
+                            })
+                            .map(|(_, fs)| fs.clone())
+                            .collect::<Vec<String>>()
+                    })
+                    .unwrap_or_default(),
+                name: target.into(),
+                uuid: fs_uuid.into(),
+                mount_path: Some(mntpnt.0.to_string_lossy().to_string()),
+                fs_type: match osd {
+                    osd if osd.contains("zfs") => Some(FsType::Zfs),
+                    osd if osd.contains("ldiskfs") => Some(FsType::Ldiskfs),
+                    _ => None,
+                },
+            },
+        )
         .fold(HashMap::new(), |mut acc: HashMap<String, Target>, x| {
             // We may have multiple incoming mounts for the same uuid.
             // This could happen when a target moves quickly but not all agents have reported new
@@ -482,7 +493,7 @@ pub fn find_targets<'a>(
         })
         .into_iter()
         .map(|(_, x)| x)
-        .collect()
+        .collect::<Vec<_>>()
 }
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
@@ -495,6 +506,7 @@ pub struct Target {
     pub filesystems: Vec<String>,
     pub uuid: String,
     pub mount_path: Option<String>,
+    pub fs_type: Option<FsType>,
 }
 
 impl Identifiable for Target {
@@ -668,6 +680,7 @@ mod tests {
                 filesystems: vec!["fs1".to_string()],
                 uuid: "123456".into(),
                 mount_path: Some("/mnt/mdt1".into()),
+                fs_type: Some(FsType::Ldiskfs),
             },
             Target {
                 state: "mounted".into(),
@@ -678,6 +691,7 @@ mod tests {
                 filesystems: vec!["fs1".to_string()],
                 uuid: "567890".into(),
                 mount_path: Some("/mnt/ost1".into()),
+                fs_type: Some(FsType::Ldiskfs),
             },
         ];
 
@@ -699,6 +713,7 @@ mod tests {
             filesystems: vec!["fs1".to_string()],
             uuid: "123456".into(),
             mount_path: Some("/mnt/mdt1".into()),
+            fs_type: Some(FsType::Ldiskfs),
         };
 
         let deletions = Deletions(vec![&t]);
@@ -713,6 +728,7 @@ mod tests {
                 filesystems: vec!["fs1".to_string()],
                 uuid: "654321".into(),
                 mount_path: Some("/mnt/mdt2".into()),
+                fs_type: Some(FsType::Ldiskfs),
             },
             Target {
                 state: "mounted".into(),
@@ -723,6 +739,7 @@ mod tests {
                 filesystems: vec!["fs1".to_string()],
                 uuid: "567890".into(),
                 mount_path: Some("/mnt/ost1".into()),
+                fs_type: Some(FsType::Ldiskfs),
             },
         ];
 
@@ -744,6 +761,7 @@ mod tests {
             filesystems: vec!["fs1".into()],
             uuid: "123456".into(),
             mount_path: Some("/mnt/mdt1".into()),
+            fs_type: Some(FsType::Ldiskfs),
         };
 
         let deletions = Deletions(vec![&t]);

--- a/iml-services/iml-device/src/snapshots/iml_device__tests__deletions_only.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__tests__deletions_only.snap
@@ -18,5 +18,8 @@ expression: xs
         mount_path: Some(
             "/mnt/mdt1",
         ),
+        fs_type: Some(
+            Ldiskfs,
+        ),
     },
 ]

--- a/iml-services/iml-device/src/snapshots/iml_device__tests__upserts_and_deletions.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__tests__upserts_and_deletions.snap
@@ -18,6 +18,9 @@ expression: xs
         mount_path: Some(
             "/mnt/mdt1",
         ),
+        fs_type: Some(
+            Ldiskfs,
+        ),
     },
     Target {
         state: "mounted",
@@ -36,6 +39,9 @@ expression: xs
         mount_path: Some(
             "/mnt/mdt2",
         ),
+        fs_type: Some(
+            Ldiskfs,
+        ),
     },
     Target {
         state: "mounted",
@@ -53,6 +59,9 @@ expression: xs
         uuid: "567890",
         mount_path: Some(
             "/mnt/ost1",
+        ),
+        fs_type: Some(
+            Ldiskfs,
         ),
     },
 ]

--- a/iml-services/iml-device/src/snapshots/iml_device__tests__upserts_only.snap
+++ b/iml-services/iml-device/src/snapshots/iml_device__tests__upserts_only.snap
@@ -20,6 +20,9 @@ expression: xs
         mount_path: Some(
             "/mnt/mdt1",
         ),
+        fs_type: Some(
+            Ldiskfs,
+        ),
     },
     Target {
         state: "mounted",
@@ -39,6 +42,9 @@ expression: xs
         uuid: "567890",
         mount_path: Some(
             "/mnt/ost1",
+        ),
+        fs_type: Some(
+            Ldiskfs,
         ),
     },
 ]

--- a/iml-system-docker-tests/Cargo.lock
+++ b/iml-system-docker-tests/Cargo.lock
@@ -281,6 +281,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "iml-graphql-queries"
+version = "0.2.0"
+dependencies = [
+ "humantime",
+ "iml-wire-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "iml-system-docker-tests"
 version = "0.4.0"
 dependencies = [
@@ -302,8 +312,10 @@ dependencies = [
  "futures",
  "iml-cmd",
  "iml-fs",
+ "iml-graphql-queries",
  "iml-wire-types",
  "petgraph",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/iml-system-docker-tests/tests/zfs_test.rs
+++ b/iml-system-docker-tests/tests/zfs_test.rs
@@ -4,6 +4,7 @@
 
 use iml_system_docker_tests::run_fs_test;
 use iml_system_test_utils::*;
+use iml_wire_types::FsType;
 
 #[tokio::test]
 async fn test_docker_zfs_setup() -> Result<(), TestError> {
@@ -15,7 +16,7 @@ async fn test_docker_zfs_setup() -> Result<(), TestError> {
         ],
         test_type: TestType::Docker,
         ntp_server: NtpServer::HostOnly,
-        fs_type: FsType::ZFS,
+        fs_type: FsType::Zfs,
         ..config
     };
 

--- a/iml-system-rpm-tests/Cargo.lock
+++ b/iml-system-rpm-tests/Cargo.lock
@@ -303,6 +303,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "iml-graphql-queries"
+version = "0.2.0"
+dependencies = [
+ "humantime",
+ "iml-wire-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "iml-system-rpm-tests"
 version = "0.4.0"
 dependencies = [
@@ -322,8 +332,10 @@ dependencies = [
  "futures",
  "iml-cmd",
  "iml-fs",
+ "iml-graphql-queries",
  "iml-wire-types",
  "petgraph",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/iml-system-rpm-tests/tests/zfs_test.rs
+++ b/iml-system-rpm-tests/tests/zfs_test.rs
@@ -4,6 +4,7 @@
 
 use iml_system_rpm_tests::run_fs_test;
 use iml_system_test_utils::*;
+use iml_wire_types::FsType;
 
 #[tokio::test]
 async fn test_zfs_setup() -> Result<(), TestError> {
@@ -13,7 +14,7 @@ async fn test_zfs_setup() -> Result<(), TestError> {
             ("base_monitored".into(), config.storage_servers()),
             ("base_client".into(), config.client_servers()),
         ],
-        fs_type: FsType::ZFS,
+        fs_type: FsType::Zfs,
         ..config
     };
 

--- a/iml-system-test-utils/src/lib.rs
+++ b/iml-system-test-utils/src/lib.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use futures::future::try_join_all;
 use iml_cmd::{CheckedChildExt, CheckedCommandExt};
 use iml_graphql_queries::task;
-use iml_wire_types::{task::KeyValue, task::TaskArgs, Branding};
+use iml_wire_types::{task::KeyValue, task::TaskArgs, Branding, FsType};
 use ssh::create_iml_diagnostics;
 use std::{collections::HashMap, env, path::PathBuf, process::Stdio, str, time::Duration};
 use tokio::{
@@ -46,12 +46,6 @@ pub enum TestType {
 pub enum NtpServer {
     HostOnly,
     Adm,
-}
-
-#[derive(Clone)]
-pub enum FsType {
-    LDISKFS,
-    ZFS,
 }
 
 pub enum TestState {
@@ -220,7 +214,7 @@ impl Default for Config {
             branding: Branding::default(),
             test_type: TestType::Rpm,
             ntp_server: NtpServer::Adm,
-            fs_type: FsType::LDISKFS,
+            fs_type: FsType::Ldiskfs,
         }
     }
 }
@@ -623,8 +617,8 @@ pub async fn install_fs(config: Config) -> Result<Config, TestError> {
 
 pub async fn create_fs(config: Config) -> Result<Config, TestError> {
     match config.fs_type {
-        FsType::LDISKFS => create_monitored_ldiskfs(&config).await?,
-        FsType::ZFS => create_monitored_zfs(&config).await?,
+        FsType::Ldiskfs => create_monitored_ldiskfs(&config).await?,
+        FsType::Zfs => create_monitored_zfs(&config).await?,
     };
 
     wait_for_ntp(&config).await?;
@@ -637,8 +631,8 @@ pub async fn create_fs(config: Config) -> Result<Config, TestError> {
 
 async fn mount_fs(config: &Config) -> Result<usize, TestError> {
     let (count, provisioner) = match config.fs_type {
-        FsType::LDISKFS => (2, "mount-ldiskfs-fs,mount-ldiskfs-fs2"),
-        FsType::ZFS => (1, "mount-zfs-fs"),
+        FsType::Ldiskfs => (2, "mount-ldiskfs-fs,mount-ldiskfs-fs2"),
+        FsType::Zfs => (1, "mount-zfs-fs"),
     };
 
     let xs = config.storage_servers().into_iter().map(|x| {

--- a/iml-system-test-utils/src/snapshots.rs
+++ b/iml-system-test-utils/src/snapshots.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use futures::{Future, FutureExt};
+use iml_wire_types::FsType;
 use petgraph::{
     graph::{DiGraph, EdgeIndex, NodeIndex},
     prelude::*,
@@ -117,8 +118,8 @@ pub fn get_snapshot_name_for_state(config: &Config, state: TestState) -> snapsho
                 SnapshotName::StratagemCreated
             } else {
                 match config.fs_type {
-                    FsType::LDISKFS => SnapshotName::LdiskfsCreated,
-                    FsType::ZFS => SnapshotName::ZfsCreated,
+                    FsType::Ldiskfs => SnapshotName::LdiskfsCreated,
+                    FsType::Zfs => SnapshotName::ZfsCreated,
                 }
             }
         }
@@ -380,8 +381,8 @@ pub fn get_active_snapshots<'a>(
         get_snapshots_from_graph(graph, &stratagem_filter)
     } else {
         match config.fs_type {
-            FsType::LDISKFS => get_snapshots_from_graph(graph, &ldiskfs_filter),
-            FsType::ZFS => get_snapshots_from_graph(graph, &zfs_filter),
+            FsType::Ldiskfs => get_snapshots_from_graph(graph, &ldiskfs_filter),
+            FsType::Zfs => get_snapshots_from_graph(graph, &zfs_filter),
         }
     }
 }
@@ -395,8 +396,8 @@ pub fn get_active_test_path(
         get_test_path(graph, start_node, &stratagem_filter)
     } else {
         match config.fs_type {
-            FsType::LDISKFS => get_test_path(graph, start_node, &ldiskfs_filter),
-            FsType::ZFS => get_test_path(graph, start_node, &zfs_filter),
+            FsType::Ldiskfs => get_test_path(graph, start_node, &ldiskfs_filter),
+            FsType::Zfs => get_test_path(graph, start_node, &zfs_filter),
         }
     }
 }

--- a/iml-wire-types/src/db.rs
+++ b/iml-wire-types/src/db.rs
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::CompositeId;
-use crate::ToCompositeId;
-use crate::{EndpointName, Label};
+use crate::{CompositeId, EndpointName, FsType, Label, ToCompositeId};
 use chrono::{offset::Utc, DateTime};
 #[cfg(feature = "postgres-interop")]
 use std::str::FromStr;
@@ -329,6 +327,8 @@ pub struct TargetRecord {
     pub uuid: String,
     /// Where this target is mounted
     pub mount_path: Option<String>,
+    /// The filesystem type associated with this target
+    pub fs_type: Option<FsType>,
 }
 
 impl Id for TargetRecord {

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -2111,6 +2111,7 @@ pub struct LustreClient {
 #[cfg_attr(feature = "postgres-interop", derive(sqlx::Type))]
 #[cfg_attr(feature = "postgres-interop", sqlx(rename = "fs_type"))]
 #[cfg_attr(feature = "postgres-interop", sqlx(rename_all = "lowercase"))]
+#[serde(rename_all = "lowercase")]
 #[derive(PartialEq, Eq, Clone, Debug, serde::Serialize, serde::Deserialize, Ord, PartialOrd)]
 pub enum FsType {
     Zfs,

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -2114,7 +2114,9 @@ pub struct LustreClient {
 #[serde(rename_all = "lowercase")]
 #[derive(PartialEq, Eq, Clone, Debug, serde::Serialize, serde::Deserialize, Ord, PartialOrd)]
 pub enum FsType {
+    #[graphql(name="zfs")]
     Zfs,
+    #[graphql(name="ldiskfs")]
     Ldiskfs,
 }
 

--- a/iml-wire-types/src/lib.rs
+++ b/iml-wire-types/src/lib.rs
@@ -2114,9 +2114,9 @@ pub struct LustreClient {
 #[serde(rename_all = "lowercase")]
 #[derive(PartialEq, Eq, Clone, Debug, serde::Serialize, serde::Deserialize, Ord, PartialOrd)]
 pub enum FsType {
-    #[graphql(name="zfs")]
+    #[cfg_attr(feature = "graphql", graphql(name = "zfs"))]
     Zfs,
-    #[graphql(name="ldiskfs")]
+    #[cfg_attr(feature = "graphql", graphql(name = "ldiskfs"))]
     Ldiskfs,
 }
 

--- a/migrations/20201021191942_fs_type_field.sql
+++ b/migrations/20201021191942_fs_type_field.sql
@@ -1,0 +1,4 @@
+DROP TYPE IF EXISTS fs_type;
+CREATE TYPE fs_type AS ENUM('zfs', 'ldiskfs');
+
+ALTER TABLE IF EXISTS target add column fs_type fs_type;

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -4619,31 +4619,6 @@
       ]
     }
   },
-  "fd476db34f4391964ce18a3b50a04cbd6c5f42dafa83a42e980ecb42376a6813": {
-    "query": "DELETE FROM chroma_core_serverprofile where name = $1",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "fed610ec991f5563f72a042573293f69b13ca76d63b71db622bb32cfd484b60f": {
-    "query": "\n                INSERT INTO chroma_core_serverprofilepackage (package_name, server_profile_id)\n                SELECT package_name, $2\n                FROM UNNEST($1::text[])\n                as t(package_name)\n                ON CONFLICT DO NOTHING\n                ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "TextArray",
-          "Varchar"
-        ]
-      },
-      "nullable": []
-    }
-  },
   "ff665ccfecba5163af63c1cea7652c54d31d79fda9c79084bcf861640c58d0a1": {
     "query": "SELECT state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path, fs_type AS \"fs_type: FsType\" FROM target",
     "describe": {

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -326,6 +326,30 @@
       "nullable": []
     }
   },
+  "12f2675288501efff4eabda622666db5f6ac0e8df536c02e25870ae00e614594": {
+    "query": "SELECT fqdn, id FROM chroma_core_managedhost WHERE not_deleted = 't'",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "fqdn",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 1,
+          "name": "id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
   "131959cfcc0275c8797cb5aa12f0ad15dd6baa2f75c716815607a039defac3a6": {
     "query": "select fqdn from chroma_core_managedhost where id = $1 and not_deleted = 't'",
     "describe": {
@@ -1187,52 +1211,41 @@
       ]
     }
   },
-  "3cb1094d7efdccbf02af2f702d8c6accea293012eb426d70648c32c1682cc1b8": {
-    "query": "\n            SELECT b.id, b.resource, b.node, b.cluster_id, nh.host_id, t.mount_point\n            FROM corosync_resource_bans b\n            INNER JOIN corosync_node_managed_host nh ON (nh.corosync_node_id).name = b.node\n            AND nh.cluster_id = b.cluster_id\n            INNER JOIN corosync_resource t ON t.id = b.resource AND b.cluster_id = t.cluster_id\n            WHERE t.mount_point != NULL\n        ",
+  "3c99aaa8e34a6833fb400741010a76a53b45ce1de7f67e633f56160dcac5de15": {
+    "query": "INSERT INTO target\n                        (state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path, fs_type)\n                        SELECT state, name, active_host_id, string_to_array(host_ids, ',')::int[], string_to_array(filesystems, ',')::text[], uuid, mount_path, dev_path, fs_type\n                        FROM UNNEST($1::text[], $2::text[], $3::int[], $4::text[], $5::text[], $6::text[], $7::text[], $8::text[], $9::fs_type[])\n                        AS t(state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path, fs_type)\n                        ON CONFLICT (uuid)\n                            DO\n                            UPDATE SET  state          = EXCLUDED.state,\n                                        name           = EXCLUDED.name,\n                                        active_host_id = EXCLUDED.active_host_id,\n                                        host_ids       = EXCLUDED.host_ids,\n                                        filesystems    = EXCLUDED.filesystems,\n                                        mount_path     = EXCLUDED.mount_path,\n                                        dev_path       = EXCLUDED.dev_path,\n                                        fs_type        = EXCLUDED.fs_type",
     "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 1,
-          "name": "resource",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "node",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 3,
-          "name": "cluster_id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 4,
-          "name": "host_id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 5,
-          "name": "mount_point",
-          "type_info": "Text"
-        }
-      ],
+      "columns": [],
       "parameters": {
-        "Left": []
+        "Left": [
+          "TextArray",
+          "TextArray",
+          "Int4Array",
+          "TextArray",
+          "TextArray",
+          "TextArray",
+          "TextArray",
+          "TextArray",
+          {
+            "Custom": {
+              "name": "_fs_type",
+              "kind": {
+                "Array": {
+                  "Custom": {
+                    "name": "fs_type",
+                    "kind": {
+                      "Enum": [
+                        "zfs",
+                        "ldiskfs"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
       },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        true
-      ]
+      "nullable": []
     }
   },
   "414a5b7c63ec04ad876c282460de775c0e919c1063c46c7a49704b3ccd87ab3f": {
@@ -2016,108 +2029,84 @@
       "nullable": []
     }
   },
-  "6f3c08f058a72efb6a3926dbe47380662c1eb80ec3001bf551792719fcd51e74": {
-    "query": "\n                SELECT jsonb_agg((r.repo_name, r.location))\n                    AS repos, sp.*\n                    FROM chroma_core_repo AS r\n                    INNER JOIN chroma_core_serverprofile_repolist AS rl ON r.repo_name = rl.repo_id\n                    INNER JOIN chroma_core_serverprofile AS sp ON rl.serverprofile_id = sp.name\n                    GROUP BY sp.name;\n            ",
+  "6f09a199e586713a8d4e6f62be9ed5eef10653667445362c90966d7344b8c0fa": {
+    "query": "\n            SELECT state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path, fs_type as \"fs_type: FsType\" from target t\n            ORDER BY\n                CASE WHEN $3 = 'asc' THEN t.name END ASC,\n                CASE WHEN $3 = 'desc' THEN t.name END DESC\n            OFFSET $1 LIMIT $2",
     "describe": {
       "columns": [
         {
           "ordinal": 0,
-          "name": "repos",
-          "type_info": "Jsonb"
+          "name": "state",
+          "type_info": "Text"
         },
         {
           "ordinal": 1,
           "name": "name",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 2,
-          "name": "ui_name",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 3,
-          "name": "ui_description",
           "type_info": "Text"
         },
         {
+          "ordinal": 2,
+          "name": "active_host_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 3,
+          "name": "host_ids",
+          "type_info": "Int4Array"
+        },
+        {
           "ordinal": 4,
-          "name": "managed",
-          "type_info": "Bool"
+          "name": "filesystems",
+          "type_info": "TextArray"
         },
         {
           "ordinal": 5,
-          "name": "worker",
-          "type_info": "Bool"
+          "name": "uuid",
+          "type_info": "Text"
         },
         {
           "ordinal": 6,
-          "name": "user_selectable",
-          "type_info": "Bool"
+          "name": "mount_path",
+          "type_info": "Text"
         },
         {
           "ordinal": 7,
-          "name": "initial_state",
-          "type_info": "Varchar"
+          "name": "dev_path",
+          "type_info": "Text"
         },
         {
           "ordinal": 8,
-          "name": "ntp",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 9,
-          "name": "corosync",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 10,
-          "name": "corosync2",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 11,
-          "name": "pacemaker",
-          "type_info": "Bool"
-        },
-        {
-          "ordinal": 12,
-          "name": "default",
-          "type_info": "Bool"
+          "name": "fs_type: FsType",
+          "type_info": {
+            "Custom": {
+              "name": "fs_type",
+              "kind": {
+                "Enum": [
+                  "zfs",
+                  "ldiskfs"
+                ]
+              }
+            }
+          }
         }
       ],
       "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        null,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "7ba0b27a4f4fca50c30701d9adbbf0c0421c310b6b99453bffb4bc7834fa765c": {
-    "query": "\n                INSERT INTO corosync_resource_managed_host (host_id, cluster_id, corosync_resource_id)\n                SELECT $1, $2, corosync_resource_id FROM UNNEST($3::text[]) as corosync_resource_id\n                ON CONFLICT (host_id, corosync_resource_id, cluster_id)\n                DO NOTHING\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
         "Left": [
-          "Int4",
-          "Int4",
-          "TextArray"
+          "Int8",
+          "Int8",
+          "Text"
         ]
       },
-      "nullable": []
+      "nullable": [
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true
+      ]
     }
   },
   "7bee1c38d05ac3f8bcf4d48b375c740341121c04d2f5b04ceb1d58ef0a006c08": {
@@ -2205,72 +2194,6 @@
         ]
       },
       "nullable": [
-        false
-      ]
-    }
-  },
-  "7c433739308a525cdead14f9b38d0da9d5ad14df3ce97eeb1b85a28c2635f209": {
-    "query": "select * from target",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "state",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "active_host_id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 3,
-          "name": "host_ids",
-          "type_info": "Int4Array"
-        },
-        {
-          "ordinal": 4,
-          "name": "filesystems",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 5,
-          "name": "uuid",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "mount_path",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "dev_path",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 8,
-          "name": "id",
-          "type_info": "Int4"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
-        true,
-        true,
         false
       ]
     }
@@ -2778,30 +2701,6 @@
       "nullable": []
     }
   },
-  "9472740d062c38f49e290c6173d7b676329a956cf9713bb55ff7ffdc0eeaae7f": {
-    "query": "select fqdn, id from chroma_core_managedhost where not_deleted = 't'",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "fqdn",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 1,
-          "name": "id",
-          "type_info": "Int4"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
-  },
   "9a4c05da9d9233e6b3fa63ca2f50cf90feb0c305b1cc05e0eb2edcf2572db4ba": {
     "query": "select * from chroma_core_volume where not_deleted = 't'",
     "describe": {
@@ -3078,76 +2977,6 @@
         false,
         true,
         false,
-        false
-      ]
-    }
-  },
-  "a36f75c883918331f080025b809fb0d2ebf00ef9a4c40d5cdb5e6e960c3f7c58": {
-    "query": "\n                SELECT * from target t\n                ORDER BY\n                    CASE WHEN $3 = 'ASC' THEN t.name END ASC,\n                    CASE WHEN $3 = 'DESC' THEN t.name END DESC\n                OFFSET $1 LIMIT $2",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "state",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 2,
-          "name": "active_host_id",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 3,
-          "name": "host_ids",
-          "type_info": "Int4Array"
-        },
-        {
-          "ordinal": 4,
-          "name": "filesystems",
-          "type_info": "TextArray"
-        },
-        {
-          "ordinal": 5,
-          "name": "uuid",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 6,
-          "name": "mount_path",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 7,
-          "name": "dev_path",
-          "type_info": "Text"
-        },
-        {
-          "ordinal": 8,
-          "name": "id",
-          "type_info": "Int4"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Int8",
-          "Text"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
-        true,
-        true,
         false
       ]
     }
@@ -4397,25 +4226,6 @@
       "nullable": []
     }
   },
-  "f4165ef6b0015f9503e88fafa27d7e5dc1e6c7150254dbdb9e67c5d10cbef4be": {
-    "query": "INSERT INTO target\n                        (state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path)\n                        SELECT state, name, active_host_id, string_to_array(host_ids, ',')::int[], string_to_array(filesystems, ',')::text[], uuid, mount_path, dev_path\n                        FROM UNNEST($1::text[], $2::text[], $3::int[], $4::text[], $5::text[], $6::text[], $7::text[], $8::text[])\n                        AS t(state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path)\n                        ON CONFLICT (uuid)\n                            DO\n                            UPDATE SET  state          = EXCLUDED.state,\n                                        name           = EXCLUDED.name,\n                                        active_host_id = EXCLUDED.active_host_id,\n                                        host_ids       = EXCLUDED.host_ids,\n                                        filesystems    = EXCLUDED.filesystems,\n                                        mount_path     = EXCLUDED.mount_path,\n                                        dev_path       = EXCLUDED.dev_path",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "TextArray",
-          "TextArray",
-          "Int4Array",
-          "TextArray",
-          "TextArray",
-          "TextArray",
-          "TextArray",
-          "TextArray"
-        ]
-      },
-      "nullable": []
-    }
-  },
   "f41f8df43f7062267e95bb90cabcb67d07d4978f9f27e834c7ca21ab91ce99c6": {
     "query": "SELECT * FROM chroma_core_task",
     "describe": {
@@ -4648,6 +4458,107 @@
         true,
         false,
         false
+      ]
+    }
+  },
+  "fd476db34f4391964ce18a3b50a04cbd6c5f42dafa83a42e980ecb42376a6813": {
+    "query": "DELETE FROM chroma_core_serverprofile where name = $1",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "fed610ec991f5563f72a042573293f69b13ca76d63b71db622bb32cfd484b60f": {
+    "query": "\n                INSERT INTO chroma_core_serverprofilepackage (package_name, server_profile_id)\n                SELECT package_name, $2\n                FROM UNNEST($1::text[])\n                as t(package_name)\n                ON CONFLICT DO NOTHING\n                ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "TextArray",
+          "Varchar"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "ff665ccfecba5163af63c1cea7652c54d31d79fda9c79084bcf861640c58d0a1": {
+    "query": "SELECT state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path, fs_type AS \"fs_type: FsType\" FROM target",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "state",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 1,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "active_host_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 3,
+          "name": "host_ids",
+          "type_info": "Int4Array"
+        },
+        {
+          "ordinal": 4,
+          "name": "filesystems",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 5,
+          "name": "uuid",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 6,
+          "name": "mount_path",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "dev_path",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 8,
+          "name": "fs_type: FsType",
+          "type_info": {
+            "Custom": {
+              "name": "fs_type",
+              "kind": {
+                "Enum": [
+                  "zfs",
+                  "ldiskfs"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true
       ]
     }
   }

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -521,6 +521,92 @@
       "nullable": []
     }
   },
+  "1cc41f526860fb071f25210fb0c8e661055342e1526968553ae4422959171a6c": {
+    "query": "\n                SELECT id, state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path, fs_type as \"fs_type: FsType\" from target t\n                ORDER BY\n                    CASE WHEN $3 = 'ASC' THEN t.name END ASC,\n                    CASE WHEN $3 = 'DESC' THEN t.name END DESC\n                OFFSET $1 LIMIT $2",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "state",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "active_host_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 4,
+          "name": "host_ids",
+          "type_info": "Int4Array"
+        },
+        {
+          "ordinal": 5,
+          "name": "filesystems",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 6,
+          "name": "uuid",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 7,
+          "name": "mount_path",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 8,
+          "name": "dev_path",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 9,
+          "name": "fs_type: FsType",
+          "type_info": {
+            "Custom": {
+              "name": "fs_type",
+              "kind": {
+                "Enum": [
+                  "zfs",
+                  "ldiskfs"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8",
+          "Text"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true
+      ]
+    }
+  },
   "1f0a3d6d1b9f42c2eeca372f6a030e76015214803fb010c2b2e9f2899c57ac38": {
     "query": "select * from chroma_core_managedhost where fqdn = $1 and not_deleted = 't'",
     "describe": {
@@ -1246,6 +1332,54 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "3cb1094d7efdccbf02af2f702d8c6accea293012eb426d70648c32c1682cc1b8": {
+    "query": "\n            SELECT b.id, b.resource, b.node, b.cluster_id, nh.host_id, t.mount_point\n            FROM corosync_resource_bans b\n            INNER JOIN corosync_node_managed_host nh ON (nh.corosync_node_id).name = b.node\n            AND nh.cluster_id = b.cluster_id\n            INNER JOIN corosync_resource t ON t.id = b.resource AND b.cluster_id = t.cluster_id\n            WHERE t.mount_point != NULL\n        ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 1,
+          "name": "resource",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "node",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "cluster_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 4,
+          "name": "host_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 5,
+          "name": "mount_point",
+          "type_info": "Text"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        true
+      ]
     }
   },
   "414a5b7c63ec04ad876c282460de775c0e919c1063c46c7a49704b3ccd87ab3f": {
@@ -2029,84 +2163,108 @@
       "nullable": []
     }
   },
-  "6f09a199e586713a8d4e6f62be9ed5eef10653667445362c90966d7344b8c0fa": {
-    "query": "\n            SELECT state, name, active_host_id, host_ids, filesystems, uuid, mount_path, dev_path, fs_type as \"fs_type: FsType\" from target t\n            ORDER BY\n                CASE WHEN $3 = 'asc' THEN t.name END ASC,\n                CASE WHEN $3 = 'desc' THEN t.name END DESC\n            OFFSET $1 LIMIT $2",
+  "6f3c08f058a72efb6a3926dbe47380662c1eb80ec3001bf551792719fcd51e74": {
+    "query": "\n                SELECT jsonb_agg((r.repo_name, r.location))\n                    AS repos, sp.*\n                    FROM chroma_core_repo AS r\n                    INNER JOIN chroma_core_serverprofile_repolist AS rl ON r.repo_name = rl.repo_id\n                    INNER JOIN chroma_core_serverprofile AS sp ON rl.serverprofile_id = sp.name\n                    GROUP BY sp.name;\n            ",
     "describe": {
       "columns": [
         {
           "ordinal": 0,
-          "name": "state",
-          "type_info": "Text"
+          "name": "repos",
+          "type_info": "Jsonb"
         },
         {
           "ordinal": 1,
           "name": "name",
-          "type_info": "Text"
+          "type_info": "Varchar"
         },
         {
           "ordinal": 2,
-          "name": "active_host_id",
-          "type_info": "Int4"
+          "name": "ui_name",
+          "type_info": "Varchar"
         },
         {
           "ordinal": 3,
-          "name": "host_ids",
-          "type_info": "Int4Array"
+          "name": "ui_description",
+          "type_info": "Text"
         },
         {
           "ordinal": 4,
-          "name": "filesystems",
-          "type_info": "TextArray"
+          "name": "managed",
+          "type_info": "Bool"
         },
         {
           "ordinal": 5,
-          "name": "uuid",
-          "type_info": "Text"
+          "name": "worker",
+          "type_info": "Bool"
         },
         {
           "ordinal": 6,
-          "name": "mount_path",
-          "type_info": "Text"
+          "name": "user_selectable",
+          "type_info": "Bool"
         },
         {
           "ordinal": 7,
-          "name": "dev_path",
-          "type_info": "Text"
+          "name": "initial_state",
+          "type_info": "Varchar"
         },
         {
           "ordinal": 8,
-          "name": "fs_type: FsType",
-          "type_info": {
-            "Custom": {
-              "name": "fs_type",
-              "kind": {
-                "Enum": [
-                  "zfs",
-                  "ldiskfs"
-                ]
-              }
-            }
-          }
+          "name": "ntp",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 9,
+          "name": "corosync",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 10,
+          "name": "corosync2",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 11,
+          "name": "pacemaker",
+          "type_info": "Bool"
+        },
+        {
+          "ordinal": 12,
+          "name": "default",
+          "type_info": "Bool"
         }
       ],
       "parameters": {
-        "Left": [
-          "Int8",
-          "Int8",
-          "Text"
-        ]
+        "Left": []
       },
       "nullable": [
+        null,
         false,
         false,
-        true,
         false,
         false,
         false,
-        true,
-        true,
-        true
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
       ]
+    }
+  },
+  "7ba0b27a4f4fca50c30701d9adbbf0c0421c310b6b99453bffb4bc7834fa765c": {
+    "query": "\n                INSERT INTO corosync_resource_managed_host (host_id, cluster_id, corosync_resource_id)\n                SELECT $1, $2, corosync_resource_id FROM UNNEST($3::text[]) as corosync_resource_id\n                ON CONFLICT (host_id, corosync_resource_id, cluster_id)\n                DO NOTHING\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Int4",
+          "TextArray"
+        ]
+      },
+      "nullable": []
     }
   },
   "7bee1c38d05ac3f8bcf4d48b375c740341121c04d2f5b04ceb1d58ef0a006c08": {


### PR DESCRIPTION
The fs_type data should be included in the targets table. This will be
used when creating the ldev conf and likely other things as well.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2343)
<!-- Reviewable:end -->
