### PR TITLE
Integrate network interface data into IML

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -38,7 +38,7 @@ srpm:
 	mkdir -p ${TMPDIR}/_topdir/{SOURCES,SPECS}
 	mkdir -p ${TMPDIR}/release/rust-iml
 	cargo build --release
-	cp ${TARGET}/release/iml-{action-runner,agent,agent-comms,agent-daemon,api,corosync,device,journal,mailbox,ntp,ostpool,postoffice,report,sfa,snapshot,stats,task-runner,warp-drive,timer} \
+	cp ${TARGET}/release/iml-{action-runner,agent,agent-comms,agent-daemon,api,corosync,device,journal,mailbox,network,ntp,ostpool,postoffice,report,sfa,snapshot,stats,task-runner,warp-drive,timer} \
 		iml-action-runner.service \
 		iml-action-runner.socket \
 		iml-agent-comms.service \
@@ -47,6 +47,7 @@ srpm:
 		iml-device.service \
 		iml-journal.service \
 		iml-mailbox.service \
+		iml-network.service \
 		iml-ntp.service \
 		iml-ostpool.service \
 		iml-postoffice.service \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
  "async-trait",
  "crossbeam-queue",
  "num_cpus",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -1268,7 +1268,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.22",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -1435,7 +1435,7 @@ dependencies = [
  "itoa",
  "pin-project 0.4.27",
  "socket2",
- "tokio 0.2.22",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1452,7 +1452,7 @@ dependencies = [
  "hyper",
  "log",
  "rustls",
- "tokio 0.2.22",
+ "tokio",
  "tokio-rustls",
  "webpki",
 ]
@@ -1466,7 +1466,7 @@ dependencies = [
  "bytes",
  "hyper",
  "native-tls",
- "tokio 0.2.22",
+ "tokio",
  "tokio-tls",
 ]
 
@@ -1480,7 +1480,7 @@ dependencies = [
  "hex",
  "hyper",
  "pin-project 0.4.27",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -1545,7 +1545,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "tokio-runtime-shutdown",
  "tokio-test",
  "tracing",
@@ -1595,7 +1595,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "tokio-util",
  "tracing",
  "url",
@@ -1615,7 +1615,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "serde_json",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
  "uuid",
  "warp",
@@ -1640,7 +1640,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
  "uuid",
  "warp",
@@ -1663,7 +1663,7 @@ name = "iml-cmd"
 version = "0.4.0"
 dependencies = [
  "futures",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
  "warp",
 ]
@@ -1677,7 +1677,7 @@ dependencies = [
  "iml-tracing",
  "iml-wire-types",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -1695,7 +1695,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "tokio-test",
 ]
 
@@ -1719,7 +1719,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "tokio-test",
  "url",
  "warp",
@@ -1733,7 +1733,7 @@ dependencies = [
  "futures",
  "tempdir",
  "tempfile",
- "tokio 0.2.22",
+ "tokio",
  "tokio-util",
 ]
 
@@ -1767,7 +1767,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "serde_json",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
  "uuid",
 ]
@@ -1790,7 +1790,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "time 0.2.22",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -1809,7 +1809,7 @@ dependencies = [
  "serde_json",
  "tempdir",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "warp",
 ]
 
@@ -1845,7 +1845,7 @@ dependencies = [
  "serde_yaml",
  "structopt",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
 ]
 
@@ -1882,7 +1882,7 @@ dependencies = [
  "iml-service-queue",
  "iml-tracing",
  "iml-wire-types",
- "tokio 0.3.3",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -1898,7 +1898,7 @@ dependencies = [
  "iml-service-queue",
  "iml-tracing",
  "iml-wire-types",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
 ]
 
@@ -1912,7 +1912,7 @@ dependencies = [
  "iml-service-queue",
  "iml-tracing",
  "iml-wire-types",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
 ]
 
@@ -1938,7 +1938,7 @@ dependencies = [
  "iml-service-queue",
  "iml-tracing",
  "iml-wire-types",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
 ]
 
@@ -1953,7 +1953,7 @@ dependencies = [
  "lapin",
  "serde_json",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "tokio-amqp",
  "tracing",
  "warp",
@@ -1969,7 +1969,7 @@ dependencies = [
  "iml-manager-env",
  "iml-tracing",
  "tempdir",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
  "warp",
 ]
@@ -1985,7 +1985,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tokio 0.2.22",
+ "tokio",
  "tokio-test",
  "tracing",
  "url",
@@ -2019,7 +2019,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "unzip-n",
  "url",
  "wbem-client",
@@ -2043,7 +2043,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "url",
 ]
 
@@ -2062,7 +2062,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -2082,7 +2082,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
 ]
 
@@ -2095,7 +2095,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "serde_json",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
 ]
 
@@ -2112,7 +2112,7 @@ dependencies = [
  "lazy_static",
  "serde_json",
  "thiserror",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -2125,7 +2125,7 @@ dependencies = [
  "iml-tracing",
  "serde",
  "serde_json",
- "tokio 0.2.22",
+ "tokio",
  "warp",
 ]
 
@@ -2133,7 +2133,7 @@ dependencies = [
 name = "iml-tracing"
 version = "0.3.0"
 dependencies = [
- "tokio 0.2.22",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2146,7 +2146,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "serde_json",
- "tokio 0.2.22",
+ "tokio",
  "tracing",
 ]
 
@@ -2164,7 +2164,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "serde_json",
- "tokio 0.2.22",
+ "tokio",
  "tokio-runtime-shutdown",
  "tracing",
  "uuid",
@@ -2239,7 +2239,7 @@ dependencies = [
  "inotify-sys",
  "libc",
  "mio 0.6.22",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -3521,7 +3521,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.22",
+ "tokio",
  "tokio-rustls",
  "tokio-tls",
  "url",
@@ -4018,7 +4018,7 @@ source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#3
 dependencies = [
  "native-tls",
  "once_cell",
- "tokio 0.2.22",
+ "tokio",
  "tokio-native-tls",
 ]
 
@@ -4095,7 +4095,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project 0.4.27",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -4107,7 +4107,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project 0.4.27",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -4421,21 +4421,8 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "tokio-macros 0.2.5",
+ "tokio-macros",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
-dependencies = [
- "autocfg 1.0.1",
- "num_cpus",
- "pin-project-lite",
- "slab",
- "tokio-macros 0.3.1",
 ]
 
 [[package]]
@@ -4445,7 +4432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2938fb5b638e6d8992c304e2426db2de4502f19084b91ec4562d9b45bf896fc4"
 dependencies = [
  "lapin",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -4460,24 +4447,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-macros"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "syn 1.0.48",
-]
-
-[[package]]
 name = "tokio-native-tls"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
 dependencies = [
  "native-tls",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -4498,7 +4474,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "tokio 0.2.22",
+ "tokio",
  "tokio-util",
 ]
 
@@ -4508,7 +4484,7 @@ version = "0.4.0"
 dependencies = [
  "futures",
  "stream-cancel 0.5.2",
- "tokio 0.2.22",
+ "tokio",
  "tokio-test",
 ]
 
@@ -4520,7 +4496,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.22",
+ "tokio",
  "webpki",
 ]
 
@@ -4532,7 +4508,7 @@ checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
 dependencies = [
  "bytes",
  "futures-core",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -4542,7 +4518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -4554,7 +4530,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project 0.4.27",
- "tokio 0.2.22",
+ "tokio",
  "tungstenite",
 ]
 
@@ -4569,7 +4545,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio 0.2.22",
+ "tokio",
 ]
 
 [[package]]
@@ -4899,7 +4875,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.22",
+ "tokio",
  "tokio-tungstenite",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
  "async-trait",
  "crossbeam-queue",
  "num_cpus",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1268,7 +1268,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -1435,7 +1435,7 @@ dependencies = [
  "itoa",
  "pin-project 0.4.27",
  "socket2",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
  "tracing",
  "want",
@@ -1452,7 +1452,7 @@ dependencies = [
  "hyper",
  "log",
  "rustls",
- "tokio",
+ "tokio 0.2.22",
  "tokio-rustls",
  "webpki",
 ]
@@ -1466,7 +1466,7 @@ dependencies = [
  "bytes",
  "hyper",
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tls",
 ]
 
@@ -1480,7 +1480,7 @@ dependencies = [
  "hex",
  "hyper",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1545,7 +1545,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tokio-runtime-shutdown",
  "tokio-test",
  "tracing",
@@ -1595,7 +1595,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
  "tracing",
  "url",
@@ -1615,7 +1615,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "uuid",
  "warp",
@@ -1640,7 +1640,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "uuid",
  "warp",
@@ -1663,7 +1663,7 @@ name = "iml-cmd"
 version = "0.4.0"
 dependencies = [
  "futures",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "warp",
 ]
@@ -1677,7 +1677,7 @@ dependencies = [
  "iml-tracing",
  "iml-wire-types",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1695,7 +1695,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tokio-test",
 ]
 
@@ -1719,7 +1719,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tokio-test",
  "url",
  "warp",
@@ -1733,7 +1733,7 @@ dependencies = [
  "futures",
  "tempdir",
  "tempfile",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
 ]
 
@@ -1767,7 +1767,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "uuid",
 ]
@@ -1790,7 +1790,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "time 0.2.22",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1809,7 +1809,7 @@ dependencies = [
  "serde_json",
  "tempdir",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "warp",
 ]
 
@@ -1845,7 +1845,7 @@ dependencies = [
  "serde_yaml",
  "structopt",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
 ]
 
@@ -1882,8 +1882,7 @@ dependencies = [
  "iml-service-queue",
  "iml-tracing",
  "iml-wire-types",
- "serde",
- "tokio",
+ "tokio 0.3.3",
  "tracing",
  "url",
 ]
@@ -1899,7 +1898,7 @@ dependencies = [
  "iml-service-queue",
  "iml-tracing",
  "iml-wire-types",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
 ]
 
@@ -1913,7 +1912,7 @@ dependencies = [
  "iml-service-queue",
  "iml-tracing",
  "iml-wire-types",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
 ]
 
@@ -1939,7 +1938,7 @@ dependencies = [
  "iml-service-queue",
  "iml-tracing",
  "iml-wire-types",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
 ]
 
@@ -1954,7 +1953,7 @@ dependencies = [
  "lapin",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tokio-amqp",
  "tracing",
  "warp",
@@ -1970,7 +1969,7 @@ dependencies = [
  "iml-manager-env",
  "iml-tracing",
  "tempdir",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "warp",
 ]
@@ -1986,7 +1985,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 0.2.22",
  "tokio-test",
  "tracing",
  "url",
@@ -2020,7 +2019,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "unzip-n",
  "url",
  "wbem-client",
@@ -2044,7 +2043,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "url",
 ]
 
@@ -2063,7 +2062,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "url",
 ]
@@ -2083,7 +2082,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
 ]
 
@@ -2096,7 +2095,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
 ]
 
@@ -2113,7 +2112,7 @@ dependencies = [
  "lazy_static",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -2126,7 +2125,7 @@ dependencies = [
  "iml-tracing",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 0.2.22",
  "warp",
 ]
 
@@ -2134,7 +2133,7 @@ dependencies = [
 name = "iml-tracing"
 version = "0.3.0"
 dependencies = [
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2147,7 +2146,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
 ]
 
@@ -2165,7 +2164,7 @@ dependencies = [
  "iml-wire-types",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 0.2.22",
  "tokio-runtime-shutdown",
  "tracing",
  "uuid",
@@ -2240,7 +2239,7 @@ dependencies = [
  "inotify-sys",
  "libc",
  "mio 0.6.22",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3522,7 +3521,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.22",
  "tokio-rustls",
  "tokio-tls",
  "url",
@@ -4019,7 +4018,7 @@ source = "git+https://github.com/jgrund/sqlx?branch=support-offline-workspaces#3
 dependencies = [
  "native-tls",
  "once_cell",
- "tokio",
+ "tokio 0.2.22",
  "tokio-native-tls",
 ]
 
@@ -4096,7 +4095,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4108,7 +4107,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4422,8 +4421,21 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "tokio-macros",
+ "tokio-macros 0.2.5",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
+dependencies = [
+ "autocfg 1.0.1",
+ "num_cpus",
+ "pin-project-lite",
+ "slab",
+ "tokio-macros 0.3.1",
 ]
 
 [[package]]
@@ -4433,7 +4445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2938fb5b638e6d8992c304e2426db2de4502f19084b91ec4562d9b45bf896fc4"
 dependencies = [
  "lapin",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4448,13 +4460,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
+]
+
+[[package]]
 name = "tokio-native-tls"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4475,7 +4498,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
 ]
 
@@ -4485,7 +4508,7 @@ version = "0.4.0"
 dependencies = [
  "futures",
  "stream-cancel 0.5.2",
- "tokio",
+ "tokio 0.2.22",
  "tokio-test",
 ]
 
@@ -4497,7 +4520,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio",
+ "tokio 0.2.22",
  "webpki",
 ]
 
@@ -4509,7 +4532,7 @@ checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
 dependencies = [
  "bytes",
  "futures-core",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4519,7 +4542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4531,7 +4554,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.22",
  "tungstenite",
 ]
 
@@ -4546,7 +4569,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -4876,7 +4899,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tungstenite",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,6 +1871,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "iml-network"
+version = "0.4.0"
+dependencies = [
+ "futures",
+ "iml-influx",
+ "iml-manager-env",
+ "iml-postgres",
+ "iml-rabbit",
+ "iml-service-queue",
+ "iml-tracing",
+ "iml-wire-types",
+ "serde",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "iml-ntp"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   'iml-services/iml-device',
   'iml-services/iml-journal',
   'iml-services/iml-journal',
+  'iml-services/iml-network',
   'iml-services/iml-ntp',
   'iml-services/iml-ostpool',
   'iml-services/iml-postoffice',

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -161,6 +161,17 @@ services:
       - RUST_LOG=info,sqlx::query=warn
     volumes:
       - "manager-config:/var/lib/chroma"
+  network:
+        image: "imlteam/network:6.2.0"
+        hostname: "iml-network"
+        build:
+          context: ../
+          dockerfile: ./docker/iml-network.dockerfile
+        deploy: *default-deploy
+        volumes:
+          - "manager-config:/var/lib/chroma"
+        environment:
+          - RUST_LOG=info,sqlx::query=warn
   ntp:
     image: "imlteam/ntp:6.2.0"
     hostname: "iml-ntp"

--- a/docker/iml-network.dockerfile
+++ b/docker/iml-network.dockerfile
@@ -1,0 +1,8 @@
+FROM rust-iml-base as builder
+FROM imlteam/rust-service-base:6.2.0
+
+COPY --from=builder /build/target/release/iml-network /usr/local/bin
+COPY docker/wait-for-dependencies-postgres.sh /usr/local/bin/
+
+ENTRYPOINT [ "wait-for-dependencies-postgres.sh" ]
+CMD ["iml-network"]

--- a/iml-agent/src/daemon_plugins/daemon_plugin.rs
+++ b/iml-agent/src/daemon_plugins/daemon_plugin.rs
@@ -5,7 +5,8 @@
 use crate::{
     agent_error::{NoPluginError, Result},
     daemon_plugins::{
-        action_runner, corosync, device, journal, ntp, ostpool, postoffice, snapshot, stats,
+        action_runner, corosync, device, journal, network, ntp, ostpool, postoffice, snapshot,
+        stats,
     },
 };
 use async_trait::async_trait;
@@ -81,6 +82,7 @@ pub fn plugin_registry() -> DaemonPlugins {
         ("journal".into(), mk_callback(journal::create)),
         ("corosync".into(), mk_callback(corosync::create)),
         ("snapshot".into(), mk_callback(snapshot::create)),
+        ("network".into(), mk_callback(network::create)),
     ]
     .into_iter()
     .collect();

--- a/iml-agent/src/daemon_plugins/mod.rs
+++ b/iml-agent/src/daemon_plugins/mod.rs
@@ -14,6 +14,7 @@ pub mod corosync;
 pub mod daemon_plugin;
 pub mod device;
 pub mod journal;
+pub mod network;
 pub mod ntp;
 pub mod ostpool;
 pub mod postoffice;

--- a/iml-agent/src/daemon_plugins/network.rs
+++ b/iml-agent/src/daemon_plugins/network.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+//! #Network daemon-plugin
+//!
+//! This module is responsible for continually fetching the network interfaces and their respective stats.
+//!
+//!
+
+use crate::{
+    agent_error::ImlAgentError,
+    daemon_plugins::{DaemonPlugin, Output},
+    network_interfaces,
+};
+use futures::Future;
+use iml_wire_types::NetworkInterface;
+use std::pin::Pin;
+
+#[derive(Debug)]
+pub struct Network;
+
+pub fn create() -> impl DaemonPlugin {
+    Network
+}
+
+async fn get_network_interfaces<F1>(get_interfaces: fn() -> F1) -> Result<Output, ImlAgentError>
+where
+    F1: Future<Output = Result<Vec<NetworkInterface>, ImlAgentError>>,
+{
+    let xs = get_interfaces().await?;
+    let xs = serde_json::to_value(xs).map(Some)?;
+
+    Ok(xs)
+}
+
+impl DaemonPlugin for Network {
+    fn start_session(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Output, ImlAgentError>> + Send>> {
+        self.update_session()
+    }
+
+    fn update_session(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Output, ImlAgentError>> + Send>> {
+        Box::pin(get_network_interfaces(network_interfaces::get_interfaces))
+    }
+}

--- a/iml-agent/src/daemon_plugins/network.rs
+++ b/iml-agent/src/daemon_plugins/network.rs
@@ -11,10 +11,9 @@
 use crate::{
     agent_error::ImlAgentError,
     daemon_plugins::{DaemonPlugin, Output},
-    network_interfaces,
+    network_interfaces::get_interfaces,
 };
 use futures::Future;
-use iml_wire_types::NetworkInterface;
 use std::pin::Pin;
 
 #[derive(Debug)]
@@ -24,10 +23,7 @@ pub fn create() -> impl DaemonPlugin {
     Network
 }
 
-async fn get_network_interfaces<F1>(get_interfaces: fn() -> F1) -> Result<Output, ImlAgentError>
-where
-    F1: Future<Output = Result<Vec<NetworkInterface>, ImlAgentError>>,
-{
+async fn get_network_interfaces() -> Result<Output, ImlAgentError> {
     let xs = get_interfaces().await?;
     let xs = serde_json::to_value(xs).map(Some)?;
 
@@ -44,6 +40,6 @@ impl DaemonPlugin for Network {
     fn update_session(
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<Output, ImlAgentError>> + Send>> {
-        Box::pin(get_network_interfaces(network_interfaces::get_interfaces))
+        Box::pin(get_network_interfaces())
     }
 }

--- a/iml-agent/src/network_interface_stats.rs
+++ b/iml-agent/src/network_interface_stats.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 use combine::{
     error::ParseError,
     many1,

--- a/iml-agent/src/network_interfaces.rs
+++ b/iml-agent/src/network_interfaces.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 use crate::{
     agent_error::ImlAgentError, network_interface::parse as parse_interfaces,
     network_interface_stats,

--- a/iml-manager.target
+++ b/iml-manager.target
@@ -40,6 +40,9 @@ After=iml-agent-comms.service
 Requires=iml-api.service
 After=iml-api.service
 
+Requires=iml-network.service
+After=iml-network.service
+
 Requires=iml-ntp.service
 After=iml-ntp.service
 
@@ -110,6 +113,7 @@ Also=iml-job-scheduler.service
 Also=iml-journal.service
 Also=iml-lustre-audit.service
 Also=iml-mailbox.service
+Also=iml-network.service
 Also=iml-ntp.service
 Also=iml-plugin-runner.service
 Also=iml-power-control.service

--- a/iml-network.service
+++ b/iml-network.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=IML Network Service
+PartOf=iml-manager.target
+After=rabbitmq-server.service
+After=postgresql-9.6.service
+After=iml-settings-populator.service
+Requires=iml-settings-populator.service
+
+
+[Service]
+Type=simple
+Environment=RUST_LOG=info,sqlx::query=warn
+EnvironmentFile=/var/lib/chroma/iml-settings.conf
+EnvironmentFile=-/var/lib/chroma/overrides.conf
+ExecStart=/bin/iml-network
+Restart=always
+RestartSec=2
+StandardOutput=journal
+StandardError=journal

--- a/iml-services/iml-network/Cargo.toml
+++ b/iml-services/iml-network/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+name = "iml-network"
+version = "0.4.0"
+
+[dependencies]
+futures = "0.3"
+iml-influx = {path = "../../iml-influx", version = "0.2", features = ["with-db-client"]}
+iml-manager-env = {path = "../../iml-manager-env", version = "0.4"}
+iml-postgres = {path = "../../iml-postgres", version = "0.4"}
+iml-rabbit = {path = "../../iml-rabbit", version = "0.4"}
+iml-service-queue = {path = "../iml-service-queue", version = "0.4"}
+iml-tracing = {version = "0.3", path = "../../iml-tracing"}
+iml-wire-types = {path = "../../iml-wire-types", version = "0.4"}
+serde = "1.0"
+tokio = {version = "0.2", features = ["rt-threaded", "blocking"]}
+tracing = "0.1"
+url = "2.1"

--- a/iml-services/iml-network/Cargo.toml
+++ b/iml-services/iml-network/Cargo.toml
@@ -13,7 +13,6 @@ iml-rabbit = {path = "../../iml-rabbit", version = "0.4"}
 iml-service-queue = {path = "../iml-service-queue", version = "0.4"}
 iml-tracing = {version = "0.3", path = "../../iml-tracing"}
 iml-wire-types = {path = "../../iml-wire-types", version = "0.4"}
-serde = "1.0"
-tokio = {version = "0.2", features = ["rt-threaded", "blocking"]}
+tokio = {version = "0.3", features = ["macros", "rt-multi-thread"]}
 tracing = "0.1"
 url = "2.1"

--- a/iml-services/iml-network/Cargo.toml
+++ b/iml-services/iml-network/Cargo.toml
@@ -13,6 +13,6 @@ iml-rabbit = {path = "../../iml-rabbit", version = "0.4"}
 iml-service-queue = {path = "../iml-service-queue", version = "0.4"}
 iml-tracing = {version = "0.3", path = "../../iml-tracing"}
 iml-wire-types = {path = "../../iml-wire-types", version = "0.4"}
-tokio = {version = "0.3", features = ["macros", "rt-multi-thread"]}
+tokio = {version = "0.2", features = ["rt-threaded", "blocking"]}
 tracing = "0.1"
 url = "2.1"

--- a/iml-services/iml-network/src/main.rs
+++ b/iml-services/iml-network/src/main.rs
@@ -1,0 +1,150 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use futures::TryStreamExt;
+use iml_influx::{Client, Point, Points, Precision, Value};
+use iml_manager_env::{get_influxdb_addr, get_influxdb_metrics_db, get_pool_limit};
+use iml_postgres::{get_db_pool, host_id_by_fqdn, sqlx};
+use iml_service_queue::service_queue::consume_data;
+use iml_wire_types::NetworkInterface;
+use url::Url;
+
+// Default pool limit if not overridden by POOL_LIMIT
+const DEFAULT_POOL_LIMIT: u32 = 2;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    iml_tracing::init();
+
+    let pool = get_db_pool(get_pool_limit().unwrap_or(DEFAULT_POOL_LIMIT)).await?;
+
+    let rabbit_pool = iml_rabbit::connect_to_rabbit(1);
+
+    let conn = iml_rabbit::get_conn(rabbit_pool).await?;
+
+    let ch = iml_rabbit::create_channel(&conn).await?;
+
+    let mut s = consume_data::<Vec<NetworkInterface>>(&ch, "rust_agent_network_rx");
+
+    sqlx::migrate!("../../migrations").run(&pool).await?;
+
+    let influx_url: String = format!("http://{}", get_influxdb_addr());
+    let influx_client = Client::new(
+        Url::parse(&influx_url).expect("Influx URL is invalid."),
+        get_influxdb_metrics_db(),
+    );
+
+    while let Some((fqdn, interfaces)) = s.try_next().await? {
+        tracing::debug!("fqdn: {:?} interfaces: {:?}", fqdn, interfaces);
+
+        let host_id = host_id_by_fqdn(&fqdn, &pool).await?;
+
+        let host_id = if let Some(host_id) = host_id {
+            host_id
+        } else {
+            continue;
+        };
+
+        let xs = interfaces
+            .iter()
+            .cloned()
+            .filter_map(|x| {
+                if let Some(mac_address) = x.mac_address {
+                    Some((
+                        mac_address,
+                        x.interface,
+                        x.inet4_address
+                            .into_iter()
+                            .map(|x| x.to_string())
+                            .collect::<Vec<String>>()
+                            .join(","),
+                        x.inet6_address
+                            .into_iter()
+                            .map(|x| x.to_string())
+                            .collect::<Vec<String>>()
+                            .join(","),
+                        x.interface_type.map(|x| x.to_string()),
+                        x.is_up,
+                    ))
+                } else {
+                    None
+                }
+            })
+            .fold(
+                (vec![], vec![], vec![], vec![], vec![], vec![], vec![]),
+                |mut acc,
+                 (
+                    mac_address,
+                    interface,
+                    inet4_addresses,
+                    inet6_addresses,
+                    interface_type,
+                    is_up,
+                )| {
+                    acc.0.push(mac_address);
+                    acc.1.push(interface);
+                    acc.2.push(inet4_addresses);
+                    acc.3.push(inet6_addresses);
+                    acc.4.push(interface_type);
+                    acc.5.push(is_up);
+                    acc.6.push(host_id);
+
+                    acc
+                },
+            );
+
+        sqlx::query!(
+            r#"
+                INSERT INTO network_interface 
+                (mac_address, name, inet4_address, inet6_address, lnd_type, state_up, host_id)
+                SELECT mac_address, name, string_to_array(inet4_address, ',')::inet[], string_to_array(inet6_address, ',')::inet[], lnd_type, state_up, host_id
+                FROM UNNEST($1::text[], $2::text[], $3::text[], $4::text[], $5::lnd_network_type[], $6::bool[], $7::int[])
+                AS t(mac_address, name, inet4_address, inet6_address, lnd_type, state_up, host_id)
+                ON CONFLICT (mac_address)
+                    DO
+                    UPDATE SET  name          = EXCLUDED.name,
+                                inet4_address = EXCLUDED.inet4_address,
+                                inet6_address = EXCLUDED.inet6_address,
+                                lnd_type      = EXCLUDED.lnd_type,
+                                state_up      = EXCLUDED.state_up,
+                                host_id       = EXCLUDED.host_id"#,
+                &xs.0,
+                &xs.1,
+                &xs.2,
+                &xs.3,
+                &xs.4 as &[Option<String>],
+                &xs.5,
+                &xs.6,
+        )
+        .execute(&pool)
+        .await?;
+
+        let points = interfaces
+            .iter()
+            .cloned()
+            .filter_map(|x: NetworkInterface| {
+                x.stats
+                    .clone()
+                    .map(|stat| (x.interface, stat.rx.bytes, stat.tx.bytes))
+            })
+            .map(|(interface, rx_bytes, tx_bytes)| {
+                Point::new("net")
+                    .add_tag("interface", Value::String(interface))
+                    .add_tag("host_id", Value::Integer(host_id as i64))
+                    .add_field("rx_bytes", Value::Integer(rx_bytes as i64))
+                    .add_field("tx_bytes", Value::Integer(tx_bytes as i64))
+            })
+            .collect::<Vec<Point>>();
+
+        let points = Points::create_new(points);
+
+        tracing::debug!("Writing net stats to influx.");
+
+        influx_client
+            .write_points(points, Some(Precision::Nanoseconds), None)
+            .await?;
+    }
+
+    Ok(())
+}

--- a/iml-services/iml-network/src/main.rs
+++ b/iml-services/iml-network/src/main.rs
@@ -43,6 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let host_id = if let Some(host_id) = host_id {
             host_id
         } else {
+            tracing::debug!("Couldn't get the host id using fqdn {}", fqdn);
             continue;
         };
 
@@ -122,11 +123,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let points = interfaces
             .iter()
-            .cloned()
-            .filter_map(|x: NetworkInterface| {
+            .filter_map(|x: &NetworkInterface| {
                 x.stats
                     .clone()
-                    .map(|stat| (x.interface, stat.rx.bytes, stat.tx.bytes))
+                    .map(|stat| (x.interface.to_string(), stat.rx.bytes, stat.tx.bytes))
             })
             .map(|(interface, rx_bytes, tx_bytes)| {
                 Point::new("net")

--- a/migrations/20201028182332_network_interface.sql
+++ b/migrations/20201028182332_network_interface.sql
@@ -1,0 +1,11 @@
+CREATE TYPE lnd_network_type AS ENUM ('tcp', 'o2ib');
+
+CREATE TABLE IF NOT EXISTS network_interface (
+    mac_address    text PRIMARY KEY,
+    name           text NOT NULL,
+    inet4_address  inet[] NOT NULL,
+    inet6_address  inet[] NOT NULL,
+    lnd_type       lnd_network_type,
+    state_up       boolean NOT NULL,
+    host_id        int NOT NULL
+);

--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -88,6 +88,7 @@ Requires:       rust-iml-device >= 0.4.0
 Requires:       rust-iml-gui >= 0.3.0
 Requires:       rust-iml-journal >= 0.4.0
 Requires:       rust-iml-mailbox >= 0.4.0
+Requires:       rust-iml-network >= 0.4.0
 Requires:       rust-iml-ntp >= 0.4.0
 Requires:       rust-iml-ostpool >= 0.4.0
 Requires:       rust-iml-postoffice >= 0.4.0

--- a/rust-iml.spec
+++ b/rust-iml.spec
@@ -38,6 +38,7 @@ cp iml-corosync %{buildroot}%{_bindir}
 cp iml-device %{buildroot}%{_bindir}
 cp iml-journal %{buildroot}%{_bindir}
 cp iml-mailbox %{buildroot}%{_bindir}
+cp iml-network %{buildroot}%{_bindir}
 cp iml-ntp %{buildroot}%{_bindir}
 cp iml-ostpool %{buildroot}%{_bindir}
 cp iml-postoffice %{buildroot}%{_bindir}
@@ -56,6 +57,7 @@ cp iml-rust-corosync.service %{buildroot}%{_unitdir}
 cp iml-device.service %{buildroot}%{_unitdir}
 cp iml-journal.service %{buildroot}%{_unitdir}
 cp iml-mailbox.service %{buildroot}%{_unitdir}
+cp iml-network.service %{buildroot}%{_unitdir}
 cp iml-ntp.service %{buildroot}%{_unitdir}
 cp iml-ostpool.service %{buildroot}%{_unitdir}
 cp iml-postoffice.service %{buildroot}%{_unitdir}
@@ -331,6 +333,27 @@ Group: System Environment/Libraries
 %{_bindir}/iml-mailbox
 %attr(0644,root,root)%{_unitdir}/iml-mailbox.service
 
+%package network
+Summary: Consumer of IML Agent Network push queue
+License: MIT
+Group: System Environment/Libraries
+
+%description network
+%{summary}
+
+%post network
+%systemd_post iml-network.service
+
+%preun network
+%systemd_preun iml-network.service
+
+%postun network
+%systemd_postun_with_restart iml-network.service
+
+%files network
+%{_bindir}/iml-network
+%attr(0644,root,root)%{_unitdir}/iml-network.service
+
 %package ntp
 Summary: Consumer of IML Agent Ntp push queue
 License: MIT
@@ -527,6 +550,9 @@ Group: System Environment/Libraries
 %attr(0644,root,root)%{_unitdir}/iml-timer.service
 
 %changelog
+* Wed Oct 28 2020 Will Johnson <wjohnson@whamcloud.com> - 0.4.0-1
+- Add network service
+
 * Thu Sep 17 2020 Will Johnson <wjohnson@whamcloud.com> - 0.3.0-1
 - Add timer service
 

--- a/rust-iml.spec
+++ b/rust-iml.spec
@@ -550,9 +550,6 @@ Group: System Environment/Libraries
 %attr(0644,root,root)%{_unitdir}/iml-timer.service
 
 %changelog
-* Wed Oct 28 2020 Will Johnson <wjohnson@whamcloud.com> - 0.4.0-1
-- Add network service
-
 * Thu Sep 17 2020 Will Johnson <wjohnson@whamcloud.com> - 0.3.0-1
 - Add timer service
 

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -891,6 +891,41 @@
       ]
     }
   },
+  "321e561cd3b4279dba46176519f5ac2644785954e6bbd229e41ae16fb21f5417": {
+    "query": "\n                INSERT INTO network_interface \n                (mac_address, name, inet4_address, inet6_address, lnd_type, state_up, host_id)\n                SELECT mac_address, name, string_to_array(inet4_address, ',')::inet[], string_to_array(inet6_address, ',')::inet[], lnd_type, state_up, host_id\n                FROM UNNEST($1::text[], $2::text[], $3::text[], $4::text[], $5::lnd_network_type[], $6::bool[], $7::int[])\n                AS t(mac_address, name, inet4_address, inet6_address, lnd_type, state_up, host_id)\n                ON CONFLICT (mac_address)\n                    DO\n                    UPDATE SET  name          = EXCLUDED.name,\n                                inet4_address = EXCLUDED.inet4_address,\n                                inet6_address = EXCLUDED.inet6_address,\n                                lnd_type      = EXCLUDED.lnd_type,\n                                state_up      = EXCLUDED.state_up,\n                                host_id       = EXCLUDED.host_id",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "TextArray",
+          "TextArray",
+          "TextArray",
+          "TextArray",
+          {
+            "Custom": {
+              "name": "_lnd_network_type",
+              "kind": {
+                "Array": {
+                  "Custom": {
+                    "name": "lnd_network_type",
+                    "kind": {
+                      "Enum": [
+                        "tcp",
+                        "o2ib"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "BoolArray",
+          "Int4Array"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "36188079437a0e3df0d4584e22b15673bfadcf66128168b59e13717eedcd8470": {
     "query": "\n            DELETE FROM corosync_node\n            USING corosync_node_managed_host\n            WHERE id = corosync_node_id\n            AND host_id = $1\n            AND corosync_node_id != ALL($2::corosync_node_key[])\n        ",
     "describe": {

--- a/vagrant/scripts/install_iml_docker_local.sh
+++ b/vagrant/scripts/install_iml_docker_local.sh
@@ -53,6 +53,9 @@ services:
   device:
     environment:
       - RUST_LOG=debug
+  network:
+    environment:
+      - RUST_LOG=debug
 EOF
 
 # Enable but do not start iml-docker

--- a/vagrant/scripts/install_iml_docker_repouri.sh
+++ b/vagrant/scripts/install_iml_docker_repouri.sh
@@ -92,6 +92,9 @@ services:
   device:
     environment:
       - RUST_LOG=debug
+  network:
+    environment:
+      - RUST_LOG=debug
 EOF
 
 # Enable but do not start iml-docker

--- a/vagrant/scripts/install_iml_local.sh
+++ b/vagrant/scripts/install_iml_local.sh
@@ -128,7 +128,7 @@ EOF
 rm -rf /tmp/{manager,agent}-rpms
 mkdir -p /tmp/{manager,agent}-rpms
 
-cp /tmp/iml/_topdir/RPMS/rust-iml-{action-runner,agent-comms,api,cli,corosync,config-cli,journal,mailbox,ntp,ostpool,postoffice,report,sfa,snapshot,stats,task-runner,device,warp-drive,timer}-*.rpm /tmp/manager-rpms/
+cp /tmp/iml/_topdir/RPMS/rust-iml-{action-runner,agent-comms,api,cli,corosync,config-cli,journal,mailbox,network,ntp,ostpool,postoffice,report,sfa,snapshot,stats,task-runner,device,warp-drive,timer}-*.rpm /tmp/manager-rpms/
 cp /tmp/iml/_topdir/RPMS/python2-iml-manager-*.rpm /tmp/manager-rpms/
 cp /tmp/iml/_topdir/RPMS/rust-iml-agent-[0-9]*.rpm /tmp/agent-rpms
 cp /tmp/iml/_topdir/RPMS/iml-device-scanner-*.rpm /tmp/agent-rpms


### PR DESCRIPTION
Now that the network logic / parsing lives on the rust side in the
iml-agent, the next step is to:
1. Create a daemon plugin to fetch the data
2. Ingest the data on the manager side:
   a. Insert the interface data into the database
   b. Insert the interface stats (rx/tx bytes) into influx

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2353)
<!-- Reviewable:end -->
