### PR TITLE
Remove configure-docker-network-trigger

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1156,20 +1156,6 @@ def create_iscsi_disks(vbox, name)
 end
 
 def configure_docker_network(config)
-  config.trigger.before :provision, name: 'configure-docker-network-trigger' do |t|
-    t.ruby do |_, machine|
-      if ARGV[3] == 'configure-docker-network'
-        puts 'Copying identify file to job scheduler container.'
-        puts `docker ps --format '{{.Names}}' | grep job-scheduler | xargs -I {} docker exec {} sh -c 'mkdir -p /root/.ssh'`
-        puts `docker ps --format '{{.Names}}' | grep job-scheduler | xargs -I {} docker cp id_rsa {}:/root/.ssh`
-        puts "Writing authorized keys to #{machine.name}"
-        puts `cat ~/.ssh/id_rsa.pub | ssh -i ./.vagrant/machines/#{machine.name}/virtualbox/private_key vagrant@#{machine.name} \
-             "cat > /tmp/id_rsa.pub && sudo su - -c 'mkdir -p /root/.ssh && touch /root/.ssh/authorized_keys && cat /tmp/id_rsa.pub \
-             >> /root/.ssh/authorized_keys && rm -f /tmp/id_rsa.pub'"`
-      end
-    end
-  end
-
   config.vm.provision 'configure-docker-network', type: 'shell', run: 'never', inline: <<-SHELL
     echo "10.73.10.1 nginx" >> /etc/hosts
   SHELL


### PR DESCRIPTION
It looks to be leftover from before docker was moved into the adm vm.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2413)
<!-- Reviewable:end -->
