### PR TITLE
Include MGS fs info with devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,7 +1796,6 @@ dependencies = [
  "futures",
  "im",
  "iml-change",
- "iml-influx",
  "iml-manager-env",
  "iml-postgres",
  "iml-rabbit",

--- a/iml-services/iml-device/Cargo.toml
+++ b/iml-services/iml-device/Cargo.toml
@@ -9,7 +9,6 @@ device-types = "0.3.0"
 futures = "0.3"
 im = {version = "15.0", features = ["serde"]}
 iml-change = {path = "../../iml-change", version = "0.1"}
-iml-influx = {path = "../../iml-influx", version = "0.2", features = ["with-db-client"]}
 iml-manager-env = {path = "../../iml-manager-env", version = "0.4"}
 iml-postgres = {path = "../../iml-postgres", version = "0.4"}
 iml-rabbit = {path = "../../iml-rabbit", version = "0.4"}

--- a/iml-services/iml-device/src/error.rs
+++ b/iml-services/iml-device/src/error.rs
@@ -19,8 +19,6 @@ pub enum ImlDeviceError {
     SqlxCoreError(#[from] sqlx::Error),
     #[error(transparent)]
     SqlxMigrateError(#[from] sqlx::migrate::MigrateError),
-    #[error(transparent)]
-    ImlInfluxError(#[from] iml_influx::Error),
 }
 
 impl reject::Reject for ImlDeviceError {}


### PR DESCRIPTION
Instead of looking at influx for MGS info, send it inline with the
device service. This should help prevent races where devices and lctl
data is updated out-of-sync with each other.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2420)
<!-- Reviewable:end -->
