### PR TITLE
Update graphql python client

### DIFF
--- a/chroma_core/lib/graphql.py
+++ b/chroma_core/lib/graphql.py
@@ -9,23 +9,57 @@ this = sys.modules[__name__]
 this.API_CRED = None
 
 
+class GraphQlQueryException(Exception):
+    pass
+
+
 def get_api_session_request():
     if not this.API_CRED:
         cursor = connection.cursor()
         cursor.execute("SELECT * from api_key()")
         this.API_CRED = cursor.fetchone()
         cursor.close()
+
     s = requests.Session()
     s.headers.update({"AUTHORIZATION": "ApiKey {}:{}".format(this.API_CRED[0], this.API_CRED[1])})
+
     return s
 
 
-def graphql_query(query):
+def graphql_query(query, variables={}):
     """
     Issue a GraphQL query
     """
     s = get_api_session_request()
     path = os.path.join(settings.IML_API_PROXY_PASS, "graphql")
-    q = {"query": query}
+    q = {"query": query, "variables": variables}
     res = s.post(url=path, json=q)
-    return res.json()["data"]
+
+    body = res.json()
+
+    errors = body.get("errors")
+
+    if errors is not None:
+        raise GraphQlQueryException(errors)
+
+    return body.get("data")
+
+
+def get_targets(**kwargs):
+    query = """
+        query Targets($limit: Int, $offset: Int, $dir: SortDir, $fsname: String, $exclude_unmounted: Boolean) {
+          targets(limit: $limit, offset: $offset, dir: $dir, fsName: $fsname, excludeUnmounted: $exclude_unmounted) {
+            id
+            state
+            name
+            dev_path: devPath
+            active_host_id: activeHostId
+            host_ids: hostIds
+            filesystems
+            uuid
+            mount_path: mountPath
+          }
+        }
+    """
+
+    return graphql_query(query, variables=kwargs)["targets"]


### PR DESCRIPTION
Update the graphql python client to properly raise on error when the
query returns an error. In addition, provide a way to pass variables to
the client.

Finally, add a helper function to fetch all targets.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2372)
<!-- Reviewable:end -->
