### PR TITLE
EX-2304 filesync: create the right path

### DIFF
--- a/iml-agent/src/action_plugins/stratagem/action_filesync.rs
+++ b/iml-agent/src/action_plugins/stratagem/action_filesync.rs
@@ -37,7 +37,7 @@ fn do_rsync<'a>(
                   }| async move {
                 let src_file = src_root.join(&file_path);
                 let dest_file = dest_root.join(&file_path);
-                let mut dest_dir = PathBuf::from(&src_file);
+                let mut dest_dir = PathBuf::from(&dest_file);
                 dest_dir.pop();
                 fs::create_dir_all(&dest_dir).await?;
 
@@ -92,7 +92,7 @@ fn do_dsync<'a>(
                 let mpi_count = env::get_openmpi_count();
                 let src_file = src_root.join(&file_path);
                 let dest_file = dest_root.join(&file_path);
-                let mut dest_dir = PathBuf::from(&src_file);
+                let mut dest_dir = PathBuf::from(&dest_file);
                 dest_dir.pop();
                 fs::create_dir_all(&dest_dir).await?;
 


### PR DESCRIPTION
use dest_dir instead of src_dir when creating
paths to copy data

Signed-off-by: Ben Evans <beevans@whamcloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/whamcloud/integrated-manager-for-lustre/2449)
<!-- Reviewable:end -->
