### PR TITLE
Fs usage should filter to all known fs

### DIFF
--- a/iml-gui/crate/src/components/chart/fs_usage.rs
+++ b/iml-gui/crate/src/components/chart/fs_usage.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 static DB_NAME: &str = "iml_stats";
 
 pub struct Model {
+    filesystems: Option<Vec<String>>,
     fs_name: Option<String>,
     cancel: Option<oneshot::Sender<()>>,
     pub metric_data: Option<FsUsage>,
@@ -19,6 +20,7 @@ pub struct Model {
 impl Default for Model {
     fn default() -> Self {
         Self {
+            filesystems: None,
             fs_name: None,
             cancel: None,
             metric_data: None,
@@ -67,7 +69,7 @@ pub struct FsUsage {
 #[derive(Clone, Debug)]
 pub enum Msg {
     DataFetched(Box<seed::fetch::ResponseDataResult<InfluxResults>>),
-    FetchData,
+    FetchData(Option<Vec<String>>),
     Noop,
 }
 
@@ -81,9 +83,13 @@ async fn fetch_metrics(db: &str, query: String) -> Result<Msg, Msg> {
 
 pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
     match msg {
-        Msg::FetchData => {
+        Msg::FetchData(filesystems) => {
+            model.filesystems = filesystems.clone();
+
             let part = if let Some(fs_name) = &model.fs_name {
                 format!(r#"AND "fs" = '{}'"#, fs_name)
+            } else if let Some(filesystems) = filesystems {
+                format!(r#"AND "fs" =~ /{}/"#, filesystems.join("|"))
             } else {
                 "".into()
             };
@@ -130,7 +136,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
                 }
             }
 
-            let (cancel, fut) = sleep_with_handle(Duration::from_secs(10), Msg::FetchData, Msg::Noop);
+            let (cancel, fut) = sleep_with_handle(Duration::from_secs(10), Msg::FetchData(model.filesystems.clone()), Msg::Noop);
 
             model.cancel = Some(cancel);
 

--- a/iml-gui/crate/src/page/dashboard.rs
+++ b/iml-gui/crate/src/page/dashboard.rs
@@ -131,5 +131,6 @@ pub fn init(cache: &ArcCache, model: &mut Model, orders: &mut impl Orders<Msg, G
         sfa_overview::init(overview, &mut orders.proxy(Msg::SfaOverview));
     }
 
-    orders.proxy(Msg::FsUsage).send_msg(fs_usage::Msg::FetchData);
+    let filesystems = cache.filesystem.values().map(|x| x.name.to_string()).collect::<Vec<String>>();
+    orders.proxy(Msg::FsUsage).send_msg(fs_usage::Msg::FetchData(Some(filesystems)));
 }

--- a/iml-gui/crate/src/page/fs_dashboard.rs
+++ b/iml-gui/crate/src/page/fs_dashboard.rs
@@ -125,5 +125,5 @@ pub fn view(model: &Model) -> Node<Msg> {
 }
 
 pub fn init(orders: &mut impl Orders<Msg, GMsg>) {
-    orders.proxy(Msg::FsUsage).send_msg(fs_usage::Msg::FetchData);
+    orders.proxy(Msg::FsUsage).send_msg(fs_usage::Msg::FetchData(None));
 }


### PR DESCRIPTION
When fetching data on FS usage, we should filter to only the known filesystems

Signed-off-by: johnsonw <wjohnson@whamcloud.com>