### PR TITLE
Use target table in GUI

### DIFF
--- a/iml-gui/crate/src/components/resource_links.rs
+++ b/iml-gui/crate/src/components/resource_links.rs
@@ -4,7 +4,7 @@
 
 use crate::{extensions::MergeAttrs as _, generated::css_classes::C, route::RouteId, Route};
 use iml_api_utils::extract_id;
-use iml_wire_types::{Filesystem, Target, TargetConfParam};
+use iml_wire_types::Filesystem;
 use seed::{prelude::*, *};
 
 pub fn href_view<T>(x: &str, route: Route) -> Node<T> {
@@ -27,16 +27,6 @@ pub fn server_link<T>(uri: Option<&String>, txt: &str) -> Node<T> {
     } else {
         plain!["---"]
     }
-}
-
-pub fn volume_link<T>(t: &Target<TargetConfParam>) -> Node<T> {
-    // let vol_id = match &t.volume {
-    //     VolumeOrResourceUri::ResourceUri(url) => extract_id(url).unwrap().parse::<i32>().unwrap(),
-    //     VolumeOrResourceUri::Volume(v) => v.id,
-    // };
-
-    // href_view(&t.volume_name, Route::Volume(RouteId::from(vol_id))).merge_attrs(class![C.break_all])
-    span![&t.volume_name].merge_attrs(class![C.break_all])
 }
 
 pub fn fs_link<T>(x: &Filesystem) -> Node<T> {

--- a/iml-gui/crate/src/lib.rs
+++ b/iml-gui/crate/src/lib.rs
@@ -36,15 +36,17 @@ pub(crate) use extensions::*;
 use futures::channel::oneshot;
 use generated::css_classes::C;
 use iml_wire_types::{
+    db::TargetRecord,
+    warp_drive::ArcCache,
     warp_drive::{self, ArcRecord},
-    Conf, GroupType,
+    Conf, GroupType, Target, TargetConfParam,
 };
 use lazy_static::lazy_static;
 use page::{Page, RecordChange};
 use route::Route;
 use seed::{app::MessageMapper, prelude::*, EventHandler, *};
 pub(crate) use sleep::sleep_with_handle;
-use std::{cmp, sync::Arc};
+use std::{cmp, ops::Deref as _, sync::Arc};
 pub use watch_state::*;
 use web_sys::MessageEvent;
 use Visibility::*;
@@ -723,7 +725,7 @@ fn handle_record_change(
                         .send_msg(page::mgts::Msg::AddTarget(x));
                 }
                 ArcRecord::TargetRecord(x) => {
-                    model.records.target_record.insert(x.id, x);
+                    model.records.target_record.insert(x.id, Arc::clone(&x));
                 }
                 ArcRecord::User(x) => {
                     model.records.user.insert(x.id, Arc::clone(&x));
@@ -1074,4 +1076,12 @@ pub fn run() {
         .build_and_start();
 
     log!("App started.");
+}
+
+fn get_target_from_managed_target<'a>(cache: &'a ArcCache, x: &Target<TargetConfParam>) -> Option<&'a TargetRecord> {
+    cache
+        .target_record
+        .values()
+        .find(|y| x.uuid.as_deref() == Some(y.uuid.as_str()))
+        .map(|x| x.deref())
 }

--- a/iml-gui/crate/src/page/filesystems.rs
+++ b/iml-gui/crate/src/page/filesystems.rs
@@ -159,7 +159,7 @@ pub fn view(cache: &ArcCache, model: &Model, all_locks: &Locks, session: Option<
             t::wrapper_view(vec![
                 t::thead_view(vec![
                     t::th_view(plain!["Filesystem"]),
-                    t::th_view(plain!["Primary MGS"]),
+                    t::th_view(plain!["Active MGS"]),
                     t::th_view(plain!["MDT Count"]),
                     t::th_view(plain!["Connected Clients"]),
                     t::th_view(plain!["Space Used / Available"]),
@@ -170,7 +170,7 @@ pub fn view(cache: &ArcCache, model: &Model, all_locks: &Locks, session: Option<
                         None => empty![],
                         Some(row) => {
                             let stats = model.stats.get(&f.name).cloned().unwrap_or_default();
-                            let xs: Vec<_> = cache.target.values().cloned().collect();
+                            let xs: Vec<_> = cache.target_record.values().cloned().collect();
 
                             tr![
                                 t::td_view(vec![
@@ -179,7 +179,7 @@ pub fn view(cache: &ArcCache, model: &Model, all_locks: &Locks, session: Option<
                                     alert_indicator(&cache.active_alert, f, true, Placement::Right)
                                 ])
                                 .merge_attrs(class![C.text_center]),
-                                t::td_center(filesystem::mgs(&xs, f)),
+                                t::td_center(filesystem::mgs(cache, &xs, f)),
                                 t::td_center(plain![f.mdts.len().to_string()]),
                                 t::td_center(filesystem::clients_view(stats.clients)),
                                 t::td_center(filesystem::space_used_view(

--- a/iml-wire-types/src/db.rs
+++ b/iml-wire-types/src/db.rs
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::{CompositeId, EndpointName, FsType, Label, ToCompositeId};
+use crate::{CompositeId, EndpointName, FsType, Label, TargetKind, ToCompositeId};
 use chrono::{offset::Utc, DateTime};
 #[cfg(feature = "postgres-interop")]
 use std::str::FromStr;
@@ -340,6 +340,28 @@ impl Id for TargetRecord {
 impl Id for &TargetRecord {
     fn id(&self) -> i32 {
         self.id
+    }
+}
+
+impl Label for TargetRecord {
+    fn label(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Label for &TargetRecord {
+    fn label(&self) -> &str {
+        &self.name
+    }
+}
+
+impl TargetRecord {
+    pub fn get_kind(&self) -> TargetKind {
+        match self.name.as_str() {
+            "MGS" => TargetKind::Mgt,
+            name if name.contains("-MDT") => TargetKind::Mdt,
+            _ => TargetKind::Ost,
+        }
     }
 }
 

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -319,6 +319,88 @@
       ]
     }
   },
+  "12b039adc74d7bebed739164545198b3de53a44940dbf3b8dc6137a3ae61af69": {
+    "query": "\n        SELECT\n            id,\n            state,\n            name,\n            dev_path,\n            active_host_id,\n            host_ids,\n            filesystems,\n            uuid,\n            mount_path,\n            fs_type as \"fs_type: FsType\"\n        FROM target\n        ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 1,
+          "name": "state",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "name",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 3,
+          "name": "dev_path",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 4,
+          "name": "active_host_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 5,
+          "name": "host_ids",
+          "type_info": "Int4Array"
+        },
+        {
+          "ordinal": 6,
+          "name": "filesystems",
+          "type_info": "TextArray"
+        },
+        {
+          "ordinal": 7,
+          "name": "uuid",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 8,
+          "name": "mount_path",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 9,
+          "name": "fs_type: FsType",
+          "type_info": {
+            "Custom": {
+              "name": "fs_type",
+              "kind": {
+                "Enum": [
+                  "zfs",
+                  "ldiskfs"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true
+      ]
+    }
+  },
   "12b85bdac2a34efedc73bb817f38fd589a8e2754392d863cf4211e169e935153": {
     "query": "\n        INSERT INTO chroma_core_sfadiskdrive\n        (\n            index,\n            enclosure_index,\n            failed,\n            slot_number,\n            health_state,\n            health_state_reason,\n            member_index,\n            member_state,\n            storage_system\n        )\n        SELECT * FROM UNNEST(\n            $1::integer[],\n            $2::integer[],\n            $3::bool[],\n            $4::integer[],\n            $5::smallint[],\n            $6::text[],\n            $7::smallint[],\n            $8::smallint[],\n            $9::text[]\n        )\n        ON CONFLICT (index, storage_system) DO UPDATE\n        SET\n            enclosure_index = excluded.enclosure_index,\n            failed = excluded.failed,\n            slot_number = excluded.slot_number,\n            health_state = excluded.health_state,\n            health_state_reason = excluded.health_state_reason,\n            member_index = excluded.member_index,\n            member_state = excluded.member_state\n    ",
     "describe": {


### PR DESCRIPTION
Update the GUI to use the `target` table where possible.
The goal is to shrink the reliance on the `chroma_core_managedtarget`
table so we can start removing it's fields.

![fs-refactor](https://user-images.githubusercontent.com/458717/99108782-d6eb8680-25b5-11eb-8ab2-1e9482f8b1a9.gif)


Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2383)
<!-- Reviewable:end -->
