### PR TITLE
Update action-client

### DIFF
--- a/iml-task-runner/src/main.rs
+++ b/iml-task-runner/src/main.rs
@@ -213,7 +213,10 @@ async fn send_work(
     // send fids to actions runner
     // action names on Agents are "action.ACTION_NAME"
     for action in task.actions.iter().map(|a| format!("action.{}", a)) {
-        match action_client.invoke_rust_agent(fqdn, &action, &args).await {
+        match action_client
+            .invoke_rust_agent(fqdn, &action, &args, None)
+            .await
+        {
             Err(e) => {
                 tracing::info!("Failed to send {} to {}: {:?}", &action, fqdn, e);
 


### PR DESCRIPTION
Update action-client once again to optionally take a uuid that can be
used to bookkeep the request in flight.

In addition, remove `invoke_rust_agent_cancelable` as it adds an extra
layer of indirection that is more useful in tools calling the client.

Replace it with a `cancel_request` fn that will take a `Uuid` ref and
attempt to cancel a remote rpc matching the uuid.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2356)
<!-- Reviewable:end -->
