### PR TITLE
Always use adm node as ntp server

### DIFF
--- a/iml-system-docker-tests/tests/ldiskfs_test.rs
+++ b/iml-system-docker-tests/tests/ldiskfs_test.rs
@@ -14,7 +14,6 @@ async fn test_docker_ldiskfs_setup() -> Result<(), TestError> {
             ("base_client".into(), config.client_servers()),
         ],
         test_type: TestType::Docker,
-        ntp_server: NtpServer::HostOnly,
         ..config
     };
 

--- a/iml-system-docker-tests/tests/stratagem_test.rs
+++ b/iml-system-docker-tests/tests/stratagem_test.rs
@@ -16,7 +16,6 @@ async fn test_docker_stratagem_setup() -> Result<(), TestError> {
         use_stratagem: true,
         branding: iml_wire_types::Branding::DDN(iml_wire_types::DdnBranding::Exascaler),
         test_type: TestType::Docker,
-        ntp_server: NtpServer::HostOnly,
         ..config
     };
 

--- a/iml-system-docker-tests/tests/zfs_test.rs
+++ b/iml-system-docker-tests/tests/zfs_test.rs
@@ -15,7 +15,6 @@ async fn test_docker_zfs_setup() -> Result<(), TestError> {
             ("base_client".into(), config.client_servers()),
         ],
         test_type: TestType::Docker,
-        ntp_server: NtpServer::HostOnly,
         fs_type: FsType::Zfs,
         ..config
     };

--- a/iml-system-test-utils/src/lib.rs
+++ b/iml-system-test-utils/src/lib.rs
@@ -36,16 +36,10 @@ impl From<std::io::Error> for TestError {
     }
 }
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum TestType {
     Rpm,
     Docker,
-}
-
-#[derive(Clone)]
-pub enum NtpServer {
-    HostOnly,
-    Adm,
 }
 
 pub enum TestState {
@@ -180,7 +174,6 @@ pub struct Config {
     pub use_stratagem: bool,
     pub branding: Branding,
     pub test_type: TestType,
-    pub ntp_server: NtpServer,
     pub fs_type: FsType,
 }
 
@@ -213,7 +206,6 @@ impl Default for Config {
             use_stratagem: false,
             branding: Branding::default(),
             test_type: TestType::Rpm,
-            ntp_server: NtpServer::Adm,
             fs_type: FsType::Ldiskfs,
         }
     }
@@ -280,38 +272,21 @@ impl Config {
             .collect()
     }
     pub fn get_setup_config(&self) -> String {
-        match &self.test_type {
-            TestType::Rpm => format!(
-                r#"USE_STRATAGEM={}
+        format!(
+            r#"USE_STRATAGEM={}
 BRANDING={}
 LOG_LEVEL=10
 RUST_LOG=debug
 NTP_SERVER_HOSTNAME=adm.local
 "#,
-                if self.use_stratagem { "True" } else { "False" },
-                self.branding.to_string()
-            ),
-            TestType::Docker => format!(
-                r#"USE_STRATAGEM={}
-BRANDING={}
-LOG_LEVEL=10
-RUST_LOG=debug
-NTP_SERVER_HOSTNAME=10.73.10.1
-"#,
-                self.use_stratagem,
-                self.branding.to_string()
-            ),
-        }
+            if self.use_stratagem { "True" } else { "False" },
+            self.branding.to_string()
+        )
     }
 }
 
 pub async fn wait_for_ntp(config: &Config) -> Result<(), TestError> {
-    match config.test_type {
-        TestType::Rpm => ssh::wait_for_ntp_for_adm(&config.storage_server_ips()).await?,
-        TestType::Docker => {
-            ssh::wait_for_ntp_for_host_only_if(&config.storage_server_ips()).await?
-        }
-    };
+    ssh::wait_for_ntp(&config.storage_server_ips()).await?;
 
     Ok(())
 }
@@ -393,12 +368,12 @@ pub async fn setup_bare(config: Config) -> Result<Config, TestError> {
         .checked_status()
         .await?;
 
-    match config.ntp_server {
-        NtpServer::HostOnly => {
-            ssh::configure_ntp_for_host_only_if(&config.storage_server_ips()).await?
-        }
-        NtpServer::Adm => ssh::configure_ntp_for_adm(&config.storage_server_ips()).await?,
-    };
+    ssh::configure_ntp(
+        config.test_type,
+        &config.manager_ip,
+        &config.storage_server_ips(),
+    )
+    .await?;
 
     vagrant::halt()
         .await?

--- a/iml-system-test-utils/src/ssh.rs
+++ b/iml-system-test-utils/src/ssh.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 DDN. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
-use crate::{Config, TestError};
+use crate::{Config, TestError, TestType};
 use futures::future::{try_join_all, TryFutureExt};
 use iml_cmd::{CheckedChildExt, CheckedCommandExt};
 use iml_graphql_queries::Query;
@@ -198,25 +198,19 @@ pub async fn yum_update<'a, 'b>(hosts: &'b [&'a str]) -> Result<Vec<(&'a str, Ou
     ssh_exec_parallel(hosts, "yum clean metadata; yum update -y").await
 }
 
-pub async fn configure_ntp_for_host_only_if<'a, 'b>(
+pub async fn configure_ntp<'a, 'b>(
+    test_type: TestType,
+    manager: &str,
     hosts: &'b [&'a str],
 ) -> Result<Vec<(&'a str, Output)>, TestError> {
-    ssh_script_parallel(hosts, "scripts/configure_ntp.sh", &["10.73.10.1"]).await
-}
+    if test_type == TestType::Docker {
+        ssh_script(manager, "scripts/install_ntp.sh", &[]).await?;
+    }
 
-pub async fn configure_ntp_for_adm<'a, 'b>(
-    hosts: &'b [&'a str],
-) -> Result<Vec<(&'a str, Output)>, TestError> {
     ssh_script_parallel(hosts, "scripts/configure_ntp.sh", &["adm.local"]).await
 }
 
-pub async fn wait_for_ntp_for_host_only_if<'a, 'b>(
-    hosts: &'b [&'a str],
-) -> Result<Vec<(&'a str, Output)>, TestError> {
-    ssh_script_parallel(hosts, "scripts/wait_for_ntp.sh", &["10.73.10.1"]).await
-}
-
-pub async fn wait_for_ntp_for_adm<'a, 'b>(
+pub async fn wait_for_ntp<'a, 'b>(
     hosts: &'b [&'a str],
 ) -> Result<Vec<(&'a str, Output)>, TestError> {
     ssh_script_parallel(hosts, "scripts/wait_for_ntp.sh", &["adm.local"]).await

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -319,11 +319,7 @@ Vagrant.configure('2') do |config|
 
       configure_ntp mds
 
-      configure_ntp_docker mds
-
       wait_for_ntp mds
-
-      wait_for_ntp_docker mds
 
       if i == 1
         mds.vm.provision 'create-pools',
@@ -564,11 +560,7 @@ Vagrant.configure('2') do |config|
 
       configure_ntp oss
 
-      configure_ntp_docker oss
-
       wait_for_ntp oss
-
-      wait_for_ntp_docker oss
 
       if i == 1
         oss.vm.provision 'create-pools',
@@ -865,8 +857,6 @@ Vagrant.configure('2') do |config|
 
       configure_ntp c
 
-      configure_ntp_docker c
-
       provision_clush c
 
       c.vm.provision 'install-iml-local',
@@ -1162,7 +1152,7 @@ end
 
 def configure_docker_network(config)
   config.vm.provision 'configure-docker-network', type: 'shell', run: 'never', inline: <<-SHELL
-    echo "10.73.10.1 nginx" >> /etc/hosts
+    echo "10.73.10.10 nginx" >> /etc/hosts
   SHELL
 end
 
@@ -1174,28 +1164,12 @@ def configure_ntp(config)
                          args: ["adm.local"]
 end
 
-def configure_ntp_docker(config)
-  config.vm.provision 'configure-ntp-docker',
-                         type: 'shell',
-                         run: 'never',
-                         path: 'scripts/configure_ntp.sh',
-                         args: ["10.73.10.1"]
-end
-
 def wait_for_ntp(config)
   config.vm.provision 'wait-for-ntp',
                           type: 'shell',
                           run: 'never',
                           path: 'scripts/wait_for_ntp.sh',
                           args: ["adm.local"]
-end
-
-def wait_for_ntp_docker(config)
-  config.vm.provision 'wait-for-ntp-docker',
-                          type: 'shell',
-                          run: 'never',
-                          path: 'scripts/wait_for_ntp.sh',
-                          args: ["10.73.10.1"]
 end
 
 def create_iml_diagnostics(config)

--- a/vagrant/scripts/install_iml_docker_local.sh
+++ b/vagrant/scripts/install_iml_docker_local.sh
@@ -25,13 +25,14 @@ version: "3.7"
 services:
   job-scheduler:
     extra_hosts:
+      - "adm.local:10.73.10.10"
       - "mds1.local:10.73.10.11"
       - "mds2.local:10.73.10.12"
       - "oss1.local:10.73.10.21"
       - "oss2.local:10.73.10.22"
       - "client1.local:10.73.10.31"
     environment:
-      - "NTP_SERVER_HOSTNAME=10.73.10.1"
+      - "NTP_SERVER_HOSTNAME=adm.local"
   iml-warp-drive:
     environment:
       - RUST_LOG=debug

--- a/vagrant/scripts/install_iml_docker_repouri.sh
+++ b/vagrant/scripts/install_iml_docker_repouri.sh
@@ -64,13 +64,14 @@ version: "3.7"
 services:
   job-scheduler:
     extra_hosts:
+      - "adm.local:10.73.10.10"
       - "mds1.local:10.73.10.11"
       - "mds2.local:10.73.10.12"
       - "oss1.local:10.73.10.21"
       - "oss2.local:10.73.10.22"
       - "client1.local:10.73.10.31"
     environment:
-      - "NTP_SERVER_HOSTNAME=10.73.10.1"
+      - "NTP_SERVER_HOSTNAME=adm.local"
   iml-warp-drive:
     environment:
       - RUST_LOG=debug

--- a/vagrant/scripts/install_ntp.sh
+++ b/vagrant/scripts/install_ntp.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+systemctl disable --now chronyd
+yum install -y ntp
+# delete all server entries
+sed -i -e "/^server /d" /etc/ntp.conf
+# Append ntp server address
+sed -i -e "$ a server 127.127.1.0" /etc/ntp.conf
+sed -i -e "$ a fudge 127.127.1.0 stratum 10" /etc/ntp.conf
+
+systemctl enable --now ntpd.service


### PR DESCRIPTION
The integration tests currently use the ntp server on the host when
running docker and the adm vm when running with RPMs.

Now that docker runs within the adm vm, we should always be able to use
adm to run the ntp server.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2414)
<!-- Reviewable:end -->
