### PR TITLE
Use kill_on_drop for all agent commands

### DIFF
--- a/iml-agent/src/action_plugins/check_kernel.rs
+++ b/iml-agent/src/action_plugins/check_kernel.rs
@@ -9,6 +9,7 @@ use version_utils::Version;
 async fn check_kver_module(module: &str, kver: &str) -> Result<bool, ImlAgentError> {
     Command::new("modinfo")
         .args(&["-n", "-k", kver, module])
+        .kill_on_drop(true)
         .checked_status()
         .await?;
 
@@ -18,6 +19,7 @@ async fn check_kver_module(module: &str, kver: &str) -> Result<bool, ImlAgentErr
 pub async fn get_kernel(modules: Vec<String>) -> Result<String, ImlAgentError> {
     let output = Command::new("rpm")
         .args(&["-q", "--qf", "%{V}-%{R}.%{ARCH}\n", "kernel"])
+        .kill_on_drop(true)
         .checked_output()
         .await?;
 

--- a/iml-agent/src/action_plugins/check_stonith.rs
+++ b/iml-agent/src/action_plugins/check_stonith.rs
@@ -158,6 +158,7 @@ fn do_check_stonith(xml: &[u8], nodename: &str) -> Result<ComponentState<bool>, 
 
 pub async fn check_stonith(_: ()) -> Result<ComponentState<bool>, ImlAgentError> {
     let stonith = Command::new("cibadmin")
+        .kill_on_drop(true)
         .args(&["--query", "--xpath", "//primitive[@class='stonith']"])
         .output()
         .await?;
@@ -170,7 +171,11 @@ pub async fn check_stonith(_: ()) -> Result<ComponentState<bool>, ImlAgentError>
         });
     }
 
-    let node = Command::new("crm_node").arg("-n").checked_output().await?;
+    let node = Command::new("crm_node")
+        .kill_on_drop(true)
+        .arg("-n")
+        .checked_output()
+        .await?;
 
     do_check_stonith(stonith.stdout.as_slice(), &String::from_utf8(node.stdout)?)
 }

--- a/iml-agent/src/action_plugins/firewall_cmd.rs
+++ b/iml-agent/src/action_plugins/firewall_cmd.rs
@@ -11,6 +11,7 @@ static DUPLICATE_MESSAGE: &[u8] = b"Warning: ALREADY_ENABLED\n";
 async fn port_change(action: &str, port: u16, proto: String) -> Result<(), ImlAgentError> {
     Command::new("firewall-cmd")
         .arg(format!("--{}-port={}/{}", action, port, proto))
+        .kill_on_drop(true)
         .checked_output()
         .await
         .map(drop)

--- a/iml-agent/src/action_plugins/high_availability/corosync_conf.rs
+++ b/iml-agent/src/action_plugins/high_availability/corosync_conf.rs
@@ -145,6 +145,7 @@ impl<'a> TryFrom<(&'a str, StringMap<'a>)> for Interface {
 async fn corosync_cmapctl() -> Result<(Totem, Vec<Interface>), ImlAgentError> {
     let x = Command::new("corosync-cmapctl")
         .arg("totem")
+        .kill_on_drop(true)
         .checked_output()
         .await?;
 

--- a/iml-agent/src/action_plugins/high_availability/mod.rs
+++ b/iml-agent/src/action_plugins/high_availability/mod.rs
@@ -540,6 +540,7 @@ totem.interface.1.mcastaddr (str) = 226.94.1.1
         .as_bytes();
         let output = Command::new("corosync-cmapctl")
             .args(&["totem.interface.0.mcastaddr", "totem.interface.1.mcastaddr"])
+            .kill_on_drop(true)
             .checked_output()
             .await?;
 

--- a/iml-agent/src/action_plugins/kernel_module.rs
+++ b/iml-agent/src/action_plugins/kernel_module.rs
@@ -6,7 +6,10 @@ use crate::agent_error::ImlAgentError;
 use iml_cmd::{CheckedCommandExt, Command};
 
 pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
-    let output = Command::new("lsmod").checked_output().await?;
+    let output = Command::new("lsmod")
+        .kill_on_drop(true)
+        .checked_output()
+        .await?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let module = stdout.lines().find(|m| {
@@ -21,6 +24,7 @@ pub async fn loaded(module: String) -> Result<bool, ImlAgentError> {
 pub async fn version(module: String) -> Result<String, ImlAgentError> {
     let output = Command::new("modinfo")
         .args(&["-F", "version", &module])
+        .kill_on_drop(true)
         .checked_output()
         .await?;
 

--- a/iml-agent/src/action_plugins/lustre/client.rs
+++ b/iml-agent/src/action_plugins/lustre/client.rs
@@ -76,6 +76,7 @@ pub async fn mount(mount: Mount) -> Result<(), ImlAgentError> {
     let args = vec!["-t", "lustre", &mount.mountspec, &mount.mountpoint];
     Command::new("/bin/mount")
         .args(args)
+        .kill_on_drop(true)
         .checked_output()
         .await?;
 
@@ -98,6 +99,7 @@ pub async fn unmount(unmount: Unmount) -> Result<(), ImlAgentError> {
     if is_mounted(&unmount.mountpoint, false).await? {
         Command::new("/bin/umount")
             .arg(unmount.mountpoint)
+            .kill_on_drop(true)
             .checked_output()
             .await?;
     }

--- a/iml-agent/src/action_plugins/stratagem/action_cloudsync.rs
+++ b/iml-agent/src/action_plugins/stratagem/action_cloudsync.rs
@@ -37,6 +37,7 @@ async fn archive_fids(
                         .arg("push")
                         .arg(src_file)
                         .arg(format!("{}:{}", target_name, get_unique(&fid_path)))
+                        .kill_on_drop(true)
                         .output()
                         .await?;
 
@@ -82,6 +83,7 @@ async fn restore_fids(
                         .arg("pull")
                         .arg(format!("{}:{}", target_name, get_unique(&fid_path)))
                         .arg(src_file)
+                        .kill_on_drop(true)
                         .output()
                         .await?;
 

--- a/iml-agent/src/action_plugins/stratagem/action_filesync.rs
+++ b/iml-agent/src/action_plugins/stratagem/action_filesync.rs
@@ -28,6 +28,7 @@ fn do_rsync<'a>(
                 .arg("-t")
                 .arg(&work.src_file)
                 .arg(&work.dest_file)
+                .kill_on_drop(true)
                 .output()
                 .await?;
 
@@ -93,6 +94,7 @@ async fn archive_fids(
                 .arg("-S")
                 .arg(src_file)
                 .arg(dest_file)
+                .kill_on_drop(true)
                 .output()
                 .await?;
 
@@ -168,9 +170,14 @@ async fn restore_fids(
                 .arg("-S")
                 .arg(dest_file)
                 .arg(src_file)
+                .kill_on_drop(true)
                 .output();
         } else {
-            output = Command::new("rsync").arg(dest_file).arg(src_file).output();
+            output = Command::new("rsync")
+                .arg(dest_file)
+                .arg(src_file)
+                .kill_on_drop(true)
+                .output();
         }
 
         let output = output.await?;

--- a/iml-agent/src/action_plugins/stratagem/action_mirror.rs
+++ b/iml-agent/src/action_plugins/stratagem/action_mirror.rs
@@ -16,6 +16,7 @@ async fn lfs_mirror<S: AsRef<OsStr>>(
         .arg("mirror")
         .args(args)
         .arg(path)
+        .kill_on_drop(true)
         .checked_output()
         .await
 }

--- a/iml-agent/src/action_plugins/stratagem/server.rs
+++ b/iml-agent/src/action_plugins/stratagem/server.rs
@@ -305,6 +305,7 @@ pub async fn trigger_scan(
 
     let output = Command::new("/usr/bin/lipe_scan")
         .args(&["-c", &f.path().to_str().unwrap(), "-W", &tmp_dir])
+        .kill_on_drop(true)
         .checked_output()
         .await?;
 

--- a/iml-agent/src/daemon_plugins/device.rs
+++ b/iml-agent/src/daemon_plugins/device.rs
@@ -33,6 +33,7 @@ async fn get_mgs_fses() -> Result<Vec<String>, ImlAgentError> {
         .arg("get_param")
         .arg("-N")
         .args(mgs_fs_parser::params())
+        .kill_on_drop(true)
         .output()
         .err_into()
         .await;

--- a/iml-agent/src/daemon_plugins/ntp.rs
+++ b/iml-agent/src/daemon_plugins/ntp.rs
@@ -81,7 +81,7 @@ async fn is_ntp_configured_by_iml() -> Result<bool, ImlAgentError> {
 }
 
 async fn get_ntpstat_command() -> Result<String, ImlAgentError> {
-    let p = Command::new("ntpstat").output().await?;
+    let p = Command::new("ntpstat").kill_on_drop(true).output().await?;
 
     Ok(std::str::from_utf8(&p.stdout).unwrap_or("").to_string())
 }
@@ -89,6 +89,7 @@ async fn get_ntpstat_command() -> Result<String, ImlAgentError> {
 async fn get_chronyc_ntpdata_command() -> Result<String, ImlAgentError> {
     let p = Command::new("chronyc")
         .arg("ntpdata")
+        .kill_on_drop(true)
         .checked_output()
         .await?;
 
@@ -104,6 +105,7 @@ async fn is_ntp_synced_command() -> Result<String, ImlAgentError> {
             "org.freedesktop.timedate1",
             "NTPSynchronized",
         ])
+        .kill_on_drop(true)
         .checked_output()
         .await?;
 

--- a/iml-agent/src/daemon_plugins/stats.rs
+++ b/iml-agent/src/daemon_plugins/stats.rs
@@ -38,10 +38,15 @@ impl DaemonPlugin for Stats {
     ) -> Pin<Box<dyn Future<Output = Result<Output, ImlAgentError>> + Send>> {
         async {
             let mut cmd1 = Command::new("lctl");
-            let cmd1 = cmd1.arg("get_param").args(params()).output().err_into();
+            let cmd1 = cmd1
+                .arg("get_param")
+                .args(params())
+                .kill_on_drop(true)
+                .output()
+                .err_into();
 
             let mut cmd2 = Command::new("lnetctl");
-            let cmd2 = cmd2.arg("export").output().err_into();
+            let cmd2 = cmd2.arg("export").kill_on_drop(true).output().err_into();
 
             let cmd3 = iml_fs::read_file_to_end("/proc/meminfo").err_into();
 

--- a/iml-agent/src/high_availability.rs
+++ b/iml-agent/src/high_availability.rs
@@ -16,7 +16,11 @@ use std::{collections::HashMap, convert::TryInto, ffi::OsStr, process::Output};
 static CIBADMIN_PATH: &str = "/usr/sbin/cibadmin";
 
 fn cibadmin_cmd() -> Command {
-    Command::new(CIBADMIN_PATH)
+    let mut cmd = Command::new(CIBADMIN_PATH);
+
+    cmd.kill_on_drop(true);
+
+    cmd
 }
 
 static CRM_MON_PATH: &str = "/usr/sbin/crm_mon";
@@ -24,7 +28,10 @@ static CRM_MON_PATH: &str = "/usr/sbin/crm_mon";
 pub(crate) fn crm_mon_cmd() -> Command {
     let mut cmd = Command::new(CRM_MON_PATH);
 
-    cmd.arg("--one-shot").arg("--inactive").arg("--as-xml");
+    cmd.arg("--one-shot")
+        .arg("--inactive")
+        .arg("--as-xml")
+        .kill_on_drop(true);
 
     cmd
 }
@@ -32,25 +39,41 @@ pub(crate) fn crm_mon_cmd() -> Command {
 static CRM_RESOURCE_PATH: &str = "/usr/sbin/crm_resource";
 
 fn crm_resource_cmd() -> Command {
-    Command::new(CRM_RESOURCE_PATH)
+    let mut cmd = Command::new(CRM_RESOURCE_PATH);
+
+    cmd.kill_on_drop(true);
+
+    cmd
 }
 
 static CRM_ATTRIBUTE_PATH: &str = "/usr/sbin/crm_attribute";
 
 fn crm_attribute_cmd() -> Command {
-    Command::new(CRM_ATTRIBUTE_PATH)
+    let mut cmd = Command::new(CRM_ATTRIBUTE_PATH);
+
+    cmd.kill_on_drop(true);
+
+    cmd
 }
 
 static PCS_PATH: &str = "/usr/sbin/pcs";
 
 fn pcs_cmd() -> Command {
-    Command::new(PCS_PATH)
+    let mut cmd = Command::new(PCS_PATH);
+
+    cmd.kill_on_drop(true);
+
+    cmd
 }
 
 static COROSYNC_CFGTOOL_PATH: &str = "/usr/sbin/corosync-cfgtool";
 
 fn corosync_cfgtool() -> Command {
-    Command::new(COROSYNC_CFGTOOL_PATH)
+    let mut cmd = Command::new(COROSYNC_CFGTOOL_PATH);
+
+    cmd.kill_on_drop(true);
+
+    cmd
 }
 
 pub async fn get_local_nodeid() -> Result<Option<String>, ImlAgentError> {

--- a/iml-agent/src/lustre.rs
+++ b/iml-agent/src/lustre.rs
@@ -17,6 +17,7 @@ where
 {
     Command::new("/usr/sbin/lctl")
         .args(args)
+        .kill_on_drop(true)
         .checked_output()
         .err_into()
         .await

--- a/iml-agent/src/network_interfaces.rs
+++ b/iml-agent/src/network_interfaces.rs
@@ -13,6 +13,7 @@ use std::io;
 fn ip_addr_cmd() -> Command {
     let mut cmd = Command::new("ip");
 
+    cmd.kill_on_drop(true);
     cmd.arg("address");
 
     cmd
@@ -21,6 +22,7 @@ fn ip_addr_cmd() -> Command {
 fn get_net_stats_cmd() -> Command {
     let mut cmd = Command::new("cat");
 
+    cmd.kill_on_drop(true);
     cmd.arg("/proc/net/dev");
 
     cmd
@@ -29,6 +31,7 @@ fn get_net_stats_cmd() -> Command {
 fn get_lnet_data_cmd() -> Command {
     let mut cmd = Command::new("lnetctl");
 
+    cmd.kill_on_drop(true);
     cmd.args(&["net", "show"]);
 
     cmd

--- a/iml-agent/src/rpm.rs
+++ b/iml-agent/src/rpm.rs
@@ -45,6 +45,7 @@ pub(crate) async fn installed(package_name: &str) -> Result<bool, ImlAgentError>
 pub(crate) async fn version(package_name: &str) -> Result<Option<Version>, ImlAgentError> {
     let output = Command::new("rpm")
         .args(&["--query", "--queryformat", "%{VERSION}", package_name])
+        .kill_on_drop(true)
         .output()
         .await?;
     parse(output)


### PR DESCRIPTION
If an action is cancelled, any associated child processes will keep
running.

Use
[kill_on_drop](https://docs.rs/tokio/0.3.5/tokio/process/struct.Command.html#method.kill_on_drop
) to make sure the child process is killed.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2426)
<!-- Reviewable:end -->
