### PR TITLE
Fix Stale Influx Entries

### DIFF
--- a/iml-services/iml-stats/src/main.rs
+++ b/iml-services/iml-stats/src/main.rs
@@ -547,9 +547,9 @@ async fn delete_existing_mgs_fs_records(
         .query_into(
             format!(
                 r#"
-                SELECT mgs_fs, mgs_fs_count FROM 
+                SELECT mgs_fs, mgs_fs_count FROM
                     (SELECT count(is_mgs_fs) AS mgs_fs_count FROM target WHERE is_mgs_fs=true GROUP BY mgs_fs),
-                    (SELECT LAST(is_mgs_fs),time as last_time FROM target GROUP BY mgs_fs) 
+                    (SELECT LAST(is_mgs_fs),time as last_time FROM target GROUP BY mgs_fs)
                 GROUP BY mgs_fs
                 "#
             )
@@ -560,7 +560,7 @@ async fn delete_existing_mgs_fs_records(
         .unwrap_or_default();
 
     tracing::debug!(
-        "delete existing mgs_fs records - fs_names: {:?}; query results: {:?}",
+        "delete stale mgs_fs records - fs_names: {:?}; query results: {:?}",
         fs_names,
         xs
     );
@@ -570,15 +570,12 @@ async fn delete_existing_mgs_fs_records(
         .filter(|x| {
             let mgs_fs_set = fs_names_to_hash_set(&x.mgs_fs);
 
-            let intersection = mgs_fs_set
-                .intersection(&fs_names)
-                .map(|x| x.to_string())
-                .collect::<Vec<String>>();
+            let intersection = mgs_fs_set.intersection(&fs_names).collect::<Vec<_>>();
 
-            return !intersection.is_empty();
+            !intersection.is_empty()
         })
         .fold(HashMap::new(), |mut acc, record| {
-            let mgs_fs = record.mgs_fs.to_string();
+            let mgs_fs = record.mgs_fs;
             let mut entry = acc.entry(mgs_fs).or_insert((0, 0));
 
             if record.time > 0 {
@@ -592,31 +589,38 @@ async fn delete_existing_mgs_fs_records(
             acc
         });
 
-    let delete_subset_futures = subsets.into_iter().map(|(mgs_fs, (time, count))| {
-        let mds_fs_set = fs_names_to_hash_set(&mgs_fs);
+    let delete_subset_futures = subsets
+        .into_iter()
+        .filter(|(mgs_fs, (_time, count))| {
+            let mgs_fs_set = fs_names_to_hash_set(&mgs_fs);
 
-        let query = if mds_fs_set == fs_names && count > 1 {
-            format!(
-                "DELETE FROM target WHERE time < {} AND mgs_fs = '{}' AND kind = '{}'",
-                time,
-                mgs_fs,
-                TargetVariant::MGT
-            )
-        } else {
-            format!(
-                "DELETE FROM target WHERE time <= {} AND mgs_fs = '{}' AND kind = '{}'",
-                time,
-                mgs_fs,
-                TargetVariant::MGT
-            )
-        };
+            mgs_fs_set != fs_names || *count > 1
+        })
+        .map(|(mgs_fs, (time, count))| {
+            let mds_fs_set = fs_names_to_hash_set(&mgs_fs);
 
-        tracing::debug!("Deleting entries with query: {}", query);
+            let query = if mds_fs_set == fs_names && count > 1 {
+                format!(
+                    "DELETE FROM target WHERE time < {} AND mgs_fs = '{}' AND kind = '{}'",
+                    time,
+                    mgs_fs,
+                    TargetVariant::MGT
+                )
+            } else {
+                format!(
+                    "DELETE FROM target WHERE time <= {} AND mgs_fs = '{}' AND kind = '{}'",
+                    time,
+                    mgs_fs,
+                    TargetVariant::MGT
+                )
+            };
 
-        client
-            .query(query.as_str(), Some(Precision::Nanoseconds))
-            .map_err(|e| iml_influx::Error::InfluxDbError(e))
-    });
+            tracing::debug!("Deleting entries with query: {}", query);
+
+            client
+                .query(query.as_str(), Some(Precision::Nanoseconds))
+                .map_err(|e| iml_influx::Error::InfluxDbError(e))
+        });
 
     try_join_all(delete_subset_futures).await?;
 
@@ -636,7 +640,7 @@ fn join_fs_names(xs: Vec<FsName>) -> String {
         .join(",")
 }
 
-fn fs_names_vec_to_hash_set(xs: &Vec<FsName>) -> HashSet<String> {
+fn fs_names_vec_to_hash_set(xs: &[FsName]) -> HashSet<String> {
     xs.into_iter().map(|x| x.0.to_string()).collect()
 }
 


### PR DESCRIPTION
There is currently a case in which a stale entries are being left in the
influx db. This takes place when a filesystem is mounted, data is pulled
into influx, and then another filesystem is mounted, and both
filesystems use the same mgs. For example:

time n:
mgs_fs: "fs"

time n+1:
mgs_fs: "fs2"

time n+2:
mgs_fs: "fs,fs2"

Currently, only items matching "fs,fs2" will be removed, since that's
the current input. This results in entries in the target table showing
that the filesystems are: "fs, fs2, fs,fs2".

This patch ensures that all subsets of the input filesystems are deleted
and all but the last of the current subset is deleted.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2373)
<!-- Reviewable:end -->
