### PR TITLE
Update docker setup

### DIFF
--- a/docker/copy-embedded-settings
+++ b/docker/copy-embedded-settings
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
+
 /bin/mkdir -p /etc/iml
-service=iml_influxdb
+service=iml_nginx
 trailer=$(/usr/bin/docker service ps -f "name=$service.1" $service -q --no-trunc | head -n1)
-until /usr/bin/docker exec $service.1.$trailer /bin/bash -c 'until [ -f /var/lib/chroma/iml-settings.conf ]; do echo "Waiting for settings."; sleep 1; done'; do
-  echo "Waiting for container"
-  sleep 1
+until /usr/bin/docker exec $service.1.$trailer sh -c 'until [ -f /var/lib/chroma/iml-settings.conf ]; do echo "copy-embedded-settings: Waiting for EMF container settings..."; sleep 1; done' 2>/dev/null; do
+    echo "copy-embedded-settings: Waiting for EMF startup..."
+    sleep 1
 done
+mkdir -p /etc/iml
 /usr/bin/docker cp $service.1.$trailer:/var/lib/chroma/iml-settings.conf /etc/iml/iml-settings.conf

--- a/iml-docker.service
+++ b/iml-docker.service
@@ -13,9 +13,9 @@ WorkingDirectory=/etc/iml-docker
 ExecStartPre=-/usr/bin/docker load -i /var/lib/iml-images.tgz
 ExecStart=/usr/bin/docker stack deploy -c docker-compose.yml -c docker-compose.overrides.yml iml --resolve-image=never
 ExecStart=/bin/bash /usr/bin/copy-embedded-settings
-ExecStart=/bin/bash -c 'until /usr/bin/iml server list; do sleep 1; done'
+ExecStart=/bin/bash -c 'until /usr/bin/iml server list > /dev/null 2>&1; do sleep 1; done'
 ExecStop=/usr/bin/docker stack rm iml
-ExecStop=/bin/bash -c 'while /usr/bin/docker stack ps iml; do sleep 1; done'
+ExecStop=/bin/bash -c 'while /usr/bin/docker stack ps iml > /dev/null 2>&1; do sleep 1; done'
 
 
 [Install]


### PR DESCRIPTION
Update the IML docker setup to not print output while starting.

In addition, use a container that becomes stable earlier to copy
settings to the host.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2444)
<!-- Reviewable:end -->
