### PR TITLE
 Duplicate target insert during attempted target mount

### DIFF
--- a/iml-services/iml-device/src/main.rs
+++ b/iml-services/iml-device/src/main.rs
@@ -140,6 +140,10 @@ async fn main() -> Result<(), ImlDeviceError> {
             .chain(mgs_targets_to_fs_map)
             .collect();
 
+        tracing::debug!("target_to_fs_map: {:?}", target_to_fs_map);
+
+        tracing::debug!("mount_cache: {:?}", mount_cache);
+
         let targets = find_targets(
             &device_cache,
             &mount_cache,
@@ -147,6 +151,10 @@ async fn main() -> Result<(), ImlDeviceError> {
             &index,
             &target_to_fs_map,
         );
+
+        tracing::debug!("targets: {:?}", targets);
+
+        tracing::debug!("target_cache: {:?}", target_cache);
 
         let x = targets.get_changes(&target_cache);
 


### PR DESCRIPTION
When targets are mounted quickly in succession (i.e after a failed mount), we can get data
from the agents showing the target mounted on both hosts.
When this occurs we will try to insert the target twice into the db.

Instead we should filter out any items that show as mounted but are unknown to the current host.

Fixes #2380

Signed-off-by: Joe Grund <jgrund@whamcloud.io>