### PR TITLE
Silence python http agent logging

### DIFF
--- a/chroma_core/services/http_agent/__init__.py
+++ b/chroma_core/services/http_agent/__init__.py
@@ -119,7 +119,7 @@ class Service(ChromaService):
 
         # The main thread serves incoming requests to exchanges messages
         # with agents, until it is interrupted (gevent handles signals for us)
-        self.server = wsgi.WSGIServer(("", HTTP_AGENT_PORT), WSGIHandler())
+        self.server = wsgi.WSGIServer(("", HTTP_AGENT_PORT), WSGIHandler(), log=None)
         self.server.serve_forever()
 
         session_rpc_thread.stop()


### PR DESCRIPTION
The http_agent service logs every access. This quickly becomes very
verbose. Silence the logging.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2424)
<!-- Reviewable:end -->
