### PR TITLE
Require influx < 2

### DIFF
--- a/python-iml-manager.spec
+++ b/python-iml-manager.spec
@@ -99,7 +99,7 @@ Requires:       rust-iml-task-runner >= 0.4.0
 Requires:       rust-iml-warp-drive >= 0.4.0
 Requires:       rust-iml-timer >= 0.4.0
 # Other Repos
-Requires:       influxdb
+Requires:       influxdb < 2
 Requires:       grafana
 
 Conflicts:      chroma-agent


### PR DESCRIPTION
There is a beta version 2.0 in the "stable" repo which is incompartible by
CLI at least.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2377)
<!-- Reviewable:end -->
