### PR TITLE
Switch all systemctl preset to systemd_post

### DIFF
--- a/device-scanner/iml-device-scanner.spec
+++ b/device-scanner/iml-device-scanner.spec
@@ -93,12 +93,12 @@ cp 99-iml-zed-enhancer.rules %{buildroot}%{_sysconfdir}/udev/rules.d
 
 
 %post
-systemctl preset device-scanner.socket
-systemctl preset mount-emitter.service
-systemctl preset swap-emitter.service
-systemctl preset zed-populator.service
-systemctl preset zed-enhancer.socket
-systemctl preset zed-enhancer.service
+%systemd_post device-scanner.socket
+%systemd_post mount-emitter.service
+%systemd_post swap-emitter.service
+%systemd_post zed-populator.service
+%systemd_post zed-enhancer.socket
+%systemd_post zed-enhancer.service
 
 
 %preun

--- a/iml-docker.spec
+++ b/iml-docker.spec
@@ -45,7 +45,8 @@ mv iml-docker.service %{buildroot}%{_unitdir}
 
 
 %post
-systemctl preset iml-docker.service
+%systemd_post iml-docker.service
+
 
 %preun
 %systemd_preun iml-docker.service

--- a/rust-iml.spec
+++ b/rust-iml.spec
@@ -257,7 +257,7 @@ Group: System Environment/Libraries
 %{summary}
 
 %post task-runner
-systemctl preset iml-task-runner.service
+%systemd_post iml-task-runner.service
 
 %preun task-runner
 %systemd_preun iml-task-runner.service


### PR DESCRIPTION
Switch all remaining `systemctl preset` over to `%systemd_post` so we
don't trigger any preset files on upgrade.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2431)
<!-- Reviewable:end -->
