### PR TITLE
Add rust rpm provisioner to adm node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,6 @@ NOSE_ARGS ?= --stop
 
 ZIP_TYPE := $(shell if [ "$(ZIP_DEV)" == "true" ]; then echo '-dev'; else echo ''; fi)
 
-CARGO_HOME := /root/.cargo
-SCCACHE_CACHE_SIZE" := 40G,
-SCCACHE_DIR := /root/.cache,
-RUSTC_WRAPPER := /root/.cargo/bin/sccache
-
 all: copr-rpms rpms device-scanner-rpms iml-gui-rpm docker-rpms
 
 local:

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ NOSE_ARGS ?= --stop
 
 ZIP_TYPE := $(shell if [ "$(ZIP_DEV)" == "true" ]; then echo '-dev'; else echo ''; fi)
 
+CARGO_HOME := /root/.cargo
+SCCACHE_CACHE_SIZE" := 40G,
+SCCACHE_DIR := /root/.cache,
+RUSTC_WRAPPER := /root/.cargo/bin/sccache
+
 all: copr-rpms rpms device-scanner-rpms iml-gui-rpm docker-rpms
 
 local:

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -255,6 +255,11 @@ Vagrant.configure('2') do |config|
                      type: 'shell',
                      run: 'never',
                      path: 'scripts/load-diagnostics-db.sh'
+
+    adm.vm.provision 'build-rust-rpms',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/build_rust_rpms.sh'
   end
 
   #

--- a/vagrant/scripts/build_rust_rpms.sh
+++ b/vagrant/scripts/build_rust_rpms.sh
@@ -3,4 +3,6 @@ yum install -y cargo rpm-build
 
 [ -f /root/.cargo/bin/sccache ] && echo "sccache already installed. Skipping." || cargo install sccache
 
-cd /integrated-manager-for-lustre && make copr-rpms
+cd /integrated-manager-for-lustre \
+    && sed -i 's/Release: 1.*/Release: 1.'"$(date '+%s')"'/g' rust-iml.spec \
+    && make copr-rpms

--- a/vagrant/scripts/build_rust_rpms.sh
+++ b/vagrant/scripts/build_rust_rpms.sh
@@ -3,7 +3,5 @@ yum install -y cargo rpm-build
 
 [ -f /root/.cargo/bin/sccache ] && echo "sccache already installed. Skipping." || cargo install sccache
 
-rm -rf /integrated-manager-for-lustre/_topdir
-
 cd /integrated-manager-for-lustre \
     && CARGO_HOME="/root/.cargo" SCCACHE_CACHE_SIZE="40G"  SCCACHE_DIR="/root/.cache" RUSTC_WRAPPER="/root/.cargo/bin/sccache" make copr-rpms

--- a/vagrant/scripts/build_rust_rpms.sh
+++ b/vagrant/scripts/build_rust_rpms.sh
@@ -3,5 +3,4 @@ yum install -y cargo rpm-build
 
 [ -f /root/.cargo/bin/sccache ] && echo "sccache already installed. Skipping." || cargo install sccache
 
-cd /integrated-manager-for-lustre \
-    && CARGO_HOME="/root/.cargo" SCCACHE_CACHE_SIZE="40G"  SCCACHE_DIR="/root/.cache" RUSTC_WRAPPER="/root/.cargo/bin/sccache" make copr-rpms
+cd /integrated-manager-for-lustre && make copr-rpms

--- a/vagrant/scripts/build_rust_rpms.sh
+++ b/vagrant/scripts/build_rust_rpms.sh
@@ -1,0 +1,9 @@
+yum install -y openssl-devel
+yum install -y cargo rpm-build
+
+[ -f /root/.cargo/bin/sccache ] && echo "sccache already installed. Skipping." || cargo install sccache
+
+rm -rf /integrated-manager-for-lustre/_topdir
+
+cd /integrated-manager-for-lustre \
+    && CARGO_HOME="/root/.cargo" SCCACHE_CACHE_SIZE="40G"  SCCACHE_DIR="/root/.cache" RUSTC_WRAPPER="/root/.cargo/bin/sccache" make copr-rpms

--- a/vagrant/scripts/build_rust_rpms.sh
+++ b/vagrant/scripts/build_rust_rpms.sh
@@ -18,5 +18,4 @@ EOF
 source /root/.bash_profile
 
 cd /integrated-manager-for-lustre \
-    && sed -i 's/Release: 1.*/Release: 1.'"$(date '+%s')"'/g' rust-iml.spec \
-    && make copr-rpms
+    && RPM_DIST=".$(date '+%s')" make copr-rpms

--- a/vagrant/scripts/build_rust_rpms.sh
+++ b/vagrant/scripts/build_rust_rpms.sh
@@ -3,6 +3,20 @@ yum install -y cargo rpm-build
 
 [ -f /root/.cargo/bin/sccache ] && echo "sccache already installed. Skipping." || cargo install sccache
 
+sed -i '/^export CARGO_HOME/d' /root/.bash_profile
+sed -i '/^export SCCACHE_CACHE_SIZE/d' /root/.bash_profile
+sed -i '/^export SCCACHE_DIR/d' /root/.bash_profile
+sed -i '/^export RUSTC_WRAPPER/d' /root/.bash_profile
+
+cat <<EOF >> /root/.bash_profile
+export CARGO_HOME=/root/.cargo
+export SCCACHE_CACHE_SIZE=40G
+export SCCACHE_DIR=/root/.cache
+export RUSTC_WRAPPER=/root/.cargo/bin/sccache
+EOF
+
+source /root/.bash_profile
+
 cd /integrated-manager-for-lustre \
     && sed -i 's/Release: 1.*/Release: 1.'"$(date '+%s')"'/g' rust-iml.spec \
     && make copr-rpms


### PR DESCRIPTION
Building the rpms locally has been difficult becuase using the docker
container is significantly slower, even after increasing the available
ram and cpu's. In contrast, building in the adm vm appears to be nearly
as fast as building on the host. Furthermore, adding sccache appears to
maintain dependency builds across different branches, allowing for much
quicker builds. This patch adds a new provisioner to build the rust rpms
using the adm virtual machine and takes care of installing all necessary
dependencies, including sccache. To build the rust rpms, simply run the
following:

```
vagrant provision adm --provision-with build-rust-rpms
```

Signed-off-by: johnsonw <wjohnson@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2382)
<!-- Reviewable:end -->
