### PR TITLE
Build rust rpm's

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -270,6 +270,12 @@ Vagrant.configure('2') do |config|
                      type: 'shell',
                      run: 'never',
                      path: 'scripts/build_rust_rpms.sh'
+
+    adm.vm.provision 'build-rust-rpms-clean',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/build_rust_rpms.sh',
+                     args: '--clean'
   end
 
   #

--- a/vagrant/scripts/build_rust_rpms.sh
+++ b/vagrant/scripts/build_rust_rpms.sh
@@ -1,21 +1,36 @@
+set -x
 yum install -y openssl-devel
-yum install -y cargo rpm-build
+yum install -y cargo rpm-build git
 
-[ -f /root/.cargo/bin/sccache ] && echo "sccache already installed. Skipping." || cargo install sccache
+unset RUSTC_WRAPPER
 
+[ -f /sccache/target/release/sccache ] \
+    && echo "sccache already installed. Skipping." \
+    || (cd / \
+        && rm -rf /sccache \
+        && git clone https://github.com/mozilla/sccache.git \
+        && cd /sccache \
+        && cargo build --release --no-default-features)
+
+sed -i '/^PATH=\$PATH/d' /root/.bash_profile
+sed -i '/^export PATH/d' /root/.bash_profile
 sed -i '/^export CARGO_HOME/d' /root/.bash_profile
 sed -i '/^export SCCACHE_CACHE_SIZE/d' /root/.bash_profile
 sed -i '/^export SCCACHE_DIR/d' /root/.bash_profile
 sed -i '/^export RUSTC_WRAPPER/d' /root/.bash_profile
 
 cat <<EOF >> /root/.bash_profile
+PATH=$PATH:$HOME/bin
+export PATH
 export CARGO_HOME=/root/.cargo
 export SCCACHE_CACHE_SIZE=40G
 export SCCACHE_DIR=/root/.cache
-export RUSTC_WRAPPER=/root/.cargo/bin/sccache
+export RUSTC_WRAPPER=/sccache/target/release/sccache
 EOF
 
 source /root/.bash_profile
 
+
 cd /integrated-manager-for-lustre \
+    && [ "$1" = "--clean" ] && cargo clean || echo "Attempting to build rpm's without cleaning." \
     && RPM_DIST=".$(date '+%s')" make copr-rpms


### PR DESCRIPTION
The sccahe installation from crates is not functioning properly on
centos 7. Instead, pull the repo down and build sccache in release mode
with no default features. This fixes the issue. Additionally, add a
"--clean" flag that will rebuild all of the rpms. This is useful if only
a specific rpm is being built but others also need to be built to ensure
that db migrations are baked into each service. The operation will still
be fairly quick since sccache will be used.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>