### PR TITLE
Add iml-ssh crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ _topdir
 **/.env
 *~
 *.snap.new
+*.pytest_cache
 artifacts
 /base.repo
 /chroma_support.repo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,7 +149,7 @@ checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -232,6 +238,12 @@ dependencies = [
  "shlex",
  "which",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
 
 [[package]]
 name = "bitflags"
@@ -672,6 +684,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,13 +726,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg 1.0.1",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -736,10 +756,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.1.4"
+name = "cryptovec"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
+checksum = "e4bfac8fcbf54dc25a5ac1b9f0df13ce561e1419186ed6c562b3d9902aeb7ad5"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
 dependencies = [
  "bstr",
  "csv-core",
@@ -756,6 +786,12 @@ checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "deadpool"
@@ -790,7 +826,7 @@ checksum = "64196eb9f551916167225134f1e8a90f0b5774331d3c900d6328fd94bafe3544"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -869,6 +905,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
  "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
  "dirs-sys",
 ]
 
@@ -1002,7 +1047,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -1031,6 +1076,18 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "flate2"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1124,7 +1181,7 @@ checksum = "70f3979efb3aea70991b7fd261a40decddae71f8bdfd8b2982cc8442e8f6813a"
 dependencies = [
  "derive_utils",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -1153,7 +1210,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -2079,6 +2136,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "iml-ssh"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs 3.0.1",
+ "futures",
+ "iml-fs",
+ "iml-tracing",
+ "thiserror",
+ "thrussh",
+ "thrussh-keys",
+]
+
+[[package]]
 name = "iml-stats"
 version = "0.4.0"
 dependencies = [
@@ -2269,7 +2340,7 @@ dependencies = [
  "futures-core",
  "inotify-sys",
  "libc",
- "mio 0.6.22",
+ "mio 0.6.23",
  "tokio",
 ]
 
@@ -2371,9 +2442,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2381,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "juniper"
 version = "0.14.2"
-source = "git+https://github.com/graphql-rust/juniper#f3170c7adf4405cc119d2129f78a591fe2fcd32b"
+source = "git+https://github.com/graphql-rust/juniper#4ffd276a5b33ae4423f295675f977ed6cc7fb88a"
 dependencies = [
  "async-trait",
  "bson",
@@ -2401,12 +2472,12 @@ dependencies = [
 [[package]]
 name = "juniper_codegen"
 version = "0.14.2"
-source = "git+https://github.com/graphql-rust/juniper#f3170c7adf4405cc119d2129f78a591fe2fcd32b"
+source = "git+https://github.com/graphql-rust/juniper#4ffd276a5b33ae4423f295675f977ed6cc7fb88a"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -2498,6 +2569,17 @@ version = "0.4.0"
 dependencies = [
  "bindgen",
  "libc",
+]
+
+[[package]]
+name = "libsodium-sys"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a685b64f837b339074115f2e7f7b431ac73681d08d75b389db7498b8892b8a58"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2647,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -2658,7 +2740,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -2684,7 +2766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
- "mio 0.6.22",
+ "mio 0.6.23",
  "miow 0.3.6",
  "winapi 0.3.9",
 ]
@@ -2697,14 +2779,14 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio 0.6.22",
+ "mio 0.6.23",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -2778,9 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -2821,6 +2903,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3002,7 +3095,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -3070,7 +3163,7 @@ checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -3081,7 +3174,7 @@ checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -3183,7 +3276,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
  "version_check 0.9.2",
 ]
 
@@ -3572,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.17"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5911690c9b773bab7e657471afc207f3827b249a657241327e3544d79bcabdd"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",
@@ -3594,7 +3687,7 @@ dependencies = [
  "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -3640,9 +3733,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-connector"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845a88df26a058234c01cac923fc33162932c04ebea729f8e61b1735439a9b2c"
+checksum = "4ffaf21b0bac725875490d079bb503cf88684618310c2dff167640fa006217cb"
 dependencies = [
  "log",
  "rustls 0.19.0",
@@ -3762,7 +3855,7 @@ checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -3785,7 +3878,7 @@ checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4046,7 +4139,7 @@ dependencies = [
  "sha2",
  "sqlx-core",
  "sqlx-rt",
- "syn 1.0.51",
+ "syn 1.0.53",
  "url",
 ]
 
@@ -4100,7 +4193,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4116,7 +4209,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4186,9 +4279,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -4197,15 +4290,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4243,9 +4336,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.51"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
+checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -4372,7 +4465,7 @@ checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4382,6 +4475,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "thrussh"
+version = "0.29.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd81c79be79a024bbb3d5c05b92139614573d0c8960ca01c2ae893579a87f0c3"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "byteorder",
+ "cryptovec",
+ "flate2",
+ "futures",
+ "log",
+ "openssl",
+ "thiserror",
+ "thrussh-keys",
+ "thrussh-libsodium",
+ "tokio",
+]
+
+[[package]]
+name = "thrussh-keys"
+version = "0.18.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2812af9df48a5ae6cad1ce0bc20c6a6172abd8aa158999910ef161eda8e4dbb"
+dependencies = [
+ "anyhow",
+ "bit-vec",
+ "byteorder",
+ "cryptovec",
+ "data-encoding",
+ "dirs 2.0.2",
+ "futures",
+ "log",
+ "num-bigint",
+ "num-integer",
+ "openssl",
+ "serde",
+ "serde_derive",
+ "thiserror",
+ "thrussh-libsodium",
+ "tokio",
+ "yasna",
+]
+
+[[package]]
+name = "thrussh-libsodium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe89c70d27b1cb92e13bc8af63493e890d0de46dae4df0e28233f62b4ed9500"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "libsodium-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4431,7 +4582,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "standback",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4462,7 +4613,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "mio 0.6.22",
+ "mio 0.6.23",
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
@@ -4491,7 +4642,7 @@ checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4623,7 +4774,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4763,9 +4914,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -4814,7 +4965,7 @@ checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
 ]
 
 [[package]]
@@ -4946,11 +5097,11 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -4958,26 +5109,26 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4985,9 +5136,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -4995,28 +5146,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.51",
+ "syn 1.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d1cdc8b98a557f24733d50a1199c4b0635e465eecba9c45b214544da197f64"
+checksum = "0355fa0c1f9b792a09b6dcb6a8be24d51e71e6d74972f9eb4a44c4c004d24a25"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -5028,9 +5179,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
+checksum = "27e07b46b98024c2ba2f9e83a10c2ef0515f057f2da299c1762a2017de80438b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -5053,9 +5204,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5063,9 +5214,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
@@ -5178,3 +5329,7 @@ name = "yasna"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
+dependencies = [
+ "bit-vec",
+ "num-bigint",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
   'iml-services/iml-snapshot',
   'iml-services/iml-stats',
   'iml-sfa',
+  'iml-ssh',
   'iml-system-test-utils',
   'iml-systemd',
   'iml-task-runner',

--- a/iml-fs/src/lib.rs
+++ b/iml-fs/src/lib.rs
@@ -180,12 +180,22 @@ pub async fn write_tempfile(contents: Vec<u8>) -> Result<NamedTempFile, io::Erro
     .await?
 }
 
-/// Does the given `str` ref exist as a file?
-pub async fn file_exists(path: &str) -> bool {
-    let f = fs::metadata(path).await;
+/// Does the given path exist as a file?
+pub async fn file_exists(path: impl AsRef<Path>) -> bool {
+    let x = fs::metadata(path).await;
 
-    match f {
+    match x {
         Ok(m) => m.is_file(),
+        Err(_) => false,
+    }
+}
+
+/// Does the given path exist as a directory?
+pub async fn dir_exists(path: impl AsRef<Path>) -> bool {
+    let x = tokio::fs::metadata(path).await;
+
+    match x {
+        Ok(m) => m.is_dir(),
         Err(_) => false,
     }
 }

--- a/iml-ssh/Cargo.toml
+++ b/iml-ssh/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
+name = "iml-ssh"
+version = "0.1.0"
+
+[dependencies]
+anyhow = "1.0"
+dirs = "3"
+futures = "0.3"
+iml-fs = {version = "0.4", path = "../iml-fs"}
+iml-tracing = {version = "0.3", path = "../iml-tracing"}
+thiserror = "1.0"
+thrussh = "0.29.13"
+thrussh-keys = "0.18"

--- a/iml-ssh/src/lib.rs
+++ b/iml-ssh/src/lib.rs
@@ -1,0 +1,268 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use futures::{future::BoxFuture, stream, FutureExt, TryStreamExt};
+use iml_tracing::tracing;
+use std::{io, string::FromUtf8Error, sync::Arc, time::Duration};
+use thrussh::client::{self, Channel};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    FromUtf8(#[from] FromUtf8Error),
+    #[error("SSH Authentication Failed")]
+    AuthenticationFailed,
+    #[error("No home directory found")]
+    NoHomeDir,
+    #[error("No .ssh directory found")]
+    NoSshDir,
+}
+
+/// Various ways to Authenticate the SSH client
+pub enum Auth {
+    /// Use the ssh-agent if one is available.
+    Agent,
+    /// Use password based authentication
+    Password(String),
+    /// Use a given private key with optional passphrase
+    Key {
+        key_path: String,
+        password: Option<String>,
+    },
+    /// Read and try keys out of the `~/.ssh.` directory.
+    /// Currently only reads id_rsa
+    Auto,
+}
+
+/// Connect to the given `host` on the given `port` with the given `user` and selected `auth`.
+/// A successful connection will return a session that can be used to obtain a channel.
+pub async fn connect(
+    host: impl ToString,
+    port: impl Into<Option<u16>>,
+    user: impl ToString,
+    auth: Auth,
+) -> Result<client::Handle, Error> {
+    let cfg = client::Config {
+        connection_timeout: Some(Duration::from_secs(60)),
+        ..Default::default()
+    };
+    let cfg = Arc::new(cfg);
+
+    let port = port.into();
+
+    let host = host.to_string();
+
+    let user = user.to_string();
+
+    let address = format!("{}:{}", &host, port.unwrap_or(22));
+
+    let sh = Client { host, port };
+
+    let mut session = client::connect(cfg, address, sh).await?;
+
+    let (session, authed) = match auth {
+        Auth::Password(password) => {
+            let x = session.authenticate_password(&user, password).await?;
+
+            (session, x)
+        }
+        Auth::Key { key_path, password } => {
+            let password = password.map(Vec::from);
+            let password = password.as_deref();
+
+            let keypair = thrussh_keys::load_secret_key(key_path, password)?;
+
+            let x = session
+                .authenticate_publickey(&user, Arc::new(keypair))
+                .await?;
+
+            (session, x)
+        }
+        Auth::Agent => {
+            let mut agent = thrussh_keys::agent::client::AgentClient::connect_env().await?;
+
+            let identities = agent.request_identities().await?;
+
+            let (_, session, x) = stream::iter(identities.into_iter().map(Ok::<_, Error>))
+                .try_fold(
+                    (agent, session, false),
+                    |(agent, mut session, authed), x| {
+                        let user = &user;
+
+                        async move {
+                            if authed {
+                                return Ok((agent, session, authed));
+                            }
+
+                            let (agent, authed) =
+                                session.authenticate_future(user, x, agent).await?;
+
+                            Ok((agent, session, authed))
+                        }
+                    },
+                )
+                .await?;
+
+            (session, x)
+        }
+        Auth::Auto => {
+            let dir = if let Some(mut ssh_dir) = dirs::home_dir() {
+                ssh_dir.push(".ssh");
+
+                ssh_dir
+            } else {
+                return Err(Error::NoHomeDir);
+            };
+
+            if !iml_fs::dir_exists(&dir).await {
+                return Err(Error::NoSshDir);
+            }
+
+            let mut authed = false;
+
+            for k in &["id_rsa"] {
+                let k = dir.join(k);
+
+                if !iml_fs::file_exists(&k).await {
+                    continue;
+                }
+
+                let keypair = thrussh_keys::load_secret_key(k, None)?;
+
+                authed = session
+                    .authenticate_publickey(&user, Arc::new(keypair))
+                    .await?;
+
+                if authed {
+                    break;
+                }
+            }
+
+            (session, authed)
+        }
+    };
+
+    if authed {
+        Ok(session)
+    } else {
+        Err(Error::AuthenticationFailed)
+    }
+}
+
+#[derive(Debug)]
+pub struct Output {
+    pub exit_status: Option<u32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl Output {
+    pub fn success(&self) -> bool {
+        self.exit_status == Some(0)
+    }
+}
+
+pub trait SshChannelExt {
+    /// Execute a remote command. Stdout and stderr will be buffered and returned
+    /// As well as any exit code.
+    fn exec_cmd(&mut self, cmd: impl ToString) -> BoxFuture<Result<Output, Error>>;
+}
+
+impl SshChannelExt for Channel {
+    fn exec_cmd(&mut self, cmd: impl ToString) -> BoxFuture<Result<Output, Error>> {
+        let cmd = cmd.to_string();
+
+        async move {
+            let fut = self.exec(true, cmd);
+            fut.await?;
+
+            let mut out_buf = vec![];
+            let mut err_buf = vec![];
+
+            let mut exit_status = None;
+
+            while let Some(msg) = self.wait().await {
+                match msg {
+                    thrussh::ChannelMsg::Data { ref data } => {
+                        data.write_all_from(0, &mut out_buf)?;
+                    }
+                    thrussh::ChannelMsg::ExtendedData { ref data, ext } => {
+                        if ext == 1 {
+                            data.write_all_from(0, &mut err_buf)?;
+                        }
+                    }
+                    thrussh::ChannelMsg::ExitStatus { exit_status: x } => {
+                        exit_status.replace(x);
+                    }
+                    x => {
+                        tracing::debug!("Got ssh ChannelMsg {:?}", x);
+                    }
+                }
+            }
+
+            let out = Output {
+                exit_status,
+                stdout: String::from_utf8(out_buf)?,
+                stderr: String::from_utf8(err_buf)?,
+            };
+
+            Ok(out)
+        }
+        .boxed()
+    }
+}
+
+struct Client {
+    host: String,
+    port: Option<u16>,
+}
+
+impl client::Handler for Client {
+    type FutureUnit = futures::future::Ready<Result<(Self, client::Session), anyhow::Error>>;
+    type FutureBool = futures::future::Ready<Result<(Self, bool), anyhow::Error>>;
+
+    fn finished_bool(self, b: bool) -> Self::FutureBool {
+        futures::future::ready(Ok((self, b)))
+    }
+    fn finished(self, session: client::Session) -> Self::FutureUnit {
+        futures::future::ready(Ok((self, session)))
+    }
+    fn check_server_key(
+        self,
+        server_public_key: &thrussh_keys::key::PublicKey,
+    ) -> Self::FutureBool {
+        let r =
+            thrussh_keys::check_known_hosts(&self.host, self.port.unwrap_or(22), server_public_key);
+
+        match r {
+            Ok(x) => {
+                if !x {
+                    tracing::warn!("Server key not found in known_hosts file");
+                }
+
+                self.finished_bool(true)
+            }
+            Err(ref e) => match e.downcast_ref::<thrussh_keys::Error>() {
+                Some(thrussh_keys::Error::KeyChanged { line: x }) => {
+                    tracing::error!(
+                        "Server Key for host: {} has changed on line {} of known_hosts file",
+                        &self.host,
+                        x
+                    );
+
+                    self.finished_bool(false)
+                }
+                _ => {
+                    tracing::warn!("Unknown error for host: {}, {:?}", &self.host, r);
+
+                    self.finished_bool(true)
+                }
+            },
+        }
+    }
+}


### PR DESCRIPTION
Add new `iml-ssh` crate that allows for async execution
of ssh commands.

The following auth methods are supported:

- Private Key
- SSH agent
- Password
- Auto (for now just try id_rsa)

Internally, it uses [thrussh](https://pijul.org/thrussh/)

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2410)
<!-- Reviewable:end -->
