### PR TITLE
Extract device-scanner client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,8 @@ dependencies = [
 [[package]]
 name = "device-types"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e34bac42a9bc7413aea842316cce9a11070b879a952b7671f5865899b2bfb3"
 dependencies = [
  "im",
  "libzfs-types",
@@ -1562,12 +1564,12 @@ dependencies = [
  "chrono",
  "combine 4.1.0",
  "console 0.12.0",
+ "device-types",
  "dns-lookup",
  "dotenv",
  "elementtree",
  "exitcode",
  "futures",
- "futures-util",
  "http",
  "iml-cmd",
  "iml-fs",

--- a/iml-agent/Cargo.toml
+++ b/iml-agent/Cargo.toml
@@ -14,12 +14,12 @@ bytes = "0.5"
 chrono = "0.4"
 combine = "=4.1.0"
 console = "0.12"
+device-types = "0.3.0"
 dns-lookup = "1"
 dotenv = "0.15"
 elementtree = "0.5"
 exitcode = "1.1"
 futures = "0.3"
-futures-util = "0.3"
 http = "0.2"
 iml-cmd = {path = "../iml-cmd", version = "0.4.0"}
 iml-fs = {path = "../iml-fs", version = "0.4.0"}

--- a/iml-agent/src/device_scanner_client.rs
+++ b/iml-agent/src/device_scanner_client.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::agent_error::ImlAgentError;
+use device_types::mount::Mount;
+use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt};
+use tokio::{io::AsyncWriteExt, net::UnixStream};
+use tokio_util::codec::{FramedRead, LinesCodec};
+
+pub async fn connect() -> Result<UnixStream, ImlAgentError> {
+    let x = UnixStream::connect("/var/run/device-scanner.sock").await?;
+
+    Ok(x)
+}
+
+pub enum Cmd {
+    Stream,
+    GetMounts,
+}
+
+impl From<Cmd> for &[u8] {
+    fn from(cmd: Cmd) -> Self {
+        match cmd {
+            Cmd::Stream => b"\"Stream\"\n",
+            Cmd::GetMounts => b"\"GetMounts\"\n",
+        }
+    }
+}
+
+pub fn stream_lines(
+    cmd: impl Into<&'static [u8]>,
+) -> impl Stream<Item = Result<String, ImlAgentError>> {
+    connect()
+        .and_then(|mut conn| async {
+            conn.write_all(cmd.into())
+                .err_into::<ImlAgentError>()
+                .await?;
+
+            Ok(conn)
+        })
+        .map_ok(|c| FramedRead::new(c, LinesCodec::new()).err_into())
+        .try_flatten_stream()
+}
+
+pub async fn get_mounts() -> Result<Vec<Mount>, ImlAgentError> {
+    let (x, _) = stream_lines(Cmd::GetMounts).boxed().into_future().await;
+
+    let x = match x {
+        Some(x) => serde_json::from_str(x?.as_str())?,
+        None => vec![],
+    };
+
+    Ok(x)
+}
+
+pub async fn get_snapshot_mounts() -> Result<Vec<Mount>, ImlAgentError> {
+    let xs = get_mounts()
+        .await?
+        .into_iter()
+        .filter(|x| x.opts.0.split(',').any(|x| x == "nomgs"))
+        .filter(|x| x.fs_type.0 == "lustre")
+        .collect::<Vec<Mount>>();
+
+    Ok(xs)
+}

--- a/iml-agent/src/lib.rs
+++ b/iml-agent/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod action_plugins;
 pub mod agent_error;
 pub mod daemon_plugins;
+pub mod device_scanner_client;
 pub mod env;
 pub mod fidlist;
 pub mod high_availability;

--- a/iml-services/iml-device/Cargo.toml
+++ b/iml-services/iml-device/Cargo.toml
@@ -5,7 +5,7 @@ name = "iml-device"
 version = "0.4.0"
 
 [dependencies]
-device-types = {path = "../../device-scanner/device-types", version = "0.3"}
+device-types = "0.3.0"
 futures = "0.3"
 im = {version = "15.0", features = ["serde"]}
 iml-change = {path = "../../iml-change", version = "0.1"}


### PR DESCRIPTION
Extract a client that can be used to make requests to device-scanner on
the agent side.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2378)
<!-- Reviewable:end -->
